### PR TITLE
acme_certificate: improve challenge docs

### DIFF
--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -291,7 +291,15 @@ EXAMPLES = r'''
 # - copy:
 #     dest: /var/www/html/{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource'] }}
 #     content: "{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource_value'] }}"
-#     when: sample_com_challenge is changed
+#     when: sample_com_challenge is changed and 'sample.com' in sample_com_challenge['challenge_data']
+#
+# Alternative way:
+#
+# - copy:
+#     dest: /var/www/{{ item.key }}/{{ item.value['http-01']['resource'] }}
+#     content: "{{ item.value['http-01']['resource_value'] }}"
+#   loop: "{{ sample_com_challenge.challenge_data | dictsort }}"
+#   when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
   acme_certificate:
@@ -328,7 +336,7 @@ EXAMPLES = r'''
 #     wait: yes
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
-#   when: sample_com_challenge is changed
+#   when: sample_com_challenge is changed and 'sample.com' in sample_com_challenge.challenge_data
 #
 # Alternative way:
 #


### PR DESCRIPTION
##### SUMMARY
Some of the challenge docs are no longer fully functional (since only non-valid challenges are returned by the module), and there's currently no example of looping over `http-01` challenges.

Fixes ansible/ansible#67949.

CC @resmo

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate
