### PR TITLE
Use FQCN in examples

### DIFF
--- a/plugins/modules/acme_account.py
+++ b/plugins/modules/acme_account.py
@@ -95,7 +95,7 @@ options:
 
 EXAMPLES = '''
 - name: Make sure account exists and has given contacts. We agree to TOS.
-  acme_account:
+  community.crypto.acme_account:
     account_key_src: /etc/pki/cert/private/account.key
     state: present
     terms_agreed: yes
@@ -104,7 +104,7 @@ EXAMPLES = '''
     - mailto:myself@example.org
 
 - name: Make sure account has given email address. Don't create account if it doesn't exist
-  acme_account:
+  community.crypto.acme_account:
     account_key_src: /etc/pki/cert/private/account.key
     state: present
     allow_creation: no
@@ -112,13 +112,13 @@ EXAMPLES = '''
     - mailto:me@example.com
 
 - name: Change account's key to the one stored in the variable new_account_key
-  acme_account:
+  community.crypto.acme_account:
     account_key_src: /etc/pki/cert/private/account.key
     new_account_key_content: '{{ new_account_key }}'
     state: changed_key
 
 - name: Delete account (we have to use the new key)
-  acme_account:
+  community.crypto.acme_account:
     account_key_content: '{{ new_account_key }}'
     state: absent
 '''

--- a/plugins/modules/acme_account_info.py
+++ b/plugins/modules/acme_account_info.py
@@ -51,7 +51,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 - name: Check whether an account with the given account key exists
-  acme_account_info:
+  community.crypto.acme_account_info:
     account_key_src: /etc/pki/cert/private/account.key
     register: account_data
 - name: Verify that account exists

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -262,7 +262,7 @@ EXAMPLES = r'''
 ### Example with HTTP challenge ###
 
 - name: Create a challenge for sample.com using a account key from a variable.
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_content: "{{ account_private_key }}"
     csr: /etc/pki/cert/csr/sample.com.csr
     dest: /etc/httpd/ssl/sample.com.crt
@@ -270,7 +270,7 @@ EXAMPLES = r'''
 
 # Alternative first step:
 - name: Create a challenge for sample.com using a account key from hashi vault.
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_content: "{{ lookup('hashi_vault', 'secret=secret/account_private_key:value') }}"
     csr: /etc/pki/cert/csr/sample.com.csr
     fullchain_dest: /etc/httpd/ssl/sample.com-fullchain.crt
@@ -278,7 +278,7 @@ EXAMPLES = r'''
 
 # Alternative first step:
 - name: Create a challenge for sample.com using a account key file.
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     csr: /etc/pki/cert/csr/sample.com.csr
     dest: /etc/httpd/ssl/sample.com.crt
@@ -294,7 +294,7 @@ EXAMPLES = r'''
 #     when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     csr: /etc/pki/cert/csr/sample.com.csr
     dest: /etc/httpd/ssl/sample.com.crt
@@ -305,7 +305,7 @@ EXAMPLES = r'''
 ### Example with DNS challenge against production ACME server ###
 
 - name: Create a challenge for sample.com using a account key file.
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     account_email: myself@sample.com
     src: /etc/pki/cert/csr/sample.com.csr
@@ -319,7 +319,7 @@ EXAMPLES = r'''
 # perform the necessary steps to fulfill the challenge
 # for example:
 #
-# - route53:
+# - community.aws.route53:
 #     zone: sample.com
 #     record: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].record }}"
 #     type: TXT
@@ -332,7 +332,7 @@ EXAMPLES = r'''
 #
 # Alternative way:
 #
-# - route53:
+# - community.aws.route53:
 #     zone: sample.com
 #     record: "{{ item.key }}"
 #     type: TXT
@@ -346,7 +346,7 @@ EXAMPLES = r'''
 #   when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     account_email: myself@sample.com
     src: /etc/pki/cert/csr/sample.com.csr
@@ -361,7 +361,7 @@ EXAMPLES = r'''
 
 # Alternative second step:
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     account_email: myself@sample.com
     src: /etc/pki/cert/csr/sample.com.csr

--- a/plugins/modules/acme_certificate_revoke.py
+++ b/plugins/modules/acme_certificate_revoke.py
@@ -109,12 +109,12 @@ options:
 
 EXAMPLES = '''
 - name: Revoke certificate with account key
-  acme_certificate_revoke:
+  community.crypto.acme_certificate_revoke:
     account_key_src: /etc/pki/cert/private/account.key
     certificate: /etc/httpd/ssl/sample.com.crt
 
 - name: Revoke certificate with certificate's private key
-  acme_certificate_revoke:
+  community.crypto.acme_certificate_revoke:
     private_key_src: /etc/httpd/ssl/sample.com.key
     certificate: /etc/httpd/ssl/sample.com.crt
 '''

--- a/plugins/modules/acme_challenge_cert_helper.py
+++ b/plugins/modules/acme_challenge_cert_helper.py
@@ -60,7 +60,7 @@ options:
 
 EXAMPLES = '''
 - name: Create challenges for a given CRT for sample.com
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     challenge: tls-alpn-01
     csr: /etc/pki/cert/csr/sample.com.csr
@@ -68,7 +68,7 @@ EXAMPLES = '''
   register: sample_com_challenge
 
 - name: Create certificates for challenges
-  acme_challenge_cert_helper:
+  community.crypto.acme_challenge_cert_helper:
     challenge: tls-alpn-01
     challenge_data: "{{ item.value['tls-alpn-01'] }}"
     private_key_src: /etc/pki/cert/key/sample.com.key
@@ -92,7 +92,7 @@ EXAMPLES = '''
   loop: "{{ sample_com_challenge_certs.results }}"
 
 - name: Create certificate for a given CSR for sample.com
-  acme_certificate:
+  community.crypto.acme_certificate:
     account_key_src: /etc/pki/cert/private/account.key
     challenge: tls-alpn-01
     csr: /etc/pki/cert/csr/sample.com.csr

--- a/plugins/modules/acme_inspect.py
+++ b/plugins/modules/acme_inspect.py
@@ -85,14 +85,14 @@ options:
 
 EXAMPLES = r'''
 - name: Get directory
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     method: directory-only
   register: directory
 
 - name: Create an account
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -104,7 +104,7 @@ EXAMPLES = r'''
   # if creation was successful
 
 - name: Get account information
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -113,7 +113,7 @@ EXAMPLES = r'''
     method: get
 
 - name: Update account contacts
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -129,7 +129,7 @@ EXAMPLES = r'''
       - mailto:me@example.com
 
 - name: Create certificate order
-  acme_certificate:
+  community.crypto.acme_certificate:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -143,7 +143,7 @@ EXAMPLES = r'''
 # the order URI.
 
 - name: Get order information
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -153,7 +153,7 @@ EXAMPLES = r'''
   register: order
 
 - name: Get first authz for order
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -163,7 +163,7 @@ EXAMPLES = r'''
   register: authz
 
 - name: Get HTTP-01 challenge for authz
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key
@@ -173,7 +173,7 @@ EXAMPLES = r'''
   register: http01challenge
 
 - name: Activate HTTP-01 challenge manually
-  acme_inspect:
+  community.crypto.acme_inspect:
     acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
     acme_version: 2
     account_key_src: /etc/pki/cert/private/account.key

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
 # Given a leaf certificate for www.ansible.com and one or more intermediate
 # certificates, finds the associated root certificate.
 - name: Find root certificate
-  certificate_complete_chain:
+  community.crypto.certificate_complete_chain:
     input_chain: "{{ lookup('file', '/etc/ssl/csr/www.ansible.com-fullchain.pem') }}"
     root_certificates:
     - /etc/ca-certificates/
@@ -83,7 +83,7 @@ EXAMPLES = '''
 # Given a leaf certificate for www.ansible.com, and a list of intermediate
 # certificates, finds the associated root certificate.
 - name: Find root certificate
-  certificate_complete_chain:
+  community.crypto.certificate_complete_chain:
     input_chain: "{{ lookup('file', '/etc/ssl/csr/www.ansible.com.pem') }}"
     intermediate_certificates:
     - /etc/ssl/csr/www.ansible.com-chain.pem

--- a/plugins/modules/ecs_certificate.py
+++ b/plugins/modules/ecs_certificate.py
@@ -349,7 +349,7 @@ EXAMPLES = r'''
 - name: Request a new certificate from Entrust with bare minimum parameters.
         Will request a new certificate if current one is valid but within 30
         days of expiry. If replacing an existing file in path, will back it up.
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     backup: true
     path: /etc/ssl/crt/ansible.com.crt
     full_chain_path: /etc/ssl/crt/ansible.com.chain.crt
@@ -367,7 +367,7 @@ EXAMPLES = r'''
         of type EV_SSL. Otherwise, if there is an Entrust managed certificate
         in path and it is within 63 days of expiration, request a renew of that
         certificate.
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
     cert_type: EV_SSL
@@ -387,7 +387,7 @@ EXAMPLES = r'''
         certificate is within 79 days of expiration, request a renew of that
         certificate and save it in path. This can be used to "migrate" a
         certificate to be Ansible managed.
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
     tracking_id: 2378915
@@ -399,7 +399,7 @@ EXAMPLES = r'''
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
 - name: Force a reissue of the certificate specified by tracking_id.
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     force: true
     tracking_id: 2378915
@@ -413,7 +413,7 @@ EXAMPLES = r'''
         issued certificate will have it's Subject Distinguished Name use the
         organization details associated with that client, rather than what is
         in the CSR.
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
     client_id: 2
@@ -427,7 +427,7 @@ EXAMPLES = r'''
 
 - name: Request a new certificate with a number of CSR parameters overridden
         and tracking information
-  ecs_certificate:
+  community.crypto.ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     full_chain_path: /etc/ssl/crt/ansible.com.chain.crt
     csr: /etc/ssl/csr/ansible.com.csr

--- a/plugins/modules/ecs_domain.py
+++ b/plugins/modules/ecs_domain.py
@@ -89,7 +89,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Request domain validation using email validation for client ID of 2.
-  ecs_domain:
+  community.crypto.ecs_domain:
     domain_name: ansible.com
     client_id: 2
     verification_method: email
@@ -101,7 +101,7 @@ EXAMPLES = r'''
 
 - name: Request domain validation using DNS. If domain is already valid,
         request revalidation if expires within 90 days
-  ecs_domain:
+  community.crypto.ecs_domain:
     domain_name: ansible.com
     verification_method: dns
     entrust_api_user: apiusername
@@ -111,7 +111,7 @@ EXAMPLES = r'''
 
 - name: Request domain validation using web server validation, and revalidate
         if fewer than 60 days remaining of EV eligibility.
-  ecs_domain:
+  community.crypto.ecs_domain:
     domain_name: ansible.com
     verification_method: web_server
     entrust_api_user: apiusername
@@ -120,7 +120,7 @@ EXAMPLES = r'''
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
 - name: Request domain validation using manual validation.
-  ecs_domain:
+  community.crypto.ecs_domain:
     domain_name: ansible.com
     verification_method: manual
     entrust_api_user: apiusername

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -128,7 +128,7 @@ version:
 
 EXAMPLES = '''
 - name: Get the cert from an RDP port
-  get_certificate:
+  community.crypto.get_certificate:
     host: "1.2.3.4"
     port: 3389
   delegate_to: localhost
@@ -136,7 +136,7 @@ EXAMPLES = '''
   register: cert
 
 - name: Get a cert from an https port
-  get_certificate:
+  community.crypto.get_certificate:
     host: "www.google.com"
     port: 443
   delegate_to: localhost

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -163,91 +163,91 @@ author: Jan Pokorny (@japokorn)
 EXAMPLES = '''
 
 - name: create LUKS container (remains unchanged if it already exists)
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
 
 - name: create LUKS container with a passphrase
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     passphrase: "foo"
 
 - name: (create and) open the LUKS container; name it "mycrypt"
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "opened"
     name: "mycrypt"
     keyfile: "/vault/keyfile"
 
 - name: close the existing LUKS container "mycrypt"
-  luks_device:
+  community.crypto.luks_device:
     state: "closed"
     name: "mycrypt"
 
 - name: make sure LUKS container exists and is closed
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "closed"
     keyfile: "/vault/keyfile"
 
 - name: create container if it does not exist and add new key to it
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
     new_keyfile: "/vault/keyfile2"
 
 - name: add new key to the LUKS container (container has to exist)
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     keyfile: "/vault/keyfile"
     new_keyfile: "/vault/keyfile2"
 
 - name: add new passphrase to the LUKS container
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     keyfile: "/vault/keyfile"
     new_passphrase: "foo"
 
 - name: remove existing keyfile from the LUKS container
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     remove_keyfile: "/vault/keyfile2"
 
 - name: remove existing passphrase from the LUKS container
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     remove_passphrase: "foo"
 
 - name: completely remove the LUKS container and its contents
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "absent"
 
 - name: create a container with label
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
     label: personalLabelName
 
 - name: open the LUKS container based on label without device; name it "mycrypt"
-  luks_device:
+  community.crypto.luks_device:
     label: "personalLabelName"
     state: "opened"
     name: "mycrypt"
     keyfile: "/vault/keyfile"
 
 - name: close container based on UUID
-  luks_device:
+  community.crypto.luks_device:
     uuid: 03ecd578-fad4-4e6c-9348-842e3e8fa340
     state: "closed"
     name: "mycrypt"
 
 - name: create a container using luks2 format
-  luks_device:
+  community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -123,7 +123,7 @@ extends_documentation_fragment: files
 
 EXAMPLES = '''
 # Generate an OpenSSH user certificate that is valid forever and for all users
-- openssh_cert:
+- community.crypto.openssh_cert:
     type: user
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -133,7 +133,7 @@ EXAMPLES = '''
 
 # Generate an OpenSSH host certificate that is valid for 32 weeks from now and will be regenerated
 # if it is valid for less than 2 weeks from the time the module is being run
-- openssh_cert:
+- community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -143,7 +143,7 @@ EXAMPLES = '''
     valid_at: +2w
 
 # Generate an OpenSSH host certificate that is valid forever and only for example.com and examplehost
-- openssh_cert:
+- community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -155,7 +155,7 @@ EXAMPLES = '''
         - examplehost
 
 # Generate an OpenSSH host Certificate that is valid from 21.1.2001 to 21.1.2019
-- openssh_cert:
+- community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -164,7 +164,7 @@ EXAMPLES = '''
     valid_to: "2019-01-21"
 
 # Generate an OpenSSH user Certificate with clear and force-command option:
-- openssh_cert:
+- community.crypto.openssh_cert:
     type: user
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -101,21 +101,21 @@ extends_documentation_fragment: files
 
 EXAMPLES = '''
 # Generate an OpenSSH keypair with the default values (4096 bits, rsa)
-- openssh_keypair:
+- community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
 
 # Generate an OpenSSH rsa keypair with a different size (2048 bits)
-- openssh_keypair:
+- community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     size: 2048
 
 # Force regenerate an OpenSSH keypair if it already exists
-- openssh_keypair:
+- community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     force: True
 
 # Generate an OpenSSH keypair with a different algorithm (dsa)
-- openssh_keypair:
+- community.crypto.openssh_keypair:
     path: /tmp/id_ssh_dsa
     type: dsa
 '''

--- a/plugins/modules/openssl_certificate.py
+++ b/plugins/modules/openssl_certificate.py
@@ -589,14 +589,14 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate a Self Signed OpenSSL certificate
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     privatekey_path: /etc/ssl/private/ansible.com.pem
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: selfsigned
 
 - name: Generate an OpenSSL certificate signed with your own CA certificate
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     ownca_path: /etc/ssl/crt/ansible_CA.crt
@@ -604,7 +604,7 @@ EXAMPLES = r'''
     provider: ownca
 
 - name: Generate a Let's Encrypt Certificate
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: acme
@@ -612,7 +612,7 @@ EXAMPLES = r'''
     acme_challenge_path: /etc/ssl/challenges/ansible.com/
 
 - name: Force (re-)generate a new Let's Encrypt Certificate
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: acme
@@ -621,7 +621,7 @@ EXAMPLES = r'''
     force: yes
 
 - name: Generate an Entrust certificate via the Entrust Certificate Services (ECS) API
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
     provider: entrust
@@ -639,7 +639,7 @@ EXAMPLES = r'''
 # assertonly, and shows how to emulate the behavior with the openssl_certificate_info,
 # openssl_csr_info, openssl_privatekey_info and assert modules:
 
-- openssl_certificate:
+- community.crypto.openssl_certificate:
     provider: assertonly
     path: /etc/ssl/crt/ansible.com.crt
     csr_path: /etc/ssl/csr/ansible.com.csr
@@ -670,7 +670,7 @@ EXAMPLES = r'''
     invalid_at: 20200331202428Z
     valid_in: 10  # in ten seconds
 
-- openssl_certificate_info:
+- community.crypto.openssl_certificate_info:
     path: /etc/ssl/crt/ansible.com.crt
     # for valid_at, invalid_at and valid_in
     valid_at:
@@ -679,12 +679,12 @@ EXAMPLES = r'''
       ten_seconds: "+10"
   register: result
 
-- openssl_csr_info:
+- community.crypto.openssl_csr_info:
     # Verifies that the CSR signature is valid; module will fail if not
     path: /etc/ssl/csr/ansible.com.csr
   register: result_csr
 
-- openssl_privatekey_info:
+- community.crypto.openssl_privatekey_info:
     path: /etc/ssl/csr/ansible.com.key
   register: result_privatekey
 
@@ -730,7 +730,7 @@ EXAMPLES = r'''
 
 # How to use the assertonly provider to implement and trigger your own custom certificate generation workflow:
 - name: Check if a certificate is currently still valid, ignoring failures
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     has_expired: no
@@ -742,7 +742,7 @@ EXAMPLES = r'''
   when: validity_check.failed
 
 - name: Check the new certificate again for validity with the same parameters, this time failing the play if it is still invalid
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     has_expired: no
@@ -750,7 +750,7 @@ EXAMPLES = r'''
 
 # Some other checks that assertonly could be used for:
 - name: Verify that an existing certificate was issued by the Let's Encrypt CA and is currently still valid
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     issuer:
@@ -758,7 +758,7 @@ EXAMPLES = r'''
     has_expired: no
 
 - name: Ensure that a certificate uses a modern signature algorithm (no SHA1, MD5 or DSA)
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     signature_algorithms:
@@ -772,25 +772,25 @@ EXAMPLES = r'''
       - sha512WithECDSAEncryption
 
 - name: Ensure that the existing certificate belongs to the specified private key
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     privatekey_path: /etc/ssl/private/example.com.pem
     provider: assertonly
 
 - name: Ensure that the existing certificate is still valid at the winter solstice 2017
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     valid_at: 20171221162800Z
 
 - name: Ensure that the existing certificate is still valid 2 weeks (1209600 seconds) from now
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     valid_in: 1209600
 
 - name: Ensure that the existing certificate is only used for digital signatures and encrypting other keys
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     key_usage:
@@ -799,14 +799,14 @@ EXAMPLES = r'''
     key_usage_strict: true
 
 - name: Ensure that the existing certificate can be used for client authentication
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     extended_key_usage:
       - clientAuth
 
 - name: Ensure that the existing certificate can only be used for client authentication and time stamping
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     extended_key_usage:
@@ -815,7 +815,7 @@ EXAMPLES = r'''
     extended_key_usage_strict: true
 
 - name: Ensure that the existing certificate has a certain domain in its subjectAltName
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/example.com.crt
     provider: assertonly
     subject_alt_name:

--- a/plugins/modules/openssl_certificate_info.py
+++ b/plugins/modules/openssl_certificate_info.py
@@ -72,7 +72,7 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate a Self Signed OpenSSL certificate
-  openssl_certificate:
+  community.crypto.openssl_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     privatekey_path: /etc/ssl/private/ansible.com.pem
     csr_path: /etc/ssl/csr/ansible.com.csr
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 # Get information on the certificate
 
 - name: Get information on generated certificate
-  openssl_certificate_info:
+  community.crypto.openssl_certificate_info:
     path: /etc/ssl/crt/ansible.com.crt
   register: result
 
@@ -97,7 +97,7 @@ EXAMPLES = r'''
 # makes the playbook fail in case something is not as expected.
 
 - name: Test whether that certificate is valid tomorrow and/or in three weeks
-  openssl_certificate_info:
+  community.crypto.openssl_certificate_info:
     path: /etc/ssl/crt/ansible.com.crt
     valid_at:
       point_1: "+1d"

--- a/plugins/modules/openssl_csr.py
+++ b/plugins/modules/openssl_csr.py
@@ -286,26 +286,26 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate an OpenSSL Certificate Signing Request
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     common_name: www.ansible.com
 
 - name: Generate an OpenSSL Certificate Signing Request with an inline key
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_content: "{{ private_key_content }}"
     common_name: www.ansible.com
 
 - name: Generate an OpenSSL Certificate Signing Request with a passphrase protected private key
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     privatekey_passphrase: ansible
     common_name: www.ansible.com
 
 - name: Generate an OpenSSL Certificate Signing Request with Subject information
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     country_name: FR
@@ -314,13 +314,13 @@ EXAMPLES = r'''
     common_name: www.ansible.com
 
 - name: Generate an OpenSSL Certificate Signing Request with subjectAltName extension
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     subject_alt_name: 'DNS:www.ansible.com,DNS:m.ansible.com'
 
 - name: Generate an OpenSSL CSR with subjectAltName extension with dynamic list
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     subject_alt_name: "{{ item.value | map('regex_replace', '^', 'DNS:') | list }}"
@@ -330,14 +330,14 @@ EXAMPLES = r'''
     - m.ansible.com
 
 - name: Force regenerate an OpenSSL Certificate Signing Request
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     force: yes
     common_name: www.ansible.com
 
 - name: Generate an OpenSSL Certificate Signing Request with special key usages
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     common_name: www.ansible.com
@@ -348,7 +348,7 @@ EXAMPLES = r'''
       - clientAuth
 
 - name: Generate an OpenSSL Certificate Signing Request with OCSP Must Staple
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     common_name: www.ansible.com

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -59,13 +59,13 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate an OpenSSL Certificate Signing Request
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: /etc/ssl/csr/www.ansible.com.csr
     privatekey_path: /etc/ssl/private/ansible.com.pem
     common_name: www.ansible.com
 
 - name: Get information on the CSR
-  openssl_csr_info:
+  community.crypto.openssl_csr_info:
     path: /etc/ssl/csr/www.ansible.com.csr
   register: result
 

--- a/plugins/modules/openssl_dhparam.py
+++ b/plugins/modules/openssl_dhparam.py
@@ -84,16 +84,16 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate Diffie-Hellman parameters with the default size (4096 bits)
-  openssl_dhparam:
+  community.crypto.openssl_dhparam:
     path: /etc/ssl/dhparams.pem
 
 - name: Generate DH Parameters with a different size (2048 bits)
-  openssl_dhparam:
+  community.crypto.openssl_dhparam:
     path: /etc/ssl/dhparams.pem
     size: 2048
 
 - name: Force regenerate an DH parameters if they already exist
-  openssl_dhparam:
+  community.crypto.openssl_dhparam:
     path: /etc/ssl/dhparams.pem
     force: yes
 '''

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -110,7 +110,7 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate PKCS#12 file
-  openssl_pkcs12:
+  community.crypto.openssl_pkcs12:
     action: export
     path: /opt/certs/ansible.p12
     friendly_name: raclette
@@ -120,7 +120,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Change PKCS#12 file permission
-  openssl_pkcs12:
+  community.crypto.openssl_pkcs12:
     action: export
     path: /opt/certs/ansible.p12
     friendly_name: raclette
@@ -131,7 +131,7 @@ EXAMPLES = r'''
     mode: '0600'
 
 - name: Regen PKCS#12 file
-  openssl_pkcs12:
+  community.crypto.openssl_pkcs12:
     action: export
     src: /opt/certs/ansible.p12
     path: /opt/certs/ansible.p12
@@ -144,14 +144,14 @@ EXAMPLES = r'''
     force: yes
 
 - name: Dump/Parse PKCS#12 file
-  openssl_pkcs12:
+  community.crypto.openssl_pkcs12:
     action: parse
     src: /opt/certs/ansible.p12
     path: /opt/certs/ansible.pem
     state: present
 
 - name: Remove PKCS#12 file
-  openssl_pkcs12:
+  community.crypto.openssl_pkcs12:
     path: /opt/certs/ansible.p12
     state: absent
 '''

--- a/plugins/modules/openssl_privatekey.py
+++ b/plugins/modules/openssl_privatekey.py
@@ -199,27 +199,27 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
 
 - name: Generate an OpenSSL private key with the default values (4096 bits, RSA) and a passphrase
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
     passphrase: ansible
     cipher: aes256
 
 - name: Generate an OpenSSL private key with a different size (2048 bits)
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
     size: 2048
 
 - name: Force regenerate an OpenSSL private key if it already exists
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
     force: yes
 
 - name: Generate an OpenSSL private key with a different algorithm (DSA)
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
     type: DSA
 '''

--- a/plugins/modules/openssl_privatekey_info.py
+++ b/plugins/modules/openssl_privatekey_info.py
@@ -73,11 +73,11 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
 
 - name: Get information on generated key
-  openssl_privatekey_info:
+  community.crypto.openssl_privatekey_info:
     path: /etc/ssl/private/ansible.com.pem
   register: result
 

--- a/plugins/modules/openssl_publickey.py
+++ b/plugins/modules/openssl_publickey.py
@@ -101,35 +101,35 @@ seealso:
 
 EXAMPLES = r'''
 - name: Generate an OpenSSL public key in PEM format
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     privatekey_path: /etc/ssl/private/ansible.com.pem
 
 - name: Generate an OpenSSL public key in PEM format from an inline key
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     privatekey_content: "{{ private_key_content }}"
 
 - name: Generate an OpenSSL public key in OpenSSH v2 format
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     privatekey_path: /etc/ssl/private/ansible.com.pem
     format: OpenSSH
 
 - name: Generate an OpenSSL public key with a passphrase protected private key
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     privatekey_path: /etc/ssl/private/ansible.com.pem
     privatekey_passphrase: ansible
 
 - name: Force regenerate an OpenSSL public key if it already exists
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     privatekey_path: /etc/ssl/private/ansible.com.pem
     force: yes
 
 - name: Remove an OpenSSL public key
-  openssl_publickey:
+  community.crypto.openssl_publickey:
     path: /etc/ssl/public/ansible.com.pem
     state: absent
 '''

--- a/plugins/modules/x509_crl.py
+++ b/plugins/modules/x509_crl.py
@@ -230,7 +230,7 @@ notes:
 
 EXAMPLES = r'''
 - name: Generate a CRL
-  x509_crl:
+  community.crypto.x509_crl:
     path: /etc/ssl/my-ca.crl
     privatekey_path: /etc/ssl/private/my-ca.pem
     issuer:

--- a/plugins/modules/x509_crl_info.py
+++ b/plugins/modules/x509_crl_info.py
@@ -42,7 +42,7 @@ seealso:
 
 EXAMPLES = r'''
 - name: Get information on CRL
-  x509_crl_info:
+  community.crypto.x509_crl_info:
     path: /etc/ssl/my-ca.crl
   register: result
 


### PR DESCRIPTION
##### SUMMARY
Changes all examples to use FQCN (fully qualified collection names) instead of short names.

Mainly to make sure that people copying from the examples will end up with something that is future-proof. (I'm not aware of any plans to disable routing. But eventually we add new modules which won't have a valid shortname, and suddenly you need to use the FQCN for some modules, while you can't use it for others. So let's teach new users to use FQCNs directly :) )

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
all
