### PR TITLE
Stop using custom branch to avoid full CI run on changelog fragments.

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -53,8 +53,7 @@ command -v pip
 pip --version
 pip list --disable-pip-version-check
 if [ "${ansible_version}" == "devel" ]; then
-    retry pip install https://github.com/felixfontein/ansible/archive/changelogs-docs-collections.tar.gz --disable-pip-version-check
-    # retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+    retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 else
     retry pip install ansible==${ansible_version} --disable-pip-version-check
     # force complete CI run for Ansible 2.9: 2.9's ansible-test's change detection for collections is broken


### PR DESCRIPTION
##### SUMMARY
Now that ansible/ansible#68550 has been merged, we can remove one hack from CI.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
