### PR TITLE
Cap PyOpenSSL for OS X integration test.

### DIFF
--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL
+    name: pyOpenSSL<2.9.1
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version


### PR DESCRIPTION
##### SUMMARY

Change:
Backport of https://github.com/ansible/ansible/commit/1e08bb7a6fc8cc5c54034b469920d64984d8af47

Test Plan:
Already passing in ansible/ansible.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests