### PR TITLE
Improve sanity test run for users

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -14,3 +14,5 @@ tests/unit/plugins/modules/conftest.py future-import-boilerplate
 tests/unit/plugins/modules/conftest.py metaclass-boilerplate
 tests/unit/plugins/modules/utils.py future-import-boilerplate
 tests/unit/plugins/modules/utils.py metaclass-boilerplate
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -12,3 +12,5 @@ tests/unit/plugins/modules/conftest.py future-import-boilerplate
 tests/unit/plugins/modules/conftest.py metaclass-boilerplate
 tests/unit/plugins/modules/utils.py future-import-boilerplate
 tests/unit/plugins/modules/utils.py metaclass-boilerplate
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang

--- a/tests/utils/shippable/sanity.sh
+++ b/tests/utils/shippable/sanity.sh
@@ -2,11 +2,6 @@
 
 set -o pipefail -eux
 
-declare -a args
-IFS='/:' read -ra args <<< "$1"
-
-group="${args[1]}"
-
 if [ "${BASE_BRANCH:-}" ]; then
     base_branch="origin/${BASE_BRANCH}"
 else
@@ -16,5 +11,4 @@ fi
 # shellcheck disable=SC2086
 ansible-test sanity --color -v --junit ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
     --docker --base-branch "${base_branch}" \
-    --exclude shippable.yml --exclude tests/utils/ \
     --allow-disabled

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -35,6 +35,7 @@ python -V
 
 function retry
 {
+    # shellcheck disable=SC2034
     for repetition in 1 2 3; do
         set +e
         "$@"
@@ -43,9 +44,9 @@ function retry
         if [ ${result} == 0 ]; then
             return ${result}
         fi
-        echo "$@ -> ${result}"
+        echo "@* -> ${result}"
     done
-    echo "Command '$@' failed 3 times!"
+    echo "Command '@*' failed 3 times!"
     exit -1
 }
 

--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -6,7 +6,6 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
-group="${args[2]}"
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=90


### PR DESCRIPTION
##### SUMMARY
Avoid sanity excludes so that users can run `ansible-test sanity --docker` and it only reports real problems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
