### PR TITLE
Fix example formatting

### DIFF
--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -159,91 +159,91 @@ author: Jan Pokorny (@japokorn)
 
 EXAMPLES = '''
 
-- name: create LUKS container (remains unchanged if it already exists)
+- name: Create LUKS container (remains unchanged if it already exists)
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
 
-- name: create LUKS container with a passphrase
+- name: Create LUKS container with a passphrase
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     passphrase: "foo"
 
-- name: (create and) open the LUKS container; name it "mycrypt"
+- name: (Create and) open the LUKS container; name it "mycrypt"
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "opened"
     name: "mycrypt"
     keyfile: "/vault/keyfile"
 
-- name: close the existing LUKS container "mycrypt"
+- name: Close the existing LUKS container "mycrypt"
   community.crypto.luks_device:
     state: "closed"
     name: "mycrypt"
 
-- name: make sure LUKS container exists and is closed
+- name: Make sure LUKS container exists and is closed
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "closed"
     keyfile: "/vault/keyfile"
 
-- name: create container if it does not exist and add new key to it
+- name: Create container if it does not exist and add new key to it
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
     new_keyfile: "/vault/keyfile2"
 
-- name: add new key to the LUKS container (container has to exist)
+- name: Add new key to the LUKS container (container has to exist)
   community.crypto.luks_device:
     device: "/dev/loop0"
     keyfile: "/vault/keyfile"
     new_keyfile: "/vault/keyfile2"
 
-- name: add new passphrase to the LUKS container
+- name: Add new passphrase to the LUKS container
   community.crypto.luks_device:
     device: "/dev/loop0"
     keyfile: "/vault/keyfile"
     new_passphrase: "foo"
 
-- name: remove existing keyfile from the LUKS container
+- name: Remove existing keyfile from the LUKS container
   community.crypto.luks_device:
     device: "/dev/loop0"
     remove_keyfile: "/vault/keyfile2"
 
-- name: remove existing passphrase from the LUKS container
+- name: Remove existing passphrase from the LUKS container
   community.crypto.luks_device:
     device: "/dev/loop0"
     remove_passphrase: "foo"
 
-- name: completely remove the LUKS container and its contents
+- name: Completely remove the LUKS container and its contents
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "absent"
 
-- name: create a container with label
+- name: Create a container with label
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"
     keyfile: "/vault/keyfile"
     label: personalLabelName
 
-- name: open the LUKS container based on label without device; name it "mycrypt"
+- name: Open the LUKS container based on label without device; name it "mycrypt"
   community.crypto.luks_device:
     label: "personalLabelName"
     state: "opened"
     name: "mycrypt"
     keyfile: "/vault/keyfile"
 
-- name: close container based on UUID
+- name: Close container based on UUID
   community.crypto.luks_device:
     uuid: 03ecd578-fad4-4e6c-9348-842e3e8fa340
     state: "closed"
     name: "mycrypt"
 
-- name: create a container using luks2 format
+- name: Create a container using luks2 format
   community.crypto.luks_device:
     device: "/dev/loop0"
     state: "present"

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -116,8 +116,8 @@ extends_documentation_fragment: files
 '''
 
 EXAMPLES = '''
-# Generate an OpenSSH user certificate that is valid forever and for all users
-- community.crypto.openssh_cert:
+- name: Generate an OpenSSH user certificate that is valid forever and for all users
+  community.crypto.openssh_cert:
     type: user
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -127,7 +127,8 @@ EXAMPLES = '''
 
 # Generate an OpenSSH host certificate that is valid for 32 weeks from now and will be regenerated
 # if it is valid for less than 2 weeks from the time the module is being run
-- community.crypto.openssh_cert:
+- name: Generate an OpenSSH host certificate with valid_from, valid_to and valid_at parameters
+  community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -136,8 +137,8 @@ EXAMPLES = '''
     valid_to: +32w
     valid_at: +2w
 
-# Generate an OpenSSH host certificate that is valid forever and only for example.com and examplehost
-- community.crypto.openssh_cert:
+- name: Generate an OpenSSH host certificate that is valid forever and only for example.com and examplehost
+  community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -148,8 +149,8 @@ EXAMPLES = '''
         - example.com
         - examplehost
 
-# Generate an OpenSSH host Certificate that is valid from 21.1.2001 to 21.1.2019
-- community.crypto.openssh_cert:
+- name: Generate an OpenSSH host Certificate that is valid from 21.1.2001 to 21.1.2019
+  community.crypto.openssh_cert:
     type: host
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub
@@ -157,8 +158,8 @@ EXAMPLES = '''
     valid_from: "2001-01-21"
     valid_to: "2019-01-21"
 
-# Generate an OpenSSH user Certificate with clear and force-command option:
-- community.crypto.openssh_cert:
+- name: Generate an OpenSSH user Certificate with clear and force-command option
+  community.crypto.openssh_cert:
     type: user
     signing_key: /path/to/private_key
     public_key: /path/to/public_key.pub

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -88,28 +88,29 @@ options:
             - always
         default: partial_idempotence
 notes:
-    - In case the ssh key is broken or password protected, the module will fail. Set the I(force) option to C(yes) if you want to regenerate the keypair.
+    - In case the ssh key is broken or password protected, the module will fail.
+      Set the I(force) option to C(yes) if you want to regenerate the keypair.
 
 extends_documentation_fragment: files
 '''
 
 EXAMPLES = '''
-# Generate an OpenSSH keypair with the default values (4096 bits, rsa)
-- community.crypto.openssh_keypair:
+- name: Generate an OpenSSH keypair with the default values (4096 bits, rsa)
+  community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
 
-# Generate an OpenSSH rsa keypair with a different size (2048 bits)
-- community.crypto.openssh_keypair:
+- name: Generate an OpenSSH rsa keypair with a different size (2048 bits)
+  community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     size: 2048
 
-# Force regenerate an OpenSSH keypair if it already exists
-- community.crypto.openssh_keypair:
+- name: Force regenerate an OpenSSH keypair if it already exists
+  community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     force: True
 
-# Generate an OpenSSH keypair with a different algorithm (dsa)
-- community.crypto.openssh_keypair:
+- name: Generate an OpenSSH keypair with a different algorithm (dsa)
+  community.crypto.openssh_keypair:
     path: /tmp/id_ssh_dsa
     type: dsa
 '''


### PR DESCRIPTION
##### SUMMARY
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#examples-block
```
Per playbook best practices, each example should include a name: line:
EXAMPLES = r'''
- name: Ensure foo is installed
  modulename:
    name: foo
    state: present
'''
The name: line should be capitalized and not include a trailing dot.
```

##### ISSUE TYPE
- Docs Pull Request

