### PR TITLE
Remove unused field from meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -7,10 +7,6 @@ action_groups:
   - acme_account_facts
   - acme_account_info
 
-action_groups_redirection:
-  acme:
-    redirect: acme
-
 plugin_routing:
   modules:
     acme_account_facts:


### PR DESCRIPTION
##### SUMMARY
Remove action_groups_redirection from meta/runtime.yml since Ansible 2.10 is not supporting it

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
