### PR TITLE
x509_certificate: Update docs for macOS 10.15 requirements

### DIFF
--- a/plugins/modules/x509_certificate.py
+++ b/plugins/modules/x509_certificate.py
@@ -155,6 +155,8 @@ options:
             - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will stop being valid 10 years from now.
             - This is only used by the C(selfsigned) provider.
+            - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
+              Please see U(https://support.apple.com/en-us/HT210176) for more details.
         type: str
         default: +3650d
         aliases: [ selfsigned_notAfter ]
@@ -245,6 +247,8 @@ options:
             - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will stop being valid 10 years from now.
             - This is only used by the C(ownca) provider.
+            - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
+              Please see U(https://support.apple.com/en-us/HT210176) for more details.
         type: str
         default: +3650d
 


### PR DESCRIPTION
##### SUMMARY

selfsigned_not_after and ownca_not_after values for macOS 10.15,
can be +825d. Updated the docs accordingly.

Migrated from https://github.com/ansible/ansible/pull/64563

Thanks to Sironheart

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/64563_openssl_cert_mac_os.yml
plugins/modules/x509_certificate.py
