### PR TITLE
Fix acme_inspect problem with Python 3.5

### DIFF
--- a/changelogs/fragments/87-acme_inspect-python-3.5.yml
+++ b/changelogs/fragments/87-acme_inspect-python-3.5.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_inspect - fix problem with Python 3.5 that JSON was not decoded (https://github.com/ansible-collections/community.crypto/issues/86)."

--- a/plugins/modules/acme_inspect.py
+++ b/plugins/modules/acme_inspect.py
@@ -243,7 +243,7 @@ output_json:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils._text import to_native, to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.acme import (
     ModuleFailException,
@@ -299,7 +299,8 @@ def main():
             ))
             # See if we can parse the result as JSON
             try:
-                result['output_json'] = json.loads(data)
+                # to_text() is needed only for Python 3.5 (and potentially 3.0 to 3.4 as well)
+                result['output_json'] = json.loads(to_text(data))
             except Exception as dummy:
                 pass
             # Fail if error was returned

--- a/shippable.yml
+++ b/shippable.yml
@@ -37,7 +37,7 @@ matrix:
 
     - env: T=devel/cloud/2.6/1
     - env: T=devel/cloud/2.7/1
-    # - env: T=devel/cloud/3.5/1
+    - env: T=devel/cloud/3.5/1
     - env: T=devel/cloud/3.6/1
     - env: T=devel/cloud/3.7/1
     - env: T=devel/cloud/3.8/1


### PR DESCRIPTION
##### SUMMARY
`json.loads()` does not accept `bytes` input for Python 3.5. (It does for 3.6+, and for 2.6 and 2.7.)

Fixes #86.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_inspect
