### PR TITLE
Self promotion for openssl_privatekey

### DIFF
--- a/plugins/doc_fragments/acme.py
+++ b/plugins/doc_fragments/acme.py
@@ -31,10 +31,13 @@ options:
     description:
       - "Path to a file containing the ACME account RSA or Elliptic Curve
          key."
-      - "RSA keys can be created with C(openssl genrsa ...). Elliptic curve keys can
-         be created with C(openssl ecparam -genkey ...). Any other tool creating
-         private keys in PEM format can be used as well - e.g. L(openssl_privatekey
-         module,https://docs.ansible.com/ansible/latest/modules/openssl_privatekey_module.html)."
+      - "Private keys can be created with the
+         M(community.crypto.openssl_privatekey) module. If the requisites
+         (pyOpenSSL or cryptography) are not available, keys can also be
+         created directly with the C(openssl) command line tool: RSA keys
+         can be created with C(openssl genrsa ...). Elliptic curve keys can be
+         created with C(openssl ecparam -genkey ...). Any other tool creating
+         private keys in PEM format can be used as well."
       - "Mutually exclusive with C(account_key_content)."
       - "Required if C(account_key_content) is not used."
     type: path

--- a/plugins/doc_fragments/acme.py
+++ b/plugins/doc_fragments/acme.py
@@ -33,7 +33,8 @@ options:
          key."
       - "RSA keys can be created with C(openssl genrsa ...). Elliptic curve keys can
          be created with C(openssl ecparam -genkey ...). Any other tool creating
-         private keys in PEM format can be used as well."
+         private keys in PEM format can be used as well - e.g. L(openssl_privatekey
+         module,https://docs.ansible.com/ansible/latest/modules/openssl_privatekey_module.html)."
       - "Mutually exclusive with C(account_key_content)."
       - "Required if C(account_key_content) is not used."
     type: path


### PR DESCRIPTION
ACME private keys can be created with openssl_privatekey module

##### SUMMARY
Self promote openssl_privatekey module to create rsa keys for acme modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate

##### ADDITIONAL INFORMATION

I'm not completely sure of the way to create an internal link in the documentation.
Happy to amend this if needed. 
