### PR TITLE
Increase # of bits for random serial numbers of certificates with PyOpenSSL backend

### DIFF
--- a/changelogs/fragments/90-openssl_certificate-pyopenssl-serial.yml
+++ b/changelogs/fragments/90-openssl_certificate-pyopenssl-serial.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "openssl_certificate - the PyOpenSSL backend now uses 160 bits of randomness for serial numbers, instead of a random number between 1000 and 99999. Please note that this is not a high quality random number (https://github.com/ansible-collections/community.crypto/issues/76)."

--- a/plugins/modules/x509_certificate.py
+++ b/plugins/modules/x509_certificate.py
@@ -1266,8 +1266,10 @@ class SelfSignedCertificateCryptography(Certificate):
 
 def generate_serial_number():
     """Generate a serial number for a certificate"""
-    highest_bit = 1 << 160
-    return randrange(0, highest_bit) | highest_bit
+    while True:
+        result = randrange(0, 1 << 160)
+        if result >= 1000:
+            return result
 
 
 class SelfSignedCertificate(Certificate):

--- a/plugins/modules/x509_certificate.py
+++ b/plugins/modules/x509_certificate.py
@@ -868,7 +868,7 @@ import tempfile
 import traceback
 
 from distutils.version import LooseVersion
-from random import randint
+from random import randrange
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native, to_bytes, to_text
@@ -1264,6 +1264,12 @@ class SelfSignedCertificateCryptography(Certificate):
         return result
 
 
+def generate_serial_number():
+    """Generate a serial number for a certificate"""
+    highest_bit = 1 << 160
+    return randrange(0, highest_bit) | highest_bit
+
+
 class SelfSignedCertificate(Certificate):
     """Generate the self-signed certificate."""
 
@@ -1275,7 +1281,7 @@ class SelfSignedCertificate(Certificate):
         self.notAfter = get_relative_time_option(module.params['selfsigned_not_after'], 'selfsigned_not_after', backend=self.backend)
         self.digest = module.params['selfsigned_digest']
         self.version = module.params['selfsigned_version']
-        self.serial_number = randint(1000, 99999)
+        self.serial_number = generate_serial_number()
 
         if self.csr_content is None and not os.path.exists(self.csr_path):
             raise CertificateError(
@@ -1570,7 +1576,7 @@ class OwnCACertificate(Certificate):
         self.notAfter = get_relative_time_option(module.params['ownca_not_after'], 'ownca_not_after', backend=self.backend)
         self.digest = module.params['ownca_digest']
         self.version = module.params['ownca_version']
-        self.serial_number = randint(1000, 99999)
+        self.serial_number = generate_serial_number()
         if module.params['ownca_create_subject_key_identifier'] != 'create_if_not_provided':
             module.fail_json(msg='ownca_create_subject_key_identifier cannot be used with the pyOpenSSL backend!')
         if module.params['ownca_create_authority_key_identifier']:


### PR DESCRIPTION
##### SUMMARY
Fixes part of #76. Instead of using a random number betwen 1000 and 99999 (both inclusive), selects a 160 bit random number between 2^160 and 2^161 - 1 (both inclusive). No special random input source is used, so the quality is not very high. I think that's ok for serial numbers of certificates (and already a lot better than what we had before).

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
openssl_certificate
