### PR TITLE
Support arbitrary dotted notation for OIDs in cryptography backend

### DIFF
--- a/changelogs/fragments/90-cryptography-oids.yml
+++ b/changelogs/fragments/90-cryptography-oids.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "cryptography backends - support arbitrary dotted OIDs (https://github.com/ansible-collections/community.crypto/issues/39)."

--- a/tests/integration/targets/openssl_csr/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr/tasks/impl.yml
@@ -550,19 +550,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage:
-      - serverAuth  # the same as "TLS Web Server Authentication"
-      - TLS Web Server Authentication
-      - TLS Web Client Authentication
-      - Code Signing
-      - E-mail Protection
-      - timeStamping
-      - OCSPSigning
-      - Any Extended Key Usage
-      - qcStatements
-      - DVCS
-      - IPSec User
-      - biometricInfo
+    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
@@ -575,6 +563,33 @@
     authority_cert_serial_number: '{{ 12345 if select_crypto_backend != "pyopenssl" else omit }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   vars:
+    value_for_extended_key_usage_pyopenssl:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+    value_for_extended_key_usage:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+      - 1.2.3.4.5.6
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
@@ -631,19 +646,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage:
-      - serverAuth  # the same as "TLS Web Server Authentication"
-      - TLS Web Server Authentication
-      - TLS Web Client Authentication
-      - Code Signing
-      - E-mail Protection
-      - timeStamping
-      - OCSPSigning
-      - Any Extended Key Usage
-      - qcStatements
-      - DVCS
-      - IPSec User
-      - biometricInfo
+    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
@@ -656,6 +659,33 @@
     authority_cert_serial_number: '{{ 12345 if select_crypto_backend != "pyopenssl" else omit }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   vars:
+    value_for_extended_key_usage_pyopenssl:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+    value_for_extended_key_usage:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+      - 1.2.3.4.5.6
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
@@ -713,19 +743,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage:
-      - serverAuth  # the same as "TLS Web Server Authentication"
-      - TLS Web Server Authentication
-      - TLS Web Client Authentication
-      - Code Signing
-      - E-mail Protection
-      - timeStamping
-      - OCSPSigning
-      - Any Extended Key Usage
-      - qcStatements
-      - DVCS
-      - IPSec User
-      - biometricInfo
+    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
@@ -738,6 +756,33 @@
     authority_cert_serial_number: '{{ 12345 if select_crypto_backend != "pyopenssl" else omit }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   vars:
+    value_for_extended_key_usage_pyopenssl:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+    value_for_extended_key_usage:
+      - serverAuth  # the same as "TLS Web Server Authentication"
+      - TLS Web Server Authentication
+      - TLS Web Client Authentication
+      - Code Signing
+      - E-mail Protection
+      - timeStamping
+      - OCSPSigning
+      - Any Extended Key Usage
+      - qcStatements
+      - DVCS
+      - IPSec User
+      - biometricInfo
+      - 1.2.3.4.5.6
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"

--- a/tests/integration/targets/openssl_csr/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr/tasks/impl.yml
@@ -550,7 +550,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
+    extended_key_usage: '{{ value_for_extended_key_usage if select_crypto_backend != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
@@ -646,7 +646,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
+    extended_key_usage: '{{ value_for_extended_key_usage if select_crypto_backend != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
@@ -743,7 +743,7 @@
       - Encipher Only
       - decipherOnly
     key_usage_critical: yes
-    extended_key_usage: '{{ value_for_san if value_for_extended_key_usage != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
+    extended_key_usage: '{{ value_for_extended_key_usage if select_crypto_backend != "pyopenssl" else value_for_extended_key_usage_pyopenssl }}'
     subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"

--- a/tests/integration/targets/openssl_csr/tests/validate.yml
+++ b/tests/integration/targets/openssl_csr/tests/validate.yml
@@ -274,6 +274,7 @@
         ]
       - everything_info.subject_key_identifier == "00:11:22:33"
       - everything_info.extended_key_usage == [
+            "1.2.3.4.5.6",
             "Any Extended Key Usage",
             "Biometric Info",
             "Code Signing",
@@ -286,7 +287,6 @@
             "Time Stamping",
             "dvcs",
             "qcStatements",
-            "1.2.3.4.5.6",
         ]
   when: select_crypto_backend != 'pyopenssl'
 

--- a/tests/integration/targets/openssl_csr/tests/validate.yml
+++ b/tests/integration/targets/openssl_csr/tests/validate.yml
@@ -189,20 +189,6 @@
           "pathlen:23",
         ]
       - everything_info.basic_constraints_critical == true
-      - everything_info.extended_key_usage == [
-            "Any Extended Key Usage",
-            "Biometric Info",
-            "Code Signing",
-            "E-mail Protection",
-            "IPSec User",
-            "OCSP Signing",
-            "TLS Web Client Authentication",
-            "TLS Web Server Authentication",
-            "TLS Web Server Authentication",
-            "Time Stamping",
-            "dvcs",
-            "qcStatements",
-        ]
       - everything_info.extended_key_usage_critical == false
       - everything_info.key_usage == [
             "CRL Sign",
@@ -249,6 +235,20 @@
             "URI:https://example.org/test/index.html",
             "RID:1.2.3.4",
         ]
+      - everything_info.extended_key_usage == [
+            "Any Extended Key Usage",
+            "Biometric Info",
+            "Code Signing",
+            "E-mail Protection",
+            "IPSec User",
+            "OCSP Signing",
+            "TLS Web Client Authentication",
+            "TLS Web Server Authentication",
+            "TLS Web Server Authentication",
+            "Time Stamping",
+            "dvcs",
+            "qcStatements",
+        ]
   when: select_crypto_backend == 'pyopenssl'
 
 - name: Check CSR with everything (non-pyOpenSSL specific)
@@ -273,6 +273,21 @@
             "dirName:/O=Example Com/CN=example.com"
         ]
       - everything_info.subject_key_identifier == "00:11:22:33"
+      - everything_info.extended_key_usage == [
+            "Any Extended Key Usage",
+            "Biometric Info",
+            "Code Signing",
+            "E-mail Protection",
+            "IPSec User",
+            "OCSP Signing",
+            "TLS Web Client Authentication",
+            "TLS Web Server Authentication",
+            "TLS Web Server Authentication",
+            "Time Stamping",
+            "dvcs",
+            "qcStatements",
+            "1.2.3.4.5.6",
+        ]
   when: select_crypto_backend != 'pyopenssl'
 
 - name: Verify Ed25519 and Ed448 tests (for cryptography >= 2.6, < 2.8)


### PR DESCRIPTION
##### SUMMARY
Instead of the symbolic name of an OID, allows to provide the OID itself as a dotted string (like `1.2.3.4`).

Fixes #39, and similar usages in other modules.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
every cryptography backend that is using OIDs
