### PR TITLE
Add support for PKCS#11 tokens to openssh_cert.

### DIFF
--- a/changelogs/fragments/openssh_cert-pkcs11.yml
+++ b/changelogs/fragments/openssh_cert-pkcs11.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "openssh_cert - add support for PKCS#11 tokens (https://github.com/ansible-collections/community.crypto/pull/95)."


### PR DESCRIPTION
##### SUMMARY
This PR adds the parameter pkcs11_provider, which can be set to the name of or path to a PKCS#11 library (e.g. libpkcs11.so). ssh-keygen will then use this library to have the token make any required signatures.
If this is used, signing_key needs to be set to a file containing the public key that matches the private key on the token.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_cert.py

##### ADDITIONAL INFORMATION
`pkcs11_provider` is simply passed to `ssh-keygen`. Usual choices include `libpkcs11.so`, `libykcs11.so` (for YubiKey) and possibly others. I think it's a bit awkward to pass a library in order to use a hardware token, but that's how `ssh-keygen` handles it and I do not think we could reasonably provider a better user interface.

If the token requires a PIN to use the key, things may get a little complicated.
If `ssh-keygen` can not get the PIN from a TTY, it uses ssh-askpass, which should be OK for interactive use. However, I could not get it to run for some reason.
When using a local connection instead of SSH, the module/`ssh-keygen` interactively asks for the PIN on the terminal, which should be sufficient for the case where the PKCS#11 token is connected to the Ansible controller, not to the target system(s). I believe that to be the common use case.
I did not find a way of providing the PIN via Ansible, unfortunately.

Note: I did not add any tests, since that would require an PKCS#11 token. It may be possible to emulate that somehow, but I did not look into this topic.