### PR TITLE
acme_certificate - allow to select first certificate in chain

### DIFF
--- a/changelogs/fragments/102-acme-certificate-select-chain-first.yml
+++ b/changelogs/fragments/102-acme-certificate-select-chain-first.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "acme_certificate - allow new selector ``test_certificates: first`` for ``select_chain`` parameter (https://github.com/ansible-collections/community.crypto/pull/102)."

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -220,11 +220,13 @@ options:
           - "Determines which certificates in the chain will be tested."
           - "I(all) tests all certificates in the chain (excluding the leaf, which is
              identical in all chains)."
+          - "I(first) only tests the first certificate in the chain, i.e. the one which
+             signed the leaf."
           - "I(last) only tests the last certificate in the chain, i.e. the one furthest
              away from the leaf. Its issuer is the root certificate of this chain."
         type: str
         default: all
-        choices: [last, all]
+        choices: [first, last, all]
       issuer:
         description:
           - "Allows to specify parts of the issuer of a certificate in the chain must
@@ -1003,6 +1005,8 @@ class ACMEClient(object):
         '''
         if criterium['test_certificates'] == 'last':
             chain = chain[-1:]
+        elif criterium['test_certificates'] == 'first':
+            chain = chain[:1]
         for cert in chain:
             try:
                 x509 = cryptography.x509.load_pem_x509_certificate(to_bytes(cert), cryptography.hazmat.backends.default_backend())
@@ -1183,7 +1187,7 @@ def main():
         force=dict(type='bool', default=False),
         retrieve_all_alternates=dict(type='bool', default=False),
         select_chain=dict(type='list', elements='dict', options=dict(
-            test_certificates=dict(type='str', default='all', choices=['last', 'all']),
+            test_certificates=dict(type='str', default='all', choices=['first', 'last', 'all']),
             issuer=dict(type='dict'),
             subject=dict(type='dict'),
             subject_key_identifier=dict(type='str'),

--- a/tests/integration/targets/acme_certificate/tasks/impl.yml
+++ b/tests/integration/targets/acme_certificate/tasks/impl.yml
@@ -251,7 +251,7 @@
       # the first chain will be found, and we need a second condition to
       # make sure that the first condition actually works. (The second
       # condition has been tested above.)
-      - test_certificates: last
+      - test_certificates: first
         subject_key_identifier: "{{ acme_intermediates[0].subject_key_identifier }}"
       - test_certificates: last
         issuer: "{{ acme_roots[1].subject }}"


### PR DESCRIPTION
##### SUMMARY
When testing letsencrypt/pebble#318 I found that in the tests, the *first* (as opposed to the last) certificate in the chain needs to be matched in some cases. This adds a selector `first`, and adjusts the test to use this selector.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme_certificate
