### PR TITLE
Removal versions in meta/runtime.yml should be collection versions

### DIFF
--- a/changelogs/fragments/108-meta-runtime-versions.yml
+++ b/changelogs/fragments/108-meta-runtime-versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "meta/runtime.yml - convert Ansible version numbers for old names of modules to collection version numbers (https://github.com/ansible-collections/community.crypto/pull/108)."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -13,13 +13,13 @@ plugin_routing:
   modules:
     acme_account_facts:
       deprecation:
-        removal_version: '2.12'
+        removal_version: 2.0.0
         warning_text: The 'community.crypto.acme_account_facts' module has been renamed to 'community.crypto.acme_account_info'.
     openssl_certificate:
       deprecation:
-        removal_version: '2.14'
+        removal_version: 2.0.0
         warning_text: The 'community.crypto.openssl_certificate' module has been renamed to 'community.crypto.x509_certificate'
     openssl_certificate_info:
       deprecation:
-        removal_version: '2.14'
+        removal_version: 2.0.0
         warning_text: The 'community.crypto.openssl_certificate_info' module has been renamed to 'community.crypto.x509_certificate_info'


### PR DESCRIPTION
##### SUMMARY
While working on ansible/ansible#71679 I noticed that we have Ansible versions in meta/runtime.yml. I guess we completely forgot to adjust them before releasing 1.0.0...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meta/runtime.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
