### PR TITLE
Avoid cffi 1.14.3 to be installed in CI by old pip versions

### DIFF
--- a/tests/integration/targets/setup_openssl/meta/main.yml
+++ b/tests/integration/targets/setup_openssl/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - setup_remote_constraints
   - setup_pkg_mgr

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -25,6 +25,7 @@
   become: True
   pip:
     name: pyOpenSSL
+    extra_args: "-c {{ remote_constraints }}"
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version

--- a/tests/integration/targets/setup_remote_constraints/aliases
+++ b/tests/integration/targets/setup_remote_constraints/aliases
@@ -1,0 +1,1 @@
+needs/file/tests/utils/constraints.txt

--- a/tests/integration/targets/setup_remote_constraints/meta/main.yml
+++ b/tests/integration/targets/setup_remote_constraints/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/setup_remote_constraints/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_constraints/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: record constraints.txt path on remote host
+  set_fact:
+    remote_constraints: "{{ remote_tmp_dir }}/constraints.txt"
+
+- name: copy constraints.txt to remote host
+  copy:
+    src: "{{ role_path }}/../../../utils/constraints.txt"
+    dest: "{{ remote_constraints }}"

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -40,6 +40,7 @@ boto3 < 1.11 ; python_version < '2.7' # boto3 1.11 drops Python 2.6 support
 botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca; botocore 1.14 drops Python 2.6 support
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
+cffi != 1.14.3 # Yanked version which older versions of pip will still install:
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -40,7 +40,7 @@ boto3 < 1.11 ; python_version < '2.7' # boto3 1.11 drops Python 2.6 support
 botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca; botocore 1.14 drops Python 2.6 support
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
-cffi != 1.14.3 # Yanked version which older versions of pip will still install:
+cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
Fixes CI.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_openssl
