### PR TITLE
CI tests: add a note not to use tests as an example of writing roles

### DIFF
--- a/tests/integration/targets/acme_account/tasks/main.yml
+++ b/tests/integration/targets/acme_account/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Running tests with OpenSSL backend
     include_tasks: impl.yml

--- a/tests/integration/targets/acme_account_info/tasks/main.yml
+++ b/tests/integration/targets/acme_account_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Running tests with OpenSSL backend
     include_tasks: impl.yml

--- a/tests/integration/targets/acme_certificate/tasks/main.yml
+++ b/tests/integration/targets/acme_certificate/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Obtain root and intermediate certificates
     get_url:

--- a/tests/integration/targets/acme_certificate_revoke/tasks/main.yml
+++ b/tests/integration/targets/acme_certificate_revoke/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Running tests with OpenSSL backend
     include_tasks: impl.yml

--- a/tests/integration/targets/acme_challenge_cert_helper/tasks/main.yml
+++ b/tests/integration/targets/acme_challenge_cert_helper/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Create ECC256 account key
     command: openssl ecparam -name prime256v1 -genkey -out {{ output_dir }}/account-ec256.pem

--- a/tests/integration/targets/acme_inspect/tasks/main.yml
+++ b/tests/integration/targets/acme_inspect/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Running tests with OpenSSL backend
     include_tasks: impl.yml

--- a/tests/integration/targets/certificate_complete_chain/tasks/main.yml
+++ b/tests/integration/targets/certificate_complete_chain/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: register cryptography version
   command: '{{ ansible_python.executable }} -c ''import cryptography; print(cryptography.__version__)'''
   register: cryptography_version

--- a/tests/integration/targets/ecs_certificate/tasks/main.yml
+++ b/tests/integration/targets/ecs_certificate/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ## Verify that integration_config was specified
 - block:
   - assert:

--- a/tests/integration/targets/ecs_domain/tasks/main.yml
+++ b/tests/integration/targets/ecs_domain/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ## Verify that integration_config was specified
 - block:
   - assert:

--- a/tests/integration/targets/get_certificate/tasks/main.yml
+++ b/tests/integration/targets/get_certificate/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
 
   - name: Get servers certificate with backend auto-detection

--- a/tests/integration/targets/luks_device/tasks/main.yml
+++ b/tests/integration/targets/luks_device/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Make sure cryptsetup is installed
   package:
     name: cryptsetup

--- a/tests/integration/targets/openssh_cert/tasks/main.yml
+++ b/tests/integration/targets/openssh_cert/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: openssh_cert integration tests
   when: not (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")
   block:

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Generate privatekey1 - standard
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'

--- a/tests/integration/targets/openssl_csr/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'

--- a/tests/integration/targets/openssl_csr_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'

--- a/tests/integration/targets/openssl_dhparam/tasks/main.yml
+++ b/tests/integration/targets/openssl_dhparam/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # The tests for this module generate unsafe parameters for testing purposes;
 # otherwise tests would be too slow. Use sizes of at least 2048 in production!
 

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Run tests
   include_tasks: impl.yml
   when: pyopenssl_version.stdout is version('17.1.0', '>=')

--- a/tests/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Find out which elliptic curves are supported by installed OpenSSL
   command: openssl ecparam -list_curves
   register: openssl_ecc

--- a/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Generate privatekey 1
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_1.pem'

--- a/tests/integration/targets/openssl_publickey/tasks/main.yml
+++ b/tests/integration/targets/openssl_publickey/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Generate privatekey1 - standard
     openssl_privatekey:

--- a/tests/integration/targets/openssl_signature/tasks/main.yml
+++ b/tests/integration/targets/openssl_signature/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test matrix:
 # * pyopenssl or cryptography
 # * DSA or ECC or ...

--- a/tests/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_http_tests/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # The docker --link functionality gives us an ENV var we can key off of to see if we have access to
 # the httptester container
 - set_fact:

--- a/tests/integration/targets/setup_acme/tasks/main.yml
+++ b/tests/integration/targets/setup_acme/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: register openssl version
   shell: "openssl version | cut -d' ' -f2"
   register: openssl_version

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Include OS-specific variables
   include_vars: '{{ ansible_os_family }}.yml'
   when: not ansible_os_family == "Darwin"

--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - set_fact:
     pkg_mgr: community.general.pkgng
     ansible_pkg_mgr: community.general.pkgng

--- a/tests/integration/targets/setup_remote_constraints/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_constraints/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: record constraints.txt path on remote host
   set_fact:
     remote_constraints: "{{ remote_tmp_dir }}/constraints.txt"

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: make sure we have the ansible_os_family and ansible_distribution_version facts
   setup:
     gather_subset: distribution

--- a/tests/integration/targets/setup_ssh_keygen/tasks/main.yml
+++ b/tests/integration/targets/setup_ssh_keygen/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Include OS-specific variables
   include_vars: '{{ ansible_os_family }}.yml'
   when: not ansible_os_family == "Darwin" and not ansible_os_family == "FreeBSD"

--- a/tests/integration/targets/x509_certificate/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Running tests with pyOpenSSL backend
   include_tasks: impl.yml
   vars:

--- a/tests/integration/targets/x509_certificate_info/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'

--- a/tests/integration/targets/x509_crl/tasks/main.yml
+++ b/tests/integration/targets/x509_crl/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - set_fact:
     certificates:
       - name: ca


### PR DESCRIPTION
##### SUMMARY
CI tests: add a note not to use tests as an example of writing roles because the tests are included in release tarballs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CI tests
