### PR TITLE
openssh_cert: Implement use_agent option to get signing key from ssh-agent

### DIFF
--- a/changelogs/fragments/117-openssh_cert-use-ssh-agent.yml
+++ b/changelogs/fragments/117-openssh_cert-use-ssh-agent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- openssh_cert - add module parameter ``use_agent`` to enable using signing keys stored in ssh-agent (https://github.com/ansible-collections/community.crypto/issues/116).

--- a/plugins/module_utils/crypto/openssh.py
+++ b/plugins/module_utils/crypto/openssh.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# (c) 2020, Doug Stanley <doug+ansible@technologixllc.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import re
+
+
+def parse_openssh_version(version_string):
+    """Parse the version output of ssh -V and return version numbers that can be compared"""
+
+    parsed_result = re.match(
+        r"^.*openssh_(?P<version>[0-9.]+)(p?[0-9]+)[^0-9]*.*$", version_string.lower()
+    )
+    if parsed_result is not None:
+        version = parsed_result.group("version").strip()
+    else:
+        version = None
+
+    return version

--- a/tests/integration/targets/openssh_cert/tasks/main.yml
+++ b/tests/integration/targets/openssh_cert/tasks/main.yml
@@ -411,3 +411,83 @@
       path: '{{ output_dir }}/id_key'
       state: absent
     check_mode: yes
+
+- name: openssh_cert integration tests that require ssh-agent
+  when: openssh_version is version("7.6",">=")
+  environment:
+    SSH_AUTH_SOCK: "{{ openssh_agent_sock }}"
+  block:
+  - name: Generate keypair for agent tests
+    openssh_keypair:
+      path: '{{ output_dir }}/id_key'
+      type: rsa
+  - name: Generate always valid cert using agent without key in agent (should fail)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_with_agent'
+      use_agent: yes
+      valid_from: always
+      valid_to: forever
+    register: rc_no_key_in_agent
+    ignore_errors: yes
+  - name: Make sure cert creation with agent fails if key not in agent
+    assert:
+      that:
+        - rc_no_key_in_agent is failed
+        - "'agent contains no identities' in rc_no_key_in_agent.msg or 'not found in agent' in rc_no_key_in_agent.msg"
+  - name: Add key to agent
+    command: 'ssh-add {{ output_dir }}/id_key'
+  - name: Generate always valid cert with agent (check mode)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_with_agent'
+      use_agent: yes
+      valid_from: always
+      valid_to: forever
+    check_mode: yes
+  - name: Generate always valid cert with agent
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_with_agent'
+      use_agent: yes
+      valid_from: always
+      valid_to: forever
+  - name: Generate always valid cert with agent (idempotent)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_with_agent'
+      use_agent: yes
+      valid_from: always
+      valid_to: forever
+    register: rc_cert_with_agent_idempotent
+  - name: Check agent idempotency
+    assert:
+      that:
+        - rc_cert_with_agent_idempotent is not changed
+      msg: OpenSSH certificate generation without serial number is idempotent.
+  - name: Generate always valid cert with agent (idempotent, check mode)
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_with_agent'
+      use_agent: yes
+      valid_from: always
+      valid_to: forever
+    check_mode: yes
+  - name: Remove keypair for agent tests
+    openssh_keypair:
+      path: '{{ output_dir }}/id_key'
+      state: absent
+  - name: Remove certificate
+    openssh_cert:
+      state: absent
+      path: '{{ output_dir }}/id_cert_with_agent'

--- a/tests/integration/targets/setup_ssh_agent/meta/main.yml
+++ b/tests/integration/targets/setup_ssh_agent/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - setup_ssh_keygen
-  - setup_ssh_agent

--- a/tests/integration/targets/setup_ssh_agent/tasks/main.yml
+++ b/tests/integration/targets/setup_ssh_agent/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Start an ssh agent to use for tests
+  shell: eval $(ssh-agent)>/dev/null&&echo "${SSH_AGENT_PID};${SSH_AUTH_SOCK}"
+  register: openssh_agent_env_vars
+
+- name: Register ssh agent facts
+  set_fact:
+    openssh_agent_pid: "{{ openssh_agent_env_vars.stdout.split(';')[0] }}"
+    openssh_agent_sock: "{{ openssh_agent_env_vars.stdout.split(';')[1] }}"
+
+- name: stat agent socket
+  stat:
+    path: "{{ openssh_agent_sock }}"
+  register: openssh_agent_socket_stat
+
+- name: Assert agent socket file is a socket
+  assert:
+    that: 
+      - openssh_agent_socket_stat.stat.issock is defined
+      - openssh_agent_socket_stat.stat.issock
+    fail_msg: "{{ openssh_agent_sock }} is not a socket"
+
+- name: Verify agent responds
+  command: ssh-add -l
+  register: rc_openssh_agent_ssh_add_check
+  environment:
+    SSH_AUTH_SOCK: "{{ openssh_agent_sock }}"
+  when: openssh_agent_socket_stat.stat.issock
+  failed_when: rc_openssh_agent_ssh_add_check.rc == 2
+
+- name: Get ssh version
+  shell: ssh -Vq 2>&1|sed 's/^.*OpenSSH_\([0-9]\{1,\}\.[0-9]\{1,\}\).*$/\1/'
+  register:
+    rc_openssh_version_output
+
+- name: Set ssh version facts
+  set_fact:
+    openssh_version: "{{ rc_openssh_version_output.stdout.strip() }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implements an additional optional boolean argument to the openssh_cert module called `use_agent` which simply passes the additional `-U` flag to `ssh-keygen` to tell it to look for the signing key in the ssh-agent.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #116 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
