### PR TITLE
Run unit tests for all Python versions in one CI node

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -11,13 +11,7 @@ matrix:
     - env: T=devel/sanity/1
     - env: T=devel/sanity/extra
 
-    - env: T=devel/units/2.6/1
-    - env: T=devel/units/2.7/1
-    - env: T=devel/units/3.5/1
-    - env: T=devel/units/3.6/1
-    - env: T=devel/units/3.7/1
-    - env: T=devel/units/3.8/1
-    - env: T=devel/units/3.9/1
+    - env: T=devel/units/1
 
     - env: T=devel/osx/10.11/1
     - env: T=devel/rhel/7.8/1
@@ -45,16 +39,14 @@ matrix:
 
     # For Ansible 2.10, use a combination of different targets
     - env: T=2.10/sanity/1
-    - env: T=2.10/units/2.7/1
-    - env: T=2.10/units/3.8/1
+    - env: T=2.10/units/1
     - env: T=2.10/rhel/7.8/1
     - env: T=2.10/linux/ubuntu1804/1
     - env: T=2.10/cloud/3.6/1
 
     # For Ansible 2.9, use a combination of different targets
     - env: T=2.9/sanity/1
-    - env: T=2.9/units/2.7/1
-    - env: T=2.9/units/3.8/1
+    - env: T=2.9/units/1
     - env: T=2.9/rhel/7.8/1
     - env: T=2.9/linux/ubuntu1804/1
     - env: T=2.9/cloud/3.5/1

--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -5,8 +5,6 @@ set -o pipefail -eux
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-version="${args[1]}"
-
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=90
 else
@@ -16,4 +14,4 @@ fi
 ansible-test env --timeout "${timeout}" --color -v
 
 # shellcheck disable=SC2086
-ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+ansible-test units --color -v --docker default ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \


### PR DESCRIPTION
##### SUMMARY
This runs tests with stable-2.9 and stable-2.10 against more Python versions, and should improve CI performance as setup takes a lot more time than actually running the tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
CI
