### PR TITLE
Work around problem with cryptography being upgraded while installing pyOpenSSL

### DIFF
--- a/tests/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -286,6 +286,13 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_2
 
+- name: Make sure that mtime actually changes.
+  # The "privatekey_mode_1_stat.stat.mtime != privatekey_mode_3_stat.stat.mtime" test should be
+  # changed to compare content instead of mtime. On macOS 10.15, mtime resolution is one second,
+  # and the machine (VM) is fast enough that both modifications can happen in the same second.
+  pause:
+    seconds: 1
+
 - name: "({{ select_crypto_backend }}) Generate privatekey_mode (mode 0400, force)"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'

--- a/tests/integration/targets/setup_pyopenssl/tasks/main.yml
+++ b/tests/integration/targets/setup_pyopenssl/tasks/main.yml
@@ -35,3 +35,11 @@
   command: "{{ ansible_python.executable }} -m OpenSSL.debug"
   register: pyopenssl_debug_version
   ignore_errors: yes
+
+# Depending on which pyOpenSSL version has been installed, it could be that cryptography has
+# been upgraded to a newer version. Make sure to register cryptography_version another time here
+# to avoid strange testing behavior due to wrong values of cryptography_version.
+- name: Register cryptography version
+  command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
+  register: cryptography_version
+  ignore_errors: yes  # in case cryptography was not installed, and setup_openssl hasn't been run before, ignore errors


### PR DESCRIPTION
##### SUMMARY
Fixes instabilities such as https://app.shippable.com/github/ansible-collections/community.crypto/runs/675/4/tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
