### PR TITLE
Fix bug in AnsibleActionModule.

### DIFF
--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -101,6 +101,7 @@ class AnsibleActionModule(object):
 
         self.aliases = {}
         self._legal_inputs = []
+        self._options_context = list()
 
         self.params = copy.deepcopy(action_plugin._task.args)
         self._set_fallbacks()


### PR DESCRIPTION
##### SUMMARY
Right now, the openssl_privatekey_pipe module crashes when an invalid option is passed due to a bug in AnsibleActionModule.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/plugin_utils/action_module.py
