### PR TITLE
openssl_pkcs12: Add a check for parsed pkcs12 files

### DIFF
--- a/changelogs/fragments/145-add-check-for-parsed-pkcs12-files.yml
+++ b/changelogs/fragments/145-add-check-for-parsed-pkcs12-files.yml
@@ -1,0 +1,3 @@
+bugfixes:
+ - openssl_pkcs12 - Add a check for parsed PKCS#12 files to prevent permanent
+   changed state in check mode (https://github.com/ansible-collections/community.crypto/issues/143).

--- a/changelogs/fragments/145-add-check-for-parsed-pkcs12-files.yml
+++ b/changelogs/fragments/145-add-check-for-parsed-pkcs12-files.yml
@@ -1,3 +1,2 @@
 bugfixes:
- - openssl_pkcs12 - Add a check for parsed PKCS#12 files to prevent permanent
-   changed state in check mode (https://github.com/ansible-collections/community.crypto/issues/143).
+ - openssl_pkcs12 - report the correct state when ``action`` is ``parse`` (https://github.com/ansible-collections/community.crypto/issues/143).

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -459,6 +459,7 @@ def main():
                     pkey, cert, other_certs, friendly_name = pkcs12.parse()
                     dump_content = ''.join([to_native(pem) for pem in [pkey, cert] + other_certs if pem is not None])
                     pkcs12.write(module, to_bytes(dump_content))
+                    changed = True
 
             file_args = module.load_file_common_arguments(module.params)
             if module.set_fs_attributes_if_different(file_args, changed):

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -302,6 +302,17 @@ class Pkcs(OpenSSLObject):
                         return False
                 elif bool(self.pkcs12.get_friendlyname()) != bool(pkcs12_friendly_name):
                     return False
+        elif module.params['action'] == 'parse' and os.path.exists(self.src) and os.path.exists(self.path):
+            try:
+                pkey, cert, other_certs, friendly_name = self.parse()
+            except crypto.Error:
+                return False
+            expected_content = to_bytes(
+                ''.join([to_native(pem) for pem in [pkey, cert] + other_certs if pem is not None])
+            )
+            dumped_content = load_file_if_exists(self.path, ignore_errors=True)
+            if expected_content != dumped_content:
+                return False
         else:
             return False
 

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -96,6 +96,14 @@
       action: parse
       state: present
     register: p12_dumped_idempotency
+  - name: Dump PKCS#12, check mode
+    openssl_pkcs12:
+      src: '{{ output_dir }}/ansible.p12'
+      path: '{{ output_dir }}/ansible_parse.pem'
+      action: parse
+      state: present
+    check_mode: true
+    register: p12_dumped_check_mode
   - name: Generate PKCS#12 file with multiple certs
     openssl_pkcs12:
       path: '{{ output_dir }}/ansible_multi_certs.p12'

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -88,6 +88,14 @@
       path: '{{ output_dir }}/ansible_parse.pem'
       action: parse
       state: present
+    register: p12_dumped
+  - name: Dump PKCS#12 file again, idempotency
+    openssl_pkcs12:
+      src: '{{ output_dir }}/ansible.p12'
+      path: '{{ output_dir }}/ansible_parse.pem'
+      action: parse
+      state: present
+    register: p12_dumped_idempotency
   - name: Generate PKCS#12 file with multiple certs
     openssl_pkcs12:
       path: '{{ output_dir }}/ansible_multi_certs.p12'

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -20,8 +20,10 @@
       - p12_validate_no_pkey.stdout_lines[-1] == '-----END CERTIFICATE-----'
       - p12_force.changed
       - p12_force_and_mode.mode == '0644' and p12_force_and_mode.changed
+      - p12_dumped.changed
       - not p12_standard_idempotency.changed
       - not p12_multiple_certs_idempotency.changed
+      - not p12_dumped_idempotency.changed
       - "'www.' in p12_validate_multi_certs.stdout"
       - "'www2.' in p12_validate_multi_certs.stdout"
       - "'www3.' in p12_validate_multi_certs.stdout"

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -24,6 +24,7 @@
       - not p12_standard_idempotency.changed
       - not p12_multiple_certs_idempotency.changed
       - not p12_dumped_idempotency.changed
+      - not p12_dumped_check_mode.changed
       - "'www.' in p12_validate_multi_certs.stdout"
       - "'www2.' in p12_validate_multi_certs.stdout"
       - "'www3.' in p12_validate_multi_certs.stdout"


### PR DESCRIPTION
##### SUMMARY
With this pull request the `parse` action for the `openssl_pkcs12` module is now considered separately in the `check()` function.

Fixes #143 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- openssl_pkcs12

##### ADDITIONAL INFORMATION
Without this change, the [`parse`](https://docs.ansible.com/ansible/2.10/collections/community/crypto/openssl_pkcs12_module.html#parameter-action) action would always result in `changed` state when running in check mode.