### PR TITLE
Speed up tests

### DIFF
--- a/tests/integration/targets/acme_certificate/tasks/impl.yml
+++ b/tests/integration/targets/acme_certificate/tasks/impl.yml
@@ -4,8 +4,8 @@
   command: "{{ openssl_binary }} ecparam -name prime256v1 -genkey -out {{ output_dir }}/account-ec256.pem"
 - name: Create ECC384 account key
   command: "{{ openssl_binary }} ecparam -name secp384r1 -genkey -out {{ output_dir }}/account-ec384.pem"
-- name: Create RSA-2048 account key
-  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/account-rsa2048.pem 2048"
+- name: Create RSA account key
+  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/account-rsa.pem {{ default_rsa_key_size }}"
 ## SET UP ACCOUNTS ############################################################################
 - name: Make sure ECC256 account hasn't been created yet
   acme_account:
@@ -28,13 +28,13 @@
     contact:
     - mailto:example@example.org
     - mailto:example@example.com
-- name: Create RSA-2048 account
+- name: Create RSA account
   acme_account:
     select_crypto_backend: "{{ select_crypto_backend }}"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
-    account_key_src: "{{ output_dir }}/account-rsa2048.pem"
+    account_key_src: "{{ output_dir }}/account-rsa.pem"
     state: present
     allow_creation: yes
     terms_agreed: yes
@@ -46,7 +46,7 @@
     certgen_title: Certificate 1
     certificate_name: cert-1
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name: "DNS:example.com"
     subject_alt_name_critical: no
     account_key: account-ec256
@@ -107,7 +107,7 @@
     key_type: ec384
     subject_alt_name: "DNS:*.example.com,DNS:example.org,DNS:t1.example.com"
     subject_alt_name_critical: no
-    account_key_content: "{{ lookup('file', output_dir ~ '/account-rsa2048.pem') }}"
+    account_key_content: "{{ lookup('file', output_dir ~ '/account-rsa.pem') }}"
     challenge: dns-01
     modify_account: no
     deactivate_authzs: no
@@ -131,10 +131,10 @@
     certgen_title: Certificate 4
     certificate_name: cert-4
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name: "DNS:example.com,DNS:t1.example.com,DNS:test.t2.example.com,DNS:example.org,DNS:test.example.org"
     subject_alt_name_critical: no
-    account_key: account-rsa2048
+    account_key: account-rsa
     challenge: http-01
     modify_account: no
     deactivate_authzs: yes
@@ -242,7 +242,7 @@
     certgen_title: Certificate 6
     certificate_name: cert-6
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name: "DNS:example.org"
     subject_alt_name_critical: no
     account_key: account-ec256
@@ -274,7 +274,7 @@
     certgen_title: Certificate 7
     certificate_name: cert-7
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name:
     - "IP:127.0.0.1"
     # - "IP:::1"
@@ -302,7 +302,7 @@
     certgen_title: Certificate 8
     certificate_name: cert-8
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name:
     - "IP:127.0.0.1"
     # IPv4 only since our test validation server doesn't work

--- a/tests/integration/targets/acme_certificate_revoke/tasks/impl.yml
+++ b/tests/integration/targets/acme_certificate_revoke/tasks/impl.yml
@@ -4,8 +4,8 @@
   command: "{{ openssl_binary }} ecparam -name prime256v1 -genkey -out {{ output_dir }}/account-ec256.pem"
 - name: Create ECC384 account key
   command: "{{ openssl_binary }} ecparam -name secp384r1 -genkey -out {{ output_dir }}/account-ec384.pem"
-- name: Create RSA-2048 account key
-  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/account-rsa2048.pem 2048"
+- name: Create RSA account key
+  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/account-rsa.pem {{ default_rsa_key_size }}"
 ## CREATE ACCOUNTS AND OBTAIN CERTIFICATES ####################################################
 - name: Obtain cert 1
   include_tasks: obtain-cert.yml
@@ -13,7 +13,7 @@
     certgen_title: Certificate 1 for revocation
     certificate_name: cert-1
     key_type: rsa
-    rsa_bits: 2048
+    rsa_bits: "{{ default_rsa_key_size }}"
     subject_alt_name: "DNS:example.com"
     subject_alt_name_critical: no
     account_key_content: "{{ lookup('file', output_dir ~ '/account-ec256.pem') }}"
@@ -48,7 +48,7 @@
     key_type: ec384
     subject_alt_name: "DNS:t1.example.com"
     subject_alt_name_critical: no
-    account_key: account-rsa2048
+    account_key: account-rsa
     challenge: dns-01
     modify_account: yes
     deactivate_authzs: no
@@ -80,7 +80,7 @@
 - name: Revoke certificate 3 via account key (fullchain)
   acme_certificate_revoke:
     select_crypto_backend: "{{ select_crypto_backend }}"
-    account_key_content: "{{ lookup('file', output_dir ~ '/account-rsa2048.pem') }}"
+    account_key_content: "{{ lookup('file', output_dir ~ '/account-rsa.pem') }}"
     certificate: "{{ output_dir }}/cert-3-fullchain.pem"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir

--- a/tests/integration/targets/acme_challenge_cert_helper/tasks/main.yml
+++ b/tests/integration/targets/acme_challenge_cert_helper/tasks/main.yml
@@ -14,7 +14,7 @@
       certgen_title: Certificate 1
       certificate_name: cert-1
       key_type: rsa
-      rsa_bits: 2048
+      rsa_bits: "{{ default_rsa_key_size }}"
       subject_alt_name: "DNS:example.com"
       subject_alt_name_critical: no
       account_key: account-ec256

--- a/tests/integration/targets/openssh_cert/tasks/main.yml
+++ b/tests/integration/targets/openssh_cert/tasks/main.yml
@@ -6,24 +6,11 @@
 - name: openssh_cert integration tests
   when: not (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")
   block:
-  - name: Generate keypair (check mode)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      type: rsa
-    check_mode: yes
   - name: Generate keypair
     openssh_keypair:
       path: '{{ output_dir }}/id_key'
       type: rsa
-  - name: Generate keypair (idempotent)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      type: rsa
-  - name: Generate keypair (idempotent, check mode)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      type: rsa
-    check_mode: yes
+      size: 2048
   - name: Generate always valid cert (check mode)
     openssh_cert:
       type: user
@@ -393,24 +380,10 @@
       #valid_from: "2001-01-21"
       #valid_to: "2019-01-21"
     check_mode: yes
-  - name: Remove keypair (check mode)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      state: absent
-    check_mode: yes
   - name: Remove keypair
     openssh_keypair:
       path: '{{ output_dir }}/id_key'
       state: absent
-  - name: Remove keypair (idempotent)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      state: absent
-  - name: Remove keypair (idempotent, check mode)
-    openssh_keypair:
-      path: '{{ output_dir }}/id_key'
-      state: absent
-    check_mode: yes
 
 - name: openssh_cert integration tests that require ssh-agent
   when: openssh_version is version("7.6",">=")
@@ -421,6 +394,7 @@
     openssh_keypair:
       path: '{{ output_dir }}/id_key'
       type: rsa
+      size: 2048
   - name: Generate always valid cert using agent without key in agent (should fail)
     openssh_cert:
       type: user

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -4,20 +4,35 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
+- name: Generate privatekey1 - standard (check mode)
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey1'
+    size: 2048
+  register: privatekey1_result_check
+  check_mode: true
+
 - name: Generate privatekey1 - standard
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'
+    size: 2048
   register: privatekey1_result
+
+- name: Generate privatekey1 - standard (check mode idempotent)
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey1'
+    size: 2048
+  register: privatekey1_idem_result_check
+  check_mode: true
 
 - name: Generate privatekey1 - standard (idempotent)
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'
+    size: 2048
   register: privatekey1_idem_result
 
-- name: Generate privatekey2 - size 2048
+- name: Generate privatekey2 - default size
   openssh_keypair:
     path: '{{ output_dir }}/privatekey2'
-    size: 2048
 
 - name: Generate privatekey3 - type dsa
   openssh_keypair:
@@ -27,6 +42,7 @@
 - name: Generate privatekey4 - standard
   openssh_keypair:
     path: '{{ output_dir }}/privatekey4'
+    size: 2048
 
 - name: Delete privatekey4 - standard
   openssh_keypair:
@@ -36,17 +52,20 @@
 - name: Generate privatekey5 - standard
   openssh_keypair:
     path: '{{ output_dir }}/privatekey5'
+    size: 2048
   register: publickey_gen
 
 - name: Generate privatekey6
   openssh_keypair:
     path: '{{ output_dir }}/privatekey6'
     type: rsa
+    size: 2048
 
 - name: Regenerate privatekey6 via force
   openssh_keypair:
     path: '{{ output_dir }}/privatekey6'
     type: rsa
+    size: 2048
     force: yes
   register: output_regenerated_via_force
 
@@ -63,6 +82,7 @@
   openssh_keypair:
     path: '{{ output_dir }}/privatekeybroken'
     type: rsa
+    size: 2048
   register: output_broken
   ignore_errors: yes
 
@@ -71,6 +91,7 @@
     path: '{{ output_dir }}/privatekeybroken'
     type: rsa
     force: yes
+    size: 2048
   register: output_broken_force
 
 - name: Generate read-only private key
@@ -78,24 +99,28 @@
     path: '{{ output_dir }}/privatekeyreadonly'
     type: rsa
     mode: '0200'
+    size: 2048
 
 - name: Regenerate read-only private key via force
   openssh_keypair:
     path: '{{ output_dir }}/privatekeyreadonly'
     type: rsa
     force: yes
+    size: 2048
   register: output_read_only
 
 - name: Generate privatekey7 - standard with comment
   openssh_keypair:
     path: '{{ output_dir }}/privatekey7'
     comment: 'test@privatekey7'
+    size: 2048
   register: privatekey7_result
 
 - name: Modify privatekey7 comment
   openssh_keypair:
     path: '{{ output_dir }}/privatekey7'
     comment: 'test_modified@privatekey7'
+    size: 2048
   register: privatekey7_modified_result
 
 - name: Generate password protected key
@@ -104,6 +129,7 @@
 - name: Try to modify the password protected key - should fail
   openssh_keypair:
     path: '{{ output_dir }}/privatekey8'
+    size: 2048
   register: privatekey8_result
   ignore_errors: yes
 
@@ -111,6 +137,7 @@
   openssh_keypair:
     path: '{{ output_dir }}/privatekey8'
     force: yes
+    size: 2048
   register: privatekey8_result_force
 
 - import_tasks: ../tests/validate.yml

--- a/tests/integration/targets/openssh_keypair/tests/validate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/validate.yml
@@ -3,6 +3,14 @@
   debug:
     var: privatekey1_result
 
+- name: Validate general behavior
+  assert:
+    that:
+      - privatekey1_result_check is changed
+      - privatekey1_result is changed
+      - privatekey1_idem_result_check is not changed
+      - privatekey1_idem_result is not changed
+
 - name: Validate privatekey1 return fingerprint
   assert:
     that:
@@ -21,7 +29,7 @@
   assert:
     that:
       - privatekey1_result["size"]|type_debug == 'int'
-      - privatekey1_result["size"] == 4096
+      - privatekey1_result["size"] == 2048
 
 - name: Validate privatekey1 return key type
   assert:
@@ -29,14 +37,14 @@
       - privatekey1_result["type"] is string
       - privatekey1_result["type"] == "rsa"
 
-- name: Validate privatekey1 (test - RSA key with size 4096 bits)
+- name: Validate privatekey1 (test - RSA key with size 2048 bits)
   shell: "ssh-keygen -lf {{ output_dir }}/privatekey1 | grep -o -E '^[0-9]+'"
   register: privatekey1
 
-- name: Validate privatekey1 (assert - RSA key with size 4096 bits)
+- name: Validate privatekey1 (assert - RSA key with size 2048 bits)
   assert:
     that:
-      - privatekey1.stdout == '4096'
+      - privatekey1.stdout == '2048'
 
 - name: Validate privatekey1 idempotence
   assert:
@@ -44,14 +52,14 @@
       - privatekey1_idem_result is not changed
 
 
-- name: Validate privatekey2 (test - RSA key with size 2048 bits)
+- name: Validate privatekey2 (test - RSA key with default size 4096 bits)
   shell: "ssh-keygen -lf {{ output_dir }}/privatekey2 | grep -o -E '^[0-9]+'"
   register: privatekey2
 
-- name: Validate privatekey2 (assert - RSA key with size 2048 bits)
+- name: Validate privatekey2 (assert - RSA key with size 4096 bits)
   assert:
     that:
-      - privatekey2.stdout == '2048'
+      - privatekey2.stdout == '4096'
 
 
 - name: Validate privatekey3 (test - DSA key with size 1024 bits)

--- a/tests/integration/targets/openssl_csr/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr/tasks/impl.yml
@@ -2,7 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate CSR (check mode)"
   openssl_csr:
@@ -262,7 +262,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate CSR with privatekey passphrase"
   openssl_csr:

--- a/tests/integration/targets/openssl_csr/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr/tasks/impl.yml
@@ -2,6 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate CSR (check mode)"
   openssl_csr:
@@ -261,6 +262,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate CSR with privatekey passphrase"
   openssl_csr:

--- a/tests/integration/targets/openssl_csr/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 - name: Run module with backend autodetection
   openssl_csr:
     path: '{{ output_dir }}/csr_backend_selection.csr'

--- a/tests/integration/targets/openssl_csr/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
+    size: 2048
 - name: Run module with backend autodetection
   openssl_csr:
     path: '{{ output_dir }}/csr_backend_selection.csr'

--- a/tests/integration/targets/openssl_csr_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr_info/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: Generate privatekey with password
   openssl_privatekey:
@@ -14,6 +15,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: Generate CSR 1
   openssl_csr:

--- a/tests/integration/targets/openssl_csr_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr_info/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate privatekey with password
   openssl_privatekey:
@@ -15,7 +15,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate CSR 1
   openssl_csr:

--- a/tests/integration/targets/openssl_csr_pipe/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr_pipe/tasks/impl.yml
@@ -2,7 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate CSR (check mode)"
   openssl_csr_pipe:

--- a/tests/integration/targets/openssl_csr_pipe/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr_pipe/tasks/impl.yml
@@ -2,6 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate CSR (check mode)"
   openssl_csr_pipe:

--- a/tests/integration/targets/openssl_csr_pipe/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr_pipe/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 - name: Run module with backend autodetection
   openssl_csr_pipe:
     privatekey_path: '{{ output_dir }}/privatekey_backend_selection.pem'

--- a/tests/integration/targets/openssl_csr_pipe/tasks/main.yml
+++ b/tests/integration/targets/openssl_csr_pipe/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
+    size: 2048
 - name: Run module with backend autodetection
   openssl_csr_pipe:
     privatekey_path: '{{ output_dir }}/privatekey_backend_selection.pem'

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -2,15 +2,15 @@
   - name: Generate privatekey
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey.pem'
-      size: '{{ default_rsa_key_size }}'
+      size: '{{ default_rsa_key_size_certifiates }}'
   - name: Generate privatekey2
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey2.pem'
-      size: '{{ default_rsa_key_size }}'
+      size: '{{ default_rsa_key_size_certifiates }}'
   - name: Generate privatekey3
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey3.pem'
-      size: '{{ default_rsa_key_size }}'
+      size: '{{ default_rsa_key_size_certifiates }}'
   - name: Generate CSR
     openssl_csr:
       path: '{{ output_dir }}/ansible.csr'

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -2,12 +2,15 @@
   - name: Generate privatekey
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey.pem'
+      size: 2048
   - name: Generate privatekey2
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey2.pem'
+      size: 2048
   - name: Generate privatekey3
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey3.pem'
+      size: 2048
   - name: Generate CSR
     openssl_csr:
       path: '{{ output_dir }}/ansible.csr'
@@ -137,6 +140,7 @@
       path: '{{ output_dir }}/privatekeypw.pem'
       passphrase: hunter2
       cipher: auto
+      size: 2048
       select_crypto_backend: cryptography
   - name: Generate PKCS#12 file (password fail 1)
     openssl_pkcs12:

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -2,15 +2,15 @@
   - name: Generate privatekey
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey.pem'
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
   - name: Generate privatekey2
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey2.pem'
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
   - name: Generate privatekey3
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey3.pem'
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
   - name: Generate CSR
     openssl_csr:
       path: '{{ output_dir }}/ansible.csr'
@@ -140,7 +140,7 @@
       path: '{{ output_dir }}/privatekeypw.pem'
       passphrase: hunter2
       cipher: auto
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: cryptography
   - name: Generate PKCS#12 file (password fail 1)
     openssl_pkcs12:

--- a/tests/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -520,14 +520,14 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
 - name: "({{ select_crypto_backend }}) Regenerate - setup password protected keys"
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-b-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
@@ -543,7 +543,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-c-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
@@ -565,7 +565,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-c-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
@@ -586,7 +586,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-b-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
@@ -608,7 +608,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-b-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
@@ -629,7 +629,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
@@ -647,7 +647,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: RSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
@@ -664,7 +664,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: RSA
-    size: 1048
+    size: '{{ default_rsa_key_size + 20 }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
@@ -684,7 +684,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: RSA
-    size: 1048
+    size: '{{ default_rsa_key_size + 20 }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
@@ -711,7 +711,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: DSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
@@ -731,7 +731,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
     type: DSA
-    size: 1024
+    size: '{{ default_rsa_key_size }}'
     regenerate: '{{ item }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   loop: "{{ regenerate_values }}"
@@ -759,7 +759,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
       type: DSA
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       format: pkcs8
       regenerate: '{{ item }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
@@ -780,7 +780,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
       type: DSA
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       format: pkcs8
       regenerate: '{{ item }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
@@ -808,7 +808,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
       type: DSA
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       format: pkcs1
       format_mismatch: convert
       regenerate: '{{ item }}'
@@ -828,7 +828,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/regenerate-a-{{ item }}.pem'
       type: DSA
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       format: pkcs1
       format_mismatch: convert
       regenerate: '{{ item }}'

--- a/tests/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -29,6 +29,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey4 - standard"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey4.pem'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - name: "({{ select_crypto_backend }}) Delete privatekey4 - standard"
@@ -51,6 +52,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     passphrase: ansible
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - name: "({{ select_crypto_backend }}) Generate privatekey5 - standard - idempotence"
@@ -58,6 +60,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     passphrase: ansible
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey5_idempotence
 
@@ -66,6 +69,7 @@
     path: '{{ output_dir }}/privatekey6.pem'
     passphrase: ànsïblé
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - set_fact:
@@ -202,6 +206,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_1
@@ -211,6 +216,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_2
@@ -218,6 +224,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate privatekey without passphrase"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_3
@@ -225,6 +232,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate privatekey without passphrase (idempotent)"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_4
@@ -234,6 +242,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_5
@@ -245,6 +254,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate broken key"
   openssl_privatekey:
     path: '{{ output_dir }}/broken.pem'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: output_broken
 
@@ -253,6 +263,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
     state: absent
@@ -263,6 +274,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
     state: absent
@@ -272,6 +284,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_1
 - name: "({{ select_crypto_backend }}) Stat for privatekey_mode"
@@ -283,6 +296,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_2
 
@@ -298,6 +312,7 @@
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
     force: yes
+    size: 2048
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_3
 - name: "({{ select_crypto_backend }}) Stat for privatekey_mode"
@@ -310,6 +325,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_1
 
@@ -317,6 +333,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_2
 
@@ -324,6 +341,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs1
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_3
 
@@ -331,6 +349,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_4
 
@@ -338,6 +357,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_5
 
@@ -345,6 +365,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto_ignore
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_6
 
@@ -352,6 +373,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_7
 
@@ -359,6 +381,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: raw
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     ignore_errors: yes
     register: privatekey_fmt_1_step_8
@@ -374,6 +397,7 @@
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
       format_mismatch: convert
+      size: 2048
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_9
 

--- a/tests/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -29,7 +29,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey4 - standard"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey4.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - name: "({{ select_crypto_backend }}) Delete privatekey4 - standard"
@@ -52,7 +52,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     passphrase: ansible
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - name: "({{ select_crypto_backend }}) Generate privatekey5 - standard - idempotence"
@@ -60,7 +60,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     passphrase: ansible
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey5_idempotence
 
@@ -69,7 +69,7 @@
     path: '{{ output_dir }}/privatekey6.pem'
     passphrase: ànsïblé
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
 
 - set_fact:
@@ -206,7 +206,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_1
@@ -216,7 +216,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_2
@@ -224,7 +224,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate privatekey without passphrase"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_3
@@ -232,7 +232,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate privatekey without passphrase (idempotent)"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekeypw.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_4
@@ -242,7 +242,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
   register: passphrase_5
@@ -254,7 +254,7 @@
 - name: "({{ select_crypto_backend }}) Regenerate broken key"
   openssl_privatekey:
     path: '{{ output_dir }}/broken.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: output_broken
 
@@ -263,7 +263,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
     state: absent
@@ -274,7 +274,7 @@
     path: '{{ output_dir }}/privatekeypw.pem'
     passphrase: hunter2
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
     backup: yes
     state: absent
@@ -284,7 +284,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_1
 - name: "({{ select_crypto_backend }}) Stat for privatekey_mode"
@@ -296,7 +296,7 @@
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_2
 
@@ -312,7 +312,7 @@
     path: '{{ output_dir }}/privatekey_mode.pem'
     mode: '0400'
     force: yes
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_3
 - name: "({{ select_crypto_backend }}) Stat for privatekey_mode"
@@ -325,7 +325,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_1
 
@@ -333,7 +333,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_2
 
@@ -341,7 +341,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs1
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_3
 
@@ -349,7 +349,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_4
 
@@ -357,7 +357,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_5
 
@@ -365,7 +365,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto_ignore
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_6
 
@@ -373,7 +373,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: auto
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_7
 
@@ -381,7 +381,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: raw
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     ignore_errors: yes
     register: privatekey_fmt_1_step_8
@@ -397,7 +397,7 @@
       path: '{{ output_dir }}/privatekey_fmt_1.pem'
       format: pkcs8
       format_mismatch: convert
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: '{{ select_crypto_backend }}'
     register: privatekey_fmt_1_step_9
 

--- a/tests/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Run module with backend autodetection
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - block:
   - name: Running tests with pyOpenSSL backend

--- a/tests/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/main.yml
@@ -77,7 +77,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/fingerprint-{{ item }}.pem'
       type: "{{ item }}"
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: pyopenssl
     loop:
     - RSA
@@ -88,7 +88,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/fingerprint-{{ item }}.pem'
       type: "{{ item }}"
-      size: 1024
+      size: '{{ default_rsa_key_size }}'
       select_crypto_backend: cryptography
     loop:
     - RSA

--- a/tests/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/main.yml
@@ -34,6 +34,7 @@
 - name: Run module with backend autodetection
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
+    size: 2048
 
 - block:
   - name: Running tests with pyOpenSSL backend

--- a/tests/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/tests/integration/targets/openssl_privatekey/tests/validate.yml
@@ -68,7 +68,7 @@
 - name: "({{ select_crypto_backend }}) Validate privatekey5 (assert - Passphrase protected key + idempotence)"
   assert:
     that:
-      - privatekey5.stdout == '4096'
+      - privatekey5.stdout == '2048'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: "({{ select_crypto_backend }}) Validate privatekey5 idempotence (assert - Passphrase protected key + idempotence)"
@@ -85,7 +85,7 @@
 - name: "({{ select_crypto_backend }}) Validate privatekey6 (assert - Passphrase protected key with non ascii character)"
   assert:
     that:
-      - privatekey6.stdout == '4096'
+      - privatekey6.stdout == '2048'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: "({{ select_crypto_backend }}) Validate ECC generation (dump with OpenSSL)"

--- a/tests/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/tests/integration/targets/openssl_privatekey/tests/validate.yml
@@ -68,7 +68,7 @@
 - name: "({{ select_crypto_backend }}) Validate privatekey5 (assert - Passphrase protected key + idempotence)"
   assert:
     that:
-      - privatekey5.stdout == '2048'
+      - privatekey5.stdout == '{{ default_rsa_key_size }}'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: "({{ select_crypto_backend }}) Validate privatekey5 idempotence (assert - Passphrase protected key + idempotence)"
@@ -85,7 +85,7 @@
 - name: "({{ select_crypto_backend }}) Validate privatekey6 (assert - Passphrase protected key with non ascii character)"
   assert:
     that:
-      - privatekey6.stdout == '2048'
+      - privatekey6.stdout == '{{ default_rsa_key_size }}'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: "({{ select_crypto_backend }}) Validate ECC generation (dump with OpenSSL)"

--- a/tests/integration/targets/openssl_privatekey_info/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/impl.yml
@@ -50,7 +50,7 @@
       - "'type' in result"
       - "result.type == 'RSA'"
       - "'public_data' in result"
-      - "result.public_data.size == 2048"
+      - "result.public_data.size == default_rsa_key_size"
       - "2 ** (result.public_data.size - 1) < result.public_data.modulus < 2 ** result.public_data.size"
       - "result.public_data.exponent > 5"
       - "'private_data' in result"

--- a/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
@@ -12,14 +12,14 @@
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_2.pem'
     type: RSA
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate privatekey 3 (with password)
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_3.pem'
     passphrase: hunter2
     cipher: auto
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     select_crypto_backend: cryptography
 
 - name: Generate privatekey 4 (ECC)

--- a/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
@@ -19,6 +19,7 @@
     path: '{{ output_dir }}/privatekey_3.pem'
     passphrase: hunter2
     cipher: auto
+    size: 2048
     select_crypto_backend: cryptography
 
 - name: Generate privatekey 4 (ECC)

--- a/tests/integration/targets/openssl_privatekey_pipe/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey_pipe/tasks/impl.yml
@@ -92,7 +92,7 @@
       - update_check_return.privatekey == result.privatekey
       - update is changed
       - update.privatekey != result.privatekey
-      - update_info.public_data.size == 2048
+      - update_info.public_data.size == default_rsa_key_size
       - update_idempotent_check is not changed
       - update_idempotent_check.privatekey is undefined
       - update_idempotent is not changed

--- a/tests/integration/targets/openssl_privatekey_pipe/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey_pipe/tasks/impl.yml
@@ -27,7 +27,7 @@
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ result.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
   register: update_check
   check_mode: true
 
@@ -35,7 +35,7 @@
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ result.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     return_current_key: true
   register: update_check_return
   check_mode: true
@@ -44,14 +44,14 @@
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ result.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
   register: update
 
 - name: ({{select_crypto_backend}}) Update key (idempotent, check mode)
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ update.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
   register: update_idempotent_check
   check_mode: true
 
@@ -59,14 +59,14 @@
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ update.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
   register: update_idempotent
 
 - name: ({{select_crypto_backend}}) Update key (idempotent, check mode, with return_current_key=true)
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ update.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     return_current_key: true
   register: update_idempotent_return_check
   check_mode: true
@@ -75,7 +75,7 @@
   openssl_privatekey_pipe:
     select_crypto_backend: '{{ select_crypto_backend }}'
     content: "{{ update.privatekey }}"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
     return_current_key: true
   register: update_idempotent_return
 

--- a/tests/integration/targets/openssl_privatekey_pipe/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_pipe/tasks/main.yml
@@ -6,6 +6,7 @@
 
 - name: Run module with backend autodetection
   openssl_privatekey_pipe:
+    size: 2048
 
 - block:
   - name: Running tests with pyOpenSSL backend

--- a/tests/integration/targets/openssl_privatekey_pipe/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_pipe/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Run module with backend autodetection
   openssl_privatekey_pipe:
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - block:
   - name: Running tests with pyOpenSSL backend

--- a/tests/integration/targets/openssl_publickey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_publickey/tasks/impl.yml
@@ -2,7 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate publickey - PEM format"
   openssl_publickey:
@@ -65,7 +65,7 @@
     path: '{{ output_dir }}/privatekey3.pem'
     passphrase: ansible
     cipher: aes256
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate publickey3 - with passphrase protected privatekey"
   openssl_publickey:
@@ -98,7 +98,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     type: ECC
     curve: secp256r1
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate publickey 5 - PEM format"
   openssl_publickey:
@@ -128,7 +128,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: "({{ select_crypto_backend }}) Generate publickey - PEM format (failed passphrase 1)"
   openssl_publickey:

--- a/tests/integration/targets/openssl_publickey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_publickey/tasks/impl.yml
@@ -2,6 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate publickey - PEM format"
   openssl_publickey:
@@ -64,6 +65,7 @@
     path: '{{ output_dir }}/privatekey3.pem'
     passphrase: ansible
     cipher: aes256
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate publickey3 - with passphrase protected privatekey"
   openssl_publickey:
@@ -96,6 +98,7 @@
     path: '{{ output_dir }}/privatekey5.pem'
     type: ECC
     curve: secp256r1
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate publickey 5 - PEM format"
   openssl_publickey:
@@ -125,6 +128,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: "({{ select_crypto_backend }}) Generate publickey - PEM format (failed passphrase 1)"
   openssl_publickey:

--- a/tests/integration/targets/openssl_publickey/tasks/main.yml
+++ b/tests/integration/targets/openssl_publickey/tasks/main.yml
@@ -8,7 +8,7 @@
   - name: Generate privatekey1 - standard
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_autodetect.pem'
-      size: 2048
+      size: '{{ default_rsa_key_size }}'
 
   - name: Run module with backend autodetection
     openssl_publickey:

--- a/tests/integration/targets/openssl_publickey/tasks/main.yml
+++ b/tests/integration/targets/openssl_publickey/tasks/main.yml
@@ -8,6 +8,7 @@
   - name: Generate privatekey1 - standard
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_autodetect.pem'
+      size: 2048
 
   - name: Run module with backend autodetection
     openssl_publickey:

--- a/tests/integration/targets/openssl_signature/tasks/main.yml
+++ b/tests/integration/targets/openssl_signature/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Add RSA tests
   set_fact:
-    key_types: "{{ key_types + [ { 'type': 'RSA' } ] }}"
+    key_types: "{{ key_types + [ { 'type': 'RSA', 'size': 2048 } ] }}"
   when: cryptography_version.stdout is version('1.4', '>=')
 
 - name: Add DSA + ECDSA tests

--- a/tests/integration/targets/openssl_signature/tasks/main.yml
+++ b/tests/integration/targets/openssl_signature/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Add RSA tests
   set_fact:
-    key_types: "{{ key_types + [ { 'type': 'RSA', 'size': 2048 } ] }}"
+    key_types: "{{ key_types + [ { 'type': 'RSA', 'size': default_rsa_key_size } ] }}"
   when: cryptography_version.stdout is version('1.4', '>=')
 
 - name: Add DSA + ECDSA tests

--- a/tests/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/tests/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -1,7 +1,7 @@
 ---
 ## PRIVATE KEY ################################################################################
 - name: ({{ certgen_title }}) Create cert private key (RSA)
-  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/{{ certificate_name }}.key {{ rsa_bits if key_type == 'rsa' else 2048 }}"
+  command: "{{ openssl_binary }} genrsa -out {{ output_dir }}/{{ certificate_name }}.key {{ rsa_bits if key_type == 'rsa' else default_rsa_key_size }}"
   when: "key_type == 'rsa'"
 - name: ({{ certgen_title }}) Create cert private key (ECC 256)
   command: "{{ openssl_binary }} ecparam -name prime256v1 -genkey -out {{ output_dir }}/{{ certificate_name }}.key"

--- a/tests/integration/targets/setup_acme/vars/main.yml
+++ b/tests/integration/targets/setup_acme/vars/main.yml
@@ -1,0 +1,1 @@
+../../setup_openssl/vars/main.yml

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -96,3 +96,7 @@
 - name: Register cryptography version
   command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
   register: cryptography_version
+
+- name: Print default key sizes
+  debug:
+    msg: "Default RSA key size: {{ default_rsa_key_size }} (for certificates: {{ default_rsa_key_size_certifiates }})"

--- a/tests/integration/targets/setup_openssl/vars/main.yml
+++ b/tests/integration/targets/setup_openssl/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-default_rsa_key_size: 2048
+default_rsa_key_size: 1024

--- a/tests/integration/targets/setup_openssl/vars/main.yml
+++ b/tests/integration/targets/setup_openssl/vars/main.yml
@@ -1,0 +1,2 @@
+---
+default_rsa_key_size: 2048

--- a/tests/integration/targets/setup_openssl/vars/main.yml
+++ b/tests/integration/targets/setup_openssl/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 default_rsa_key_size: 1024
+default_rsa_key_size_certifiates: '{{ 2048 if ansible_os_family == "RedHat" and ansible_facts.distribution_major_version | int >= 8 else 1024 }}'

--- a/tests/integration/targets/x509_certificate-acme/tasks/impl.yml
+++ b/tests/integration/targets/x509_certificate-acme/tasks/impl.yml
@@ -2,12 +2,12 @@
 - name: Generate account key
   openssl_privatekey:
     path: '{{ output_dir }}/account.key'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate CSRs
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/assertonly.yml
+++ b/tests/integration/targets/x509_certificate/tasks/assertonly.yml
@@ -2,7 +2,7 @@
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey with password
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate CSR (no extensions)
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/assertonly.yml
+++ b/tests/integration/targets/x509_certificate/tasks/assertonly.yml
@@ -2,6 +2,7 @@
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey with password
   openssl_privatekey:
@@ -9,6 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate CSR (no extensions)
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/assertonly.yml
+++ b/tests/integration/targets/x509_certificate/tasks/assertonly.yml
@@ -2,7 +2,7 @@
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate privatekey with password
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Assertonly, {{select_crypto_backend}}) - Generate CSR (no extensions)
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/expired.yml
+++ b/tests/integration/targets/x509_certificate/tasks/expired.yml
@@ -2,7 +2,7 @@
 - name: (Expired, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/has_expired_privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Expired, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/expired.yml
+++ b/tests/integration/targets/x509_certificate/tasks/expired.yml
@@ -2,7 +2,7 @@
 - name: (Expired, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/has_expired_privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Expired, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/expired.yml
+++ b/tests/integration/targets/x509_certificate/tasks/expired.yml
@@ -2,6 +2,7 @@
 - name: (Expired, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/has_expired_privatekey.pem'
+    size: 2048
 
 - name: (Expired, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/ownca.yml
+++ b/tests/integration/targets/x509_certificate/tasks/ownca.yml
@@ -2,7 +2,7 @@
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/ca_privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey with passphrase
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/ownca.yml
+++ b/tests/integration/targets/x509_certificate/tasks/ownca.yml
@@ -2,6 +2,7 @@
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/ca_privatekey.pem'
+    size: 2048
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey with passphrase
   openssl_privatekey:
@@ -9,6 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/ownca.yml
+++ b/tests/integration/targets/x509_certificate/tasks/ownca.yml
@@ -2,7 +2,7 @@
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/ca_privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey with passphrase
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/removal.yml
+++ b/tests/integration/targets/x509_certificate/tasks/removal.yml
@@ -2,7 +2,7 @@
 - name: (Removal, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/removal_privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Removal, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/removal.yml
+++ b/tests/integration/targets/x509_certificate/tasks/removal.yml
@@ -2,6 +2,7 @@
 - name: (Removal, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/removal_privatekey.pem'
+    size: 2048
 
 - name: (Removal, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/removal.yml
+++ b/tests/integration/targets/x509_certificate/tasks/removal.yml
@@ -2,7 +2,7 @@
 - name: (Removal, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/removal_privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Removal, {{select_crypto_backend}}) Generate CSR
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
+++ b/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
@@ -2,6 +2,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey with password
   openssl_privatekey:
@@ -9,6 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate without CSR
   x509_certificate:
@@ -126,6 +128,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey2
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey2.pem'
+    size: 2048
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR2
   openssl_csr:
@@ -184,6 +187,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Create private key 3
   openssl_privatekey:
     path: "{{ output_dir }}/privatekey3.pem"
+    size: 2048
 
 - name: (Selfsigned, {{select_crypto_backend}}) Create CSR 3
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
+++ b/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
@@ -2,7 +2,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey with password
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate without CSR
   x509_certificate:
@@ -128,7 +128,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey2
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey2.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR2
   openssl_csr:
@@ -187,7 +187,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Create private key 3
   openssl_privatekey:
     path: "{{ output_dir }}/privatekey3.pem"
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Create CSR 3
   openssl_csr:

--- a/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
+++ b/tests/integration/targets/x509_certificate/tasks/selfsigned.yml
@@ -2,7 +2,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey with password
   openssl_privatekey:
@@ -10,7 +10,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate without CSR
   x509_certificate:
@@ -128,7 +128,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Generate privatekey2
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey2.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR2
   openssl_csr:
@@ -187,7 +187,7 @@
 - name: (Selfsigned, {{select_crypto_backend}}) Create private key 3
   openssl_privatekey:
     path: "{{ output_dir }}/privatekey3.pem"
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: (Selfsigned, {{select_crypto_backend}}) Create CSR 3
   openssl_csr:

--- a/tests/integration/targets/x509_certificate_info/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
+    size: 2048
 
 - name: Generate privatekey with password
   openssl_privatekey:
@@ -14,6 +15,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
+    size: 2048
 
 - name: Generate CSR 1
   openssl_csr:

--- a/tests/integration/targets/x509_certificate_info/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate privatekey with password
   openssl_privatekey:
@@ -15,7 +15,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 
 - name: Generate CSR 1
   openssl_csr:

--- a/tests/integration/targets/x509_certificate_info/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: Generate privatekey with password
   openssl_privatekey:
@@ -15,7 +15,7 @@
     passphrase: hunter2
     cipher: auto
     select_crypto_backend: cryptography
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 
 - name: Generate CSR 1
   openssl_csr:

--- a/tests/integration/targets/x509_certificate_pipe/tasks/impl.yml
+++ b/tests/integration/targets/x509_certificate_pipe/tasks/impl.yml
@@ -2,7 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/{{ item }}.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
   loop:
     - privatekey
     - privatekey2

--- a/tests/integration/targets/x509_certificate_pipe/tasks/impl.yml
+++ b/tests/integration/targets/x509_certificate_pipe/tasks/impl.yml
@@ -2,7 +2,7 @@
 - name: "({{ select_crypto_backend }}) Generate privatekey"
   openssl_privatekey:
     path: '{{ output_dir }}/{{ item }}.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
   loop:
     - privatekey
     - privatekey2

--- a/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
+    size: 2048
 - name: Run module with backend autodetection
   x509_certificate_pipe:
     provider: selfsigned

--- a/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
-    size: 2048
+    size: '{{ default_rsa_key_size }}'
 - name: Run module with backend autodetection
   x509_certificate_pipe:
     provider: selfsigned

--- a/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate_pipe/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Prepare private key for backend autodetection test
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_backend_selection.pem'
-    size: '{{ default_rsa_key_size }}'
+    size: '{{ default_rsa_key_size_certifiates }}'
 - name: Run module with backend autodetection
   x509_certificate_pipe:
     provider: selfsigned


### PR DESCRIPTION
##### SUMMARY
Use smaller key sizes.

(I used 2048 instead of the default 4096 in many places. This can even further be sped up by reducing to 1024.)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
