### PR TITLE
Fix Azure Pipelines

### DIFF
--- a/.azure-pipelines/README.md
+++ b/.azure-pipelines/README.md
@@ -1,0 +1,3 @@
+## Azure Pipelines Configuration
+
+Please see the [Documentation](https://github.com/ansible/community/wiki/Testing:-Azure-Pipelines) for more information.

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,52 +36,48 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.6.0
+      image: quay.io/ansible/azure-pipelines-test-container:1.7.0
 
 pool: Standard
 
 stages:
-  - stage: Sanity_devel
-    displayName: Sanity devel
+### Sanity & units
+  - stage: Ansible_devel
+    displayName: Sanity & Units devel
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
           targets:
-            - test: 1
-            - test: extra
-  - stage: Units_devel
-    displayName: Units devel
+            - name: Sanity
+              test: 'devel/sanity/1'
+            - name: Sanity Extra # Only on devel
+              test: 'devel/sanity/extra'
+            - name: Units
+              test: 'devel/units/1'
+  - stage: Ansible_2_10
+    displayName: Sanity & Units 2.10
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
           targets:
-            - test: ''
-  - stage: Remote_devel
-    displayName: Remote devel
+            - name: Sanity
+              test: '2.10/sanity/1'
+            - name: Units
+              test: '2.10/units/1'
+  - stage: Ansible_2_9
+    displayName: Sanity & Units 2.9
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}/1
           targets:
-            - name: OS X 10.11
-              test: osx/10.11
-            - name: macOS 10.15
-              test: macos/10.15
-            - name: RHEL 7.8
-              test: rhel/7.8
-            - name: RHEL 8.2
-              test: rhel/8.2
-            - name: FreeBSD 11.1
-              test: freebsd/11.1
-            - name: FreeBSD 12.1
-              test: freebsd/12.1
+            - name: Sanity
+              test: '2.9/sanity/1'
+            - name: Units
+              test: '2.9/units/1'
+### Docker
   - stage: Docker_devel
     displayName: Docker devel
     dependsOn: []
@@ -110,6 +106,106 @@ stages:
               test: ubuntu1604
             - name: Ubuntu 18.04
               test: ubuntu1804
+  - stage: Docker_2_10
+    displayName: Docker 2.10
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.10/linux/{0}/1
+          targets:
+            - name: CentOS 6
+              test: centos6
+            - name: CentOS 7
+              test: centos7
+            - name: CentOS 8
+              test: centos8
+            - name: Fedora 30
+              test: fedora30
+            - name: Fedora 31
+              test: fedora31
+            - name: Fedora 32
+              test: fedora32
+            - name: openSUSE 15 py2
+              test: opensuse15py2
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 16.04
+              test: ubuntu1604
+            - name: Ubuntu 18.04
+              test: ubuntu1804
+  - stage: Docker_2_9
+    displayName: Docker 2.9
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.9/linux/{0}/1
+          targets:
+            - name: CentOS 6
+              test: centos6
+            - name: CentOS 7
+              test: centos7
+            - name: CentOS 8
+              test: centos8
+            - name: Fedora 30
+              test: fedora30
+            - name: Fedora 31
+              test: fedora31
+              # fedora32 doesn't exist in 2.9
+#            - name: Fedora 32
+#              test: fedora32
+            - name: openSUSE 15 py2
+              test: opensuse15py2
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 16.04
+              test: ubuntu1604
+            - name: Ubuntu 18.04
+              test: ubuntu1804              
+
+### Remote
+  - stage: Remote_devel
+    displayName: Remote devel
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}/1
+          targets:
+            - name: OS X 10.11
+              test: osx/10.11
+            - name: macOS 10.15
+              test: macos/10.15
+            - name: RHEL 7.8
+              test: rhel/7.8
+            - name: RHEL 8.2
+              test: rhel/8.2
+            - name: FreeBSD 11.1
+              test: freebsd/11.1
+            - name: FreeBSD 12.1
+              test: freebsd/12.1
+  - stage: Remote_2_10
+    displayName: Remote 2.10
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.10/{0}/1
+          targets:
+            - name: RHEL 7.8
+              test: rhel/7.8
+  - stage: Remote_2_9
+    displayName: Remote 2.9
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.9/{0}/1
+          targets:
+            - name: 'RHEL 7.8'
+              test: 'rhel/7.8'
+### cloud
   - stage: Cloud_devel
     displayName: Cloud devel
     dependsOn: []
@@ -126,121 +222,41 @@ stages:
             - test: 3.7
             - test: 3.8
             - test: 3.9
-  - stage: Sanity_2_10
-    displayName: Sanity 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test 1 {0}
-          testFormat: 2.10/sanity/1/{0}
-          targets:
-            - test: ''
-  - stage: Units_2_10
-    displayName: Units 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.10/units/{0}/1
-          targets:
-            - test: ''
-  - stage: Remote_2_10
-    displayName: Remote 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: RHEL 7.8 {0}
-          testFormat: 2.10/rhel/7.8/{0}/1
-          targets:
-            - test: ''
-  - stage: Docker_2_10
-    displayName: Docker 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Ubuntu 18.04 {0}
-          testFormat: 2.10/linux/ubuntu1804/{0}/1
-          targets:
-            - test: ''
   - stage: Cloud_2_10
     displayName: Cloud 2.10
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: Python 3.6 {0}
-          testFormat: 2.10/cloud/3.6/{0}/1
-          targets:
-            - test: ''
-  - stage: Sanity_2_9
-    displayName: Sanity 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test 1 {0}
-          testFormat: 2.9/sanity/1/{0}
-          targets:
-            - test: ''
-  - stage: Units_2_9
-    displayName: Units 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
           nameFormat: Python {0}
-          testFormat: 2.9/units/{0}/1
+          testFormat: 2.10/cloud/{0}/1
           targets:
-            - test: ''
-  - stage: Remote_2_9
-    displayName: Remote 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: RHEL 7.8 {0}
-          testFormat: 2.9/rhel/7.8/{0}/1
-          targets:
-            - test: ''
-  - stage: Docker_2_9
-    displayName: Docker 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Ubuntu 18.04 {0}
-          testFormat: 2.9/linux/ubuntu1804/{0}/1
-          targets:
-            - test: ''
+            - test: 3.6
   - stage: Cloud_2_9
     displayName: Cloud 2.9
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          nameFormat: Python 3.5 {0}
-          testFormat: 2.9/cloud/3.5/{0}/1
+          nameFormat: Python {0}
+          testFormat: 2.9/cloud/{0}/1
           targets:
-            - test: ''
+            - test: 3.5
+
+  ## Finally
+
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
-      - Units_devel
+      - Ansible_devel
+      - Ansible_2_10
+      - Ansible_2_9
       - Remote_devel
       - Docker_devel
       - Cloud_devel
-      - Sanity_2_10
-      - Units_2_10
       - Remote_2_10
       - Docker_2_10
       - Cloud_2_10
-      - Sanity_2_9
-      - Units_2_9
       - Remote_2_9
       - Docker_2_9
       - Cloud_2_9

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -14,8 +14,9 @@ function join {
     echo "$*";
 }
 
-test="$(join / "${args[@]:1}")"
+export PATH=$PATH:$HOME/.local/bin # HACK remove once azure-pipelines-test-container has been fixed
 
+test="$(join / "${args[@]:1}")"
 docker images ansible/ansible
 docker images quay.io/ansible/*
 docker ps
@@ -69,12 +70,18 @@ if [ "${script}" == "osx" ] && [ "${ansible_version}" == "2.9" ]; then
 fi
 # END: HACK
 
-export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
-SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
-TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
-mkdir -p "${TEST_DIR}"
-cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
-cd "${TEST_DIR}"
+
+if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
+    export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
+    SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
+    TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
+    mkdir -p "${TEST_DIR}"
+    cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
+    cd "${TEST_DIR}"
+else
+    # AZP
+    export ANSIBLE_COLLECTIONS_PATHS="$PWD/../../../"
+fi
 
 # START: HACK install integration test dependencies
 if [ "${script}" != "units" ] && [ "${script}" != "sanity" ] && [ "${ansible_version}" != "2.9" ]; then

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -14,7 +14,11 @@ function join {
     echo "$*";
 }
 
-export PATH=$PATH:$HOME/.local/bin # HACK remove once azure-pipelines-test-container has been fixed
+# HACK remove once azure-pipelines-test-container has been fixed
+export PATH=$PATH:$HOME/.local/bin
+
+# Ensure we can write other collections to this dir
+sudo chown "$(whoami)" "${PWD}/../../"
 
 test="$(join / "${args[@]:1}")"
 docker images ansible/ansible


### PR DESCRIPTION
`community.crypto` is the first Community Collection we are moving to Azure Pipelines (AZP).

* Simplify AZP stages
* Remove hacks, use azure-pipelines-test-container:1.7.0
* Expand test matrix


For a while, we will have AZP and Shippable running in parallel.

https://dev.azure.com/ansible/community.crypto/_build?definitionId=21&_a=summary shows the summary of AZP jobs against this repo.