### PR TITLE
Documentation: fix formatting

### DIFF
--- a/plugins/modules/acme_account_info.py
+++ b/plugins/modules/acme_account_info.py
@@ -56,9 +56,11 @@ EXAMPLES = '''
     that:
       - account_data.exists
 - name: Print account URI
-  ansible.builtin.debug: var=account_data.account_uri
+  ansible.builtin.debug:
+    var: account_data.account_uri
 - name: Print account contacts
-  ansible.builtin.debug: var=account_data.account.contact
+  ansible.builtin.debug:
+    var: account_data.account.contact
 
 - name: Check whether the account exists and is accessible with the given account key
   acme_account_info:
@@ -70,7 +72,8 @@ EXAMPLES = '''
     that:
       - account_data.exists
 - name: Print account contacts
-  ansible.builtin.debug: var=account_data.account.contact
+  ansible.builtin.debug:
+    var: account_data.account.contact
 '''
 
 RETURN = '''

--- a/plugins/modules/acme_account_info.py
+++ b/plugins/modules/acme_account_info.py
@@ -23,6 +23,7 @@ notes:
       accounts."
    - "This module was called C(acme_account_facts) before Ansible 2.8. The usage
       did not change."
+   - Supports C(check_mode).
 options:
   retrieve_orders:
     description:
@@ -55,9 +56,9 @@ EXAMPLES = '''
     that:
       - account_data.exists
 - name: Print account URI
-  debug: var=account_data.account_uri
+  ansible.builtin.debug: var=account_data.account_uri
 - name: Print account contacts
-  debug: var=account_data.account.contact
+  ansible.builtin.debug: var=account_data.account.contact
 
 - name: Check whether the account exists and is accessible with the given account key
   acme_account_info:
@@ -69,7 +70,7 @@ EXAMPLES = '''
     that:
       - account_data.exists
 - name: Print account contacts
-  debug: var=account_data.account.contact
+  ansible.builtin.debug: var=account_data.account.contact
 '''
 
 RETURN = '''

--- a/plugins/modules/acme_certificate_revoke.py
+++ b/plugins/modules/acme_certificate_revoke.py
@@ -25,6 +25,7 @@ notes:
       was different than the one specified here. Also, depending on the
       server, it can happen that some other error is returned if the
       certificate has already been revoked."
+   - Does not support C(check_mode).
 seealso:
   - name: The Let's Encrypt documentation
     description: Documentation for the Let's Encrypt Certification Authority.
@@ -98,7 +99,7 @@ options:
          C(2) (cACompromise), C(3) (affiliationChanged), C(4) (superseded),
          C(5) (cessationOfOperation), C(6) (certificateHold),
          C(8) (removeFromCRL), C(9) (privilegeWithdrawn),
-         C(10) (aACompromise)"
+         C(10) (aACompromise)."
     type: int
 '''
 
@@ -114,8 +115,7 @@ EXAMPLES = '''
     certificate: /etc/httpd/ssl/sample.com.crt
 '''
 
-RETURN = '''
-'''
+RETURN = '''#'''
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/acme_challenge_cert_helper.py
+++ b/plugins/modules/acme_challenge_cert_helper.py
@@ -52,6 +52,8 @@ options:
       - "Content of the private key to use for this challenge certificate."
       - "Mutually exclusive with C(private_key_src)."
     type: str
+notes:
+  - Does not support C(check_mode).
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Documentation: fix formatting

Testing my script, found several places to be improved.
Also noticed that `ecs_*` modules documentation should be rewritten significantly.

I also suggest using
```
ansible.builtin.debug:
  var: account_data.account.contact
```
instead of
```
ansible.builtin.debug: var=account_data.account.contact
```
as recommended by the documentation

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
modules