### PR TITLE
AZP: Install ansible:devel during report-coverage

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -162,7 +162,7 @@ stages:
             - name: Ubuntu 16.04
               test: ubuntu1604
             - name: Ubuntu 18.04
-              test: ubuntu1804              
+              test: ubuntu1804
 
 ### Remote
   - stage: Remote_devel

--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -4,5 +4,6 @@
 set -o pipefail -eu
 
 PATH="${PWD}/bin:${PATH}"
+pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
 ansible-test coverage xml --stub --venv --venv-system-site-packages --color -v


### PR DESCRIPTION
##### SUMMARY

Currently `ansible-test` isn't installed so we can't generate coverage

##### ISSUE TYPE
- Bugfix Pull Request
