### PR TITLE
Relicense plugins/module_utils/acme.py under GPLv3+

### DIFF
--- a/changelogs/fragments/acme-module-utils-relicense.yml
+++ b/changelogs/fragments/acme-module-utils-relicense.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "The ACME module_utils has been relicensed back from the Simplified BSD License (https://opensource.org/licenses/BSD-2-Clause) to the GPLv3+ (same license used by most other code in this collection). This undoes a licensing change when the original GPLv3+ licensed code was moved to module_utils in https://github.com/ansible/ansible/pull/40697 (https://github.com/ansible-collections/community.crypto/pull/165)."

--- a/plugins/module_utils/acme.py
+++ b/plugins/module_utils/acme.py
@@ -1,14 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# This code is part of Ansible, but is an independent component.
-# This particular file snippet, and this file snippet only, is BSD licensed.
-# Modules you write using this snippet, which is embedded dynamically by Ansible
-# still belong to the author of the module, and may assign their own license
-# to the complete work.
-#
-# Copyright (c), Michael Gruener <michael.gruener@chaosmoon.net>, 2016
-#
-# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+# (c) 2016 Michael Gruener <michael.gruener@chaosmoon.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type


### PR DESCRIPTION
##### SUMMARY
The code was originally licensed under GPLv3+ when being part of the letsencrypt module. It was relicensed under BSD 2-clause when moving to Ansible's module_utils (https://github.com/ansible/ansible/pull/40697).

The code was only touched by two persons (https://github.com/ansible/ansible/commits/pre-ansible-base/lib/ansible/module_utils/acme.py, https://github.com/ansible-collections/community.crypto/commits/main/plugins/module_utils/acme.py), @endorama (for https://github.com/ansible/ansible/commit/0d905a0496f4554a9de57cbd3ee90e30d6249b34) and me.

The main motivation for this re-license is to be able to do more refactoring of the ACME code, similar to the general crypto code, without having to split the result into two sets of files (one set GPL licensed, one set BSD licensed). Keeping everything BSD licensed would require to re-license some more code from the modules (which should go to module_utils) to BSD, which is quite an effort. Simply relicensing the module_utils code back to GPL is a lot easier since only two persons were involved with the code. Also this makes it easier to swap code between the ACME module utils and general crypto module utils, since these are also GPLv3+ licensed.

@endorama please review this PR and approve it if you agree to relicense your contribution in https://github.com/ansible/ansible/commit/0d905a0496f4554a9de57cbd3ee90e30d6249b34 to the acme.py module_utils under GPLv3+.

CC @resmo @gundalow

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/acme.py
