### PR TITLE
Added sever name option to use for SNI

### DIFF
--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -306,7 +306,7 @@ def main():
             if not server_name:
                 server_name = host
                          
-            cert = ctx.wrap_socket(sock, server_hostname=server_name).getpeercert(True)
+            cert = ctx.wrap_socket(sock, server_hostname=server_name or host).getpeercert(True)
             cert = DER_cert_to_PEM_cert(cert)
         except Exception as e:
             if proxy_host:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -37,7 +37,7 @@ options:
       required: true
     server_name:
       description:
-       - Server name used for SNI when hostname is an ip or is different from server name
+       - Server name used for SNI (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication)) when hostname is an IP or is different from server name.
       type: str
       version_added: 1.4.0
     proxy_host:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -39,6 +39,7 @@ options:
       description:
        - Server name used for SNI when hostname is an ip or is different from server name
       type: str
+      version_added: 1.4.0
     proxy_host:
       description:
         - Proxy host used when get a certificate.

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -37,7 +37,8 @@ options:
       required: true
     server_name:
       description:
-       - Server name used for SNI (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication)) when hostname is an IP or is different from server name.
+       - Server name used for SNI (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication)) when hostname
+         is an IP or is different from server name.
       type: str
       version_added: 1.4.0
     proxy_host:
@@ -306,7 +307,7 @@ def main():
 
             if not server_name:
                 server_name = host
-                         
+
             cert = ctx.wrap_socket(sock, server_hostname=server_name or host).getpeercert(True)
             cert = DER_cert_to_PEM_cert(cert)
         except Exception as e:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -305,9 +305,6 @@ def main():
                 ctx.check_hostname = False
                 ctx.verify_mode = CERT_NONE
 
-            if not server_name:
-                server_name = host
-
             cert = ctx.wrap_socket(sock, server_hostname=server_name or host).getpeercert(True)
             cert = DER_cert_to_PEM_cert(cert)
         except Exception as e:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -18,7 +18,7 @@ description:
       library. By default, it tries to detect which one is available. This can be
       overridden with the I(select_crypto_backend) option. Please note that the PyOpenSSL
       backend was deprecated in Ansible 2.9 and will be removed in community.crypto 2.0.0."
-    - Support SNI only with python >= 2.7 (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication))
+    - Support SNI (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication)) only with python >= 2.7.
 options:
     host:
       description:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -18,7 +18,7 @@ description:
       library. By default, it tries to detect which one is available. This can be
       overridden with the I(select_crypto_backend) option. Please note that the PyOpenSSL
       backend was deprecated in Ansible 2.9 and will be removed in community.crypto 2.0.0."
-    - Support SNI only with python >= 2.7
+    - Support SNI only with python >= 2.7 (L(Server Name Indication,https://en.wikipedia.org/wiki/Server_Name_Indication))
 options:
     host:
       description:

--- a/tests/integration/targets/get_certificate/tests/validate.yml
+++ b/tests/integration/targets/get_certificate/tests/validate.yml
@@ -1,4 +1,38 @@
 ---
+- name: Get servers certificate for SNI test part 1
+  get_certificate:
+    host: "{{ httpbin_host }}"
+    port: 443
+    server_name: "{{ sni_host }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      # This module should never change anything
+      - result is not changed
+      - result is not failed
+      # We got the correct ST from the cert
+      - "'{{ sni_host }}' == result.subject.CN"
+
+- name: Get servers certificate for SNI test part 2
+  get_certificate:
+    host: "{{ sni_host }}"
+    port: 443
+    server_name: "{{ httpbin_host }}"
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      # This module should never change anything
+      - result is not changed
+      - result is not failed
+      # We got the correct ST from the cert
+      - "'{{ httpbin_host }}' == result.subject.CN"
+
 - name: Get servers certificate
   get_certificate:
     host: "{{ httpbin_host }}"


### PR DESCRIPTION
##### SUMMARY
when connecting to a server with SNI enabled and serving multiple certificates over the same hostname or ip, current implementation returns the wrong certificate, since server name is set to the hostname. This PR provides an additional option server_name that can be used to set the server name

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
get_certificate.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
