### PR TITLE
acme_certificate: Improve challenge docs

### DIFF
--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -311,7 +311,7 @@ EXAMPLES = r'''
 # - copy:
 #     dest: /var/www/{{ item.key }}/{{ item.value['http-01']['resource'] }}
 #     content: "{{ item.value['http-01']['resource_value'] }}"
-#   loop: "{{ sample_com_challenge.challenge_data | dictsort }}"
+#   loop: "{{ sample_com_challenge.challenge_data | dict2items }}"
 #   when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
@@ -363,7 +363,7 @@ EXAMPLES = r'''
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
-#   loop: "{{ sample_com_challenge.challenge_data_dns | dictsort }}"
+#   loop: "{{ sample_com_challenge.challenge_data_dns | dict2items }}"
 #   when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate


### PR DESCRIPTION
##### SUMMARY

Some of the challenge docs are not fully functional because the playbook fails with:
```
The task includes an option with an undefined variable. The error was: 'list object' has no attribute 'value'
```

or

```
The task includes an option with an undefined variable. The error was: 'list object' has no attribute 'key'
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
acme_certificate

##### ADDITIONAL INFORMATION

`dict2items` filter should be used when accessing `item.key` and `item.value` with `loop` keyword as documented [here](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#with-dict) (option 1)