### PR TITLE
acme_account_info: deprecate returning orders when retrieve_orders=url_list

### DIFF
--- a/changelogs/fragments/178-acme_account_info-orders-urls.yml
+++ b/changelogs/fragments/178-acme_account_info-orders-urls.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- "acme_account_info - when ``retrieve_orders`` is not ``ignore`` and the ACME server allows to query orders, the new return value ``order_uris`` is always populated with a list of URIs (https://github.com/ansible-collections/community.crypto/pull/178)."
+deprecated_features:
+- "acme_account_info - when ``retrieve_orders=url_list``, ``orders`` will no longer be returned in community.crypto 2.0.0. Use ``order_uris`` instead (https://github.com/ansible-collections/community.crypto/pull/178)."

--- a/tests/integration/targets/acme_certificate/tests/validate.yml
+++ b/tests/integration/targets/acme_certificate/tests/validate.yml
@@ -121,6 +121,9 @@
       - "'account' in account_orders_urls"
       - "'orders' in account_orders_urls"
       - "account_orders_urls.orders[0] is string"
+      - "'order_uris' in account_orders_urls"
+      - "account_orders_urls.order_uris[0] is string"
+      - "account_orders_urls.order_uris == account_orders_urls.orders"
 
 - name: Validate that orders were retrieved as list of URLs (2/2)
   assert:
@@ -128,6 +131,9 @@
       - "'account' in account_orders_urls2"
       - "'orders' in account_orders_urls2"
       - "account_orders_urls2.orders[0] is string"
+      - "'order_uris' in account_orders_urls2"
+      - "account_orders_urls2.order_uris[0] is string"
+      - "account_orders_urls2.order_uris == account_orders_urls2.orders"
 
 - name: Validate that orders were retrieved as list of objects (1/2)
   assert:
@@ -135,6 +141,8 @@
       - "'account' in account_orders_full"
       - "'orders' in account_orders_full"
       - "account_orders_full.orders[0].status is string"
+      - "'order_uris' in account_orders_full"
+      - "account_orders_full.order_uris[0] is string"
 
 - name: Validate that orders were retrieved as list of objects (2/2)
   assert:
@@ -142,3 +150,5 @@
       - "'account' in account_orders_full2"
       - "'orders' in account_orders_full2"
       - "account_orders_full2.orders[0].status is string"
+      - "'order_uris' in account_orders_full2"
+      - "account_orders_full2.order_uris[0] is string"


### PR DESCRIPTION
##### SUMMARY
This allows to get rid of the [ignore.txt entries](https://github.com/ansible-collections/community.crypto/blob/main/tests/sanity/ignore-2.11.txt#L6) for the return value syntax error since then orders will always have the same type when returned.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
acme_account_info
