### PR TITLE
exclude test folder from release

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,6 +25,8 @@ documentation: https://docs.ansible.com/ansible/latest/collections/community/cry
 homepage: https://github.com/ansible-collections/community.crypto
 issues: https://github.com/ansible-collections/community.crypto/issues
 build_ignore:
+  - .azure-pipelines
   - 'community-crypto-*.tar.gz'
   - .gitignore
   - changelogs/.plugin-cache.yaml
+  - tests


### PR DESCRIPTION
##### SUMMARY
Don't include tests and pipeline definition in galaxy release, since these only increase package size and do not bring any benefit.

##### ISSUE TYPE
- Bugfix Pull Request ?
- Feature Pull Request ?

##### ADDITIONAL INFORMATION
currently following files are included in the release:
```
$ ls -la
total 196
drwxr-xr-x 7 root root   4096 Feb  5 18:50 .
drwxr-xr-x 3 root root   4096 Feb  5 17:00 ..
drwxr-xr-x 4 root root   4096 Feb  5 17:00 .azure-pipelines
-rw-r--r-- 1 root root  15691 Feb  5 17:00 CHANGELOG.rst
-rw-r--r-- 1 root root  35149 Feb  5 17:00 COPYING
-rw-r--r-- 1 root root 102410 Feb  5 17:00 FILES.json
-rw-r--r-- 1 root root    997 Feb  5 17:00 MANIFEST.json
-rw-r--r-- 1 root root   5459 Feb  5 17:00 README.md
drwxr-xr-x 3 root root   4096 Feb  5 18:51 changelogs
drwxr-xr-x 2 root root   4096 Feb  5 17:00 meta
drwxr-xr-x 7 root root   4096 Feb  5 17:00 plugins
drwxr-xr-x 6 root root   4096 Feb  5 17:00 tests
```

Should we also exclude the `changelogs` folder?