### PR TITLE
Adding support for passphrase with openssh_keypair

### DIFF
--- a/changelogs/fragments/196-openssh_keypair-passphrase-support.yml
+++ b/changelogs/fragments/196-openssh_keypair-passphrase-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - openssh_keypair - added ``passphrase`` parameter to generate protected ssh keypairs (https://github.com/ansible-collections/community.crypto/pull/196).

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -185,7 +185,6 @@ class Keypair(object):
         self.fingerprint = {}
         self.public_key = {}
         self.regenerate = module.params['regenerate']
-
         if self.regenerate == 'always':
             self.force = True
 

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -307,7 +307,7 @@ class Keypair(object):
         if self._check_pass_protected_or_broken_key(module):
             if self.regenerate in ('full_idempotence', 'always'):
                 return False
-            module.fail_json(msg='Unable to read the key. The key is protected with an unknown passphrase or broken.'
+            module.fail_json(msg='Unable to read the key. The key is protected with a passphrase or broken.'
                                  ' Will not proceed. To force regeneration, call the module with `generate`'
                                  ' set to `full_idempotence` or `always`, or with `force=yes`.')
 
@@ -325,7 +325,7 @@ class Keypair(object):
 
             if self.regenerate in ('full_idempotence', 'always'):
                 return False
-            module.fail_json(msg='Unable to read the key. The key is protected with an unknown passphrase or broken.'
+            module.fail_json(msg='Unable to read the key. The key is protected with a passphrase or broken.'
                                  ' Will not proceed. To force regeneration, call the module with `generate`'
                                  ' set to `full_idempotence` or `always`, or with `force=yes`.')
 


### PR DESCRIPTION
##### SUMMARY
Allowing users to generate a keypair with a supplied passphrase. (And consequently manage private keys with passphrases)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_keypair.py

##### ADDITIONAL INFORMATION
Most of the work for this was already in the module with the updates being:
- New parameter for passphrase
- Updates to any invocations of ssh-keygen to use either the -N or -P flags when passphrase is required.
- An additional helper function to determine when the user has supplied a passphrase if it was previously null (Providing a passphrase when the key is unprotected does not produce an error so this was necessary)
- Use of the new helper function to maintain expected behavior when using various idempotency options.
- Updates to documentation for new parameter however the regenerate parameter description already defined the behavior for how the module handles idempotency with passphrases. (Even though it was not implemented)