### PR TITLE
Improve openssl_privatekey docs: mention default mode in more places

### DIFF
--- a/plugins/modules/openssl_privatekey.py
+++ b/plugins/modules/openssl_privatekey.py
@@ -14,6 +14,7 @@ module: openssl_privatekey
 short_description: Generate OpenSSL private keys
 description:
     - This module allows one to (re)generate OpenSSL private keys.
+    - The default mode for the private key file will be C(0600) if I(mode) is not explicitly set.
 author:
     - Yanis Guenane (@Spredzy)
     - Felix Fontein (@felixfontein)


### PR DESCRIPTION
##### SUMMARY
I originally wanted to change the `default` of `mode` to `0600`, but that's more complicated the way `add_file_common_args=True` works (the argspec entries are only added in `AnsibleModule` itself, if they haven't been present, so I would have had to replace the complete `mode` entry - which I think is more dangerous than just changing its `default` value). So I've added one more remark about the default mode being `0600` to the main description (currently it's only mentioned in `path`'s description).

CC @bmillemathias 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openssl_privatekey
