### PR TITLE
acme: improve error handling in backend's parse_key()

### DIFF
--- a/plugins/module_utils/acme/_compatibility.py
+++ b/plugins/module_utils/acme/_compatibility.py
@@ -159,7 +159,7 @@ class ACMELegacyAccount(object):
         try:
             return None, self.client.parse_key(key_file=key_file, key_content=key_content)
         except KeyParsingError as e:
-            return e.msg, None
+            return e.msg, {}
 
     def sign_request(self, protected, payload, key_data, encode_payload=True):
         return self.client.sign_request(protected, payload, key_data, encode_payload=encode_payload)

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -157,10 +157,7 @@ class ACMEClient(object):
         '''
         if key_file is None and key_content is None:
             raise AssertionError('One of key_file and key_content must be specified!')
-        error, key_data = self.backend.parse_key(key_file, key_content, passphrase=passphrase)
-        if error:
-            raise KeyParsingError(error)
-        return key_data
+        return self.backend.parse_key(key_file, key_content, passphrase=passphrase)
 
     def sign_request(self, protected, payload, key_data, encode_payload=True):
         '''

--- a/plugins/module_utils/acme/backends.py
+++ b/plugins/module_utils/acme/backends.py
@@ -21,8 +21,8 @@ class CryptoBackend(object):
     @abc.abstractmethod
     def parse_key(self, key_file=None, key_content=None, passphrase=None):
         '''
-        Parses an RSA or Elliptic Curve key file in PEM format and returns a pair
-        (error, key_data).
+        Parses an RSA or Elliptic Curve key file in PEM format and returns key_data.
+        Raises KeyParsingError in case of errors.
         '''
 
     @abc.abstractmethod

--- a/tests/unit/plugins/module_utils/acme/test_backend_cryptography.py
+++ b/tests/unit/plugins/module_utils/acme/test_backend_cryptography.py
@@ -30,12 +30,10 @@ def test_eckeyparse_cryptography(pem, result, dummy, tmpdir):
     fn.write(pem)
     module = MagicMock()
     backend = CryptographyBackend(module)
-    error, key = backend.parse_key(key_file=str(fn))
-    assert error is None
+    key = backend.parse_key(key_file=str(fn))
     key.pop('key_obj')
     assert key == result
-    error, key = backend.parse_key(key_content=pem)
-    assert error is None
+    key = backend.parse_key(key_content=pem)
     key.pop('key_obj')
     assert key == result
 

--- a/tests/unit/plugins/module_utils/acme/test_backend_openssl_cli.py
+++ b/tests/unit/plugins/module_utils/acme/test_backend_openssl_cli.py
@@ -37,8 +37,7 @@ def test_eckeyparse_openssl(pem, result, openssl_output, tmpdir):
     module = MagicMock()
     module.run_command = MagicMock(return_value=(0, openssl_output, 0))
     backend = OpenSSLCLIBackend(module, openssl_binary='openssl')
-    error, key = backend.parse_key(key_file=str(fn))
-    assert error is None
+    key = backend.parse_key(key_file=str(fn))
     key.pop('key_file')
     assert key == result
 


### PR DESCRIPTION
##### SUMMARY
Something I wanted to clean up for some time, but apparently forgot during the big ACME refactoring.

Instead of returning `(error, result)` pairs, use `KeyParsingError` exceptions.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/acme/
