### PR TITLE
Fix invalid arguments to exception

### DIFF
--- a/plugins/module_utils/acme/challenges.py
+++ b/plugins/module_utils/acme/challenges.py
@@ -236,8 +236,7 @@ class Authorization(object):
                 error=error_msg,
                 details='; '.join(error_details),
             ),
-            identifier=self.combined_identifier,
-            authorization=self.data,
+            content_json=self.data,
         )
 
     def find_challenge(self, challenge_type):


### PR DESCRIPTION
##### SUMMARY
Fixes the fact there are invalid arguments to the ACME Exception causing a hiding of any invalid errors from ACME

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ACME Certificate

##### ADDITIONAL INFORMATION
Create an invalid record identifier for a let's encrypt certificate and try and create a certificate.

Before:
```
"/tmp/ansible_acme_certificate_payload_QGwNTg/ansible_acme_certificate_payload.zip/ansible_collections/community/crypto/plugins/module_utils/acme/challenges.py", line 240, in raise_error
TypeError: __init__() got an unexpected keyword argument 'identifier'
```

After:
```
msg": "ACME request failed for None with HTTP status None. The JSON error result: {u'status': u'invalid', u'challenges': [{u'status': u'invalid', u'url': u'https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/<removed>/<removed>', u'token': u'<removed>', u'error': {u'status': 403, u'type': u'urn:ietf:params:acme:error:unauthorized', u'detail': u'Incorrect TXT record \"<removed>\" found at _acme-challenge.<removed>'}, u'validated': u'2021-04-06T16:27:29Z', u'type': u'dns-01'}], u'identifier': {u'type': u'dns', u'value': u'<removed>'}, 'uri': u'https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/23306744', u'expires': u'2021-04-13T16:26:53Z'}",
    "other": {
        "http_status": null,
        "http_url": null
    }
}
```