### PR TITLE
openssh_keypair: Adding passphrase parameter

### DIFF
--- a/changelogs/fragments/225-openssh-keypair-passphrase.yml
+++ b/changelogs/fragments/225-openssh-keypair-passphrase.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openssh_keypair - Added ``passphrase`` paramter to openssh_keypair for encrypting/decrtypting OpenSSH private keys (https://github.com/ansible-collections/community.crypto/pull/225).

--- a/plugins/module_utils/openssh/cryptography_openssh.py
+++ b/plugins/module_utils/openssh/cryptography_openssh.py
@@ -19,24 +19,23 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from base64 import b64encode, b64decode
+from distutils.version import LooseVersion
 from getpass import getuser
 from socket import gethostname
 
-from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
-    HAS_CRYPTOGRAPHY,
-    CRYPTOGRAPHY_HAS_ED25519,
-)
-
 try:
+    import cryptography as c
     from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
     from cryptography.hazmat.backends.openssl import backend
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa, padding
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
-except ImportError:
-    pass
 
-if HAS_CRYPTOGRAPHY and CRYPTOGRAPHY_HAS_ED25519:
+    if LooseVersion(c.__version__) >= LooseVersion("3.0"):
+        HAS_OPENSSH_PRIVATE_FORMAT = True
+    else:
+        HAS_OPENSSH_PRIVATE_FORMAT = False
+
     HAS_OPENSSH_SUPPORT = True
 
     _ALGORITHM_PARAMETERS = {
@@ -76,7 +75,8 @@ if HAS_CRYPTOGRAPHY and CRYPTOGRAPHY_HAS_ED25519:
             }
         }
     }
-else:
+except ImportError:
+    HAS_OPENSSH_PRIVATE_FORMAT = False
     HAS_OPENSSH_SUPPORT = False
     _ALGORITHM_PARAMETERS = {}
 
@@ -192,12 +192,14 @@ class Asymmetric_Keypair(object):
         )
 
     @classmethod
-    def load(cls, path, passphrase=None, key_format='PEM'):
+    def load(cls, path, passphrase=None, private_key_format='PEM', public_key_format='PEM', no_public_key=False):
         """Returns an Asymmetric_Keypair object loaded from the supplied file path
 
            :path: A path to an existing private key to be loaded
            :passphrase: Secret of type bytes used to decrypt the private key being loaded
-           :key_format: Format of key files to be loaded
+           :private_key_format: Format of private key to be loaded
+           :public_key_format: Format of public key to be loaded
+           :no_public_key: Set 'True' to only load a private key and automatically populate the matching public key
         """
 
         if passphrase:
@@ -205,8 +207,11 @@ class Asymmetric_Keypair(object):
         else:
             encryption_algorithm = serialization.NoEncryption()
 
-        privatekey = load_privatekey(path, passphrase, key_format)
-        publickey = load_publickey(path + '.pub', key_format)
+        privatekey = load_privatekey(path, passphrase, private_key_format)
+        if no_public_key:
+            publickey = privatekey.public_key()
+        else:
+            publickey = load_publickey(path + '.pub', public_key_format)
 
         # Ed25519 keys are always of size 256 and do not have a key_size attribute
         if isinstance(privatekey, Ed25519PrivateKey):
@@ -352,11 +357,11 @@ class OpenSSH_Keypair(object):
            :comment: Comment for a newly generated OpenSSH public key
         """
 
-        if not comment:
+        if comment is None:
             comment = "%s@%s" % (getuser(), gethostname())
 
         asym_keypair = Asymmetric_Keypair.generate(keytype, size, passphrase)
-        openssh_privatekey = cls.encode_openssh_privatekey(asym_keypair)
+        openssh_privatekey = cls.encode_openssh_privatekey(asym_keypair, 'SSH')
         openssh_publickey = cls.encode_openssh_publickey(asym_keypair, comment)
         fingerprint = calculate_fingerprint(openssh_publickey)
 
@@ -365,20 +370,21 @@ class OpenSSH_Keypair(object):
             openssh_privatekey=openssh_privatekey,
             openssh_publickey=openssh_publickey,
             fingerprint=fingerprint,
-            comment=comment
+            comment=comment,
         )
 
     @classmethod
-    def load(cls, path, passphrase=None):
+    def load(cls, path, passphrase=None, no_public_key=False):
         """Returns an Openssh_Keypair object loaded from the supplied file path
 
            :path: A path to an existing private key to be loaded
            :passphrase: Secret used to decrypt the private key being loaded
+           :no_public_key: Set 'True' to only load a private key and automatically populate the matching public key
         """
 
         comment = extract_comment(path + '.pub')
-        asym_keypair = Asymmetric_Keypair.load(path, passphrase, 'SSH')
-        openssh_privatekey = cls.encode_openssh_privatekey(asym_keypair)
+        asym_keypair = Asymmetric_Keypair.load(path, passphrase, 'SSH', 'SSH', no_public_key)
+        openssh_privatekey = cls.encode_openssh_privatekey(asym_keypair, 'SSH')
         openssh_publickey = cls.encode_openssh_publickey(asym_keypair, comment)
         fingerprint = calculate_fingerprint(openssh_publickey)
 
@@ -387,21 +393,27 @@ class OpenSSH_Keypair(object):
             openssh_privatekey=openssh_privatekey,
             openssh_publickey=openssh_publickey,
             fingerprint=fingerprint,
-            comment=comment
+            comment=comment,
         )
 
     @staticmethod
-    def encode_openssh_privatekey(asym_keypair):
+    def encode_openssh_privatekey(asym_keypair, key_format):
         """Returns an OpenSSH encoded private key for a given keypair
 
            :asym_keypair: Asymmetric_Keypair from the private key is extracted
+           :key_format: Format of the encoded private key.
         """
 
-        # OpenSSH formatted private keys are not available in Cryptography <3.0
-        try:
-            privatekey_format = serialization.PrivateFormat.OpenSSH
-        except AttributeError:
+        if key_format == 'SSH':
+            # Default to PEM format if SSH not available
+            if not HAS_OPENSSH_PRIVATE_FORMAT:
+                privatekey_format = serialization.PrivateFormat.PKCS8
+            else:
+                privatekey_format = serialization.PrivateFormat.OpenSSH
+        elif key_format == 'PEM':
             privatekey_format = serialization.PrivateFormat.PKCS8
+        else:
+            raise InvalidKeyFormatError("The accepted private key formats are SSH or PEM")
 
         encoded_privatekey = asym_keypair.private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -425,7 +437,7 @@ class OpenSSH_Keypair(object):
 
         validate_comment(comment)
 
-        encoded_publickey += (" %s" % comment).encode(encoding=_TEXT_ENCODING)
+        encoded_publickey += (" %s" % comment).encode(encoding=_TEXT_ENCODING) if comment else b''
 
         return encoded_publickey
 
@@ -502,7 +514,7 @@ class OpenSSH_Keypair(object):
         validate_comment(comment)
 
         self.__comment = comment
-        encoded_comment = (" %s" % self.__comment).encode(encoding=_TEXT_ENCODING)
+        encoded_comment = (" %s" % self.__comment).encode(encoding=_TEXT_ENCODING) if self.__comment else b''
         self.__openssh_publickey = b' '.join(self.__openssh_publickey.split(b' ', 2)[:2]) + encoded_comment
         return self.__openssh_publickey
 
@@ -513,7 +525,7 @@ class OpenSSH_Keypair(object):
         """
 
         self.__asym_keypair.update_passphrase(passphrase)
-        self.__openssh_privatekey = OpenSSH_Keypair.encode_openssh_privatekey(self.__asym_keypair)
+        self.__openssh_privatekey = OpenSSH_Keypair.encode_openssh_privatekey(self.__asym_keypair, 'SSH')
 
 
 def load_privatekey(path, passphrase, key_format):
@@ -549,7 +561,22 @@ def load_privatekey(path, passphrase, key_format):
             )
 
     except ValueError as e:
-        raise InvalidPrivateKeyFileError(e)
+        # Revert to PEM if key could not be loaded in SSH format
+        if key_format == 'SSH':
+            try:
+                privatekey = privatekey_loaders['PEM'](
+                    data=content,
+                    password=passphrase,
+                    backend=backend,
+                )
+            except ValueError as e:
+                raise InvalidPrivateKeyFileError(e)
+            except TypeError as e:
+                raise InvalidPassphraseError(e)
+            except UnsupportedAlgorithm as e:
+                raise InvalidAlgorithmError(e)
+        else:
+            raise InvalidPrivateKeyFileError(e)
     except TypeError as e:
         raise InvalidPassphraseError(e)
     except UnsupportedAlgorithm as e:
@@ -645,4 +672,4 @@ def calculate_fingerprint(openssh_publickey):
     decoded_pubkey = b64decode(openssh_publickey.split(b' ')[1])
     digest.update(decoded_pubkey)
 
-    return b64encode(digest.finalize()).decode(encoding=_TEXT_ENCODING).rstrip('=')
+    return 'SHA256:%s' % b64encode(digest.finalize()).decode(encoding=_TEXT_ENCODING).rstrip('=')

--- a/plugins/module_utils/openssh/cryptography_openssh.py
+++ b/plugins/module_utils/openssh/cryptography_openssh.py
@@ -410,10 +410,14 @@ class OpenSSH_Keypair(object):
                 privatekey_format = serialization.PrivateFormat.PKCS8
             else:
                 privatekey_format = serialization.PrivateFormat.OpenSSH
-        elif key_format == 'PEM':
+        elif key_format == 'PKCS8':
             privatekey_format = serialization.PrivateFormat.PKCS8
+        elif key_format == 'PKCS1':
+            if asym_keypair.key_type == 'ed25519':
+                raise InvalidKeyFormatError("ed25519 keys cannot be represented in PKCS1 format")
+            privatekey_format = serialization.PrivateFormat.TraditionalOpenSSL
         else:
-            raise InvalidKeyFormatError("The accepted private key formats are SSH or PEM")
+            raise InvalidKeyFormatError("The accepted private key formats are SSH, PKCS8, and PKCS1")
 
         encoded_privatekey = asym_keypair.private_key.private_bytes(
             encoding=serialization.Encoding.PEM,

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -62,7 +62,7 @@ options:
             - Passphrases are not supported for I(type=rsa1).
         type: str
         version_added: 1.7.0
-    key_format:
+    private_key_format:
         description:
             - Used when a value for I(passphrase) is provided to select a format for the private key at the provided I(path).
             - The only valid option currently is C(auto) which will match the key format of the installed OpenSSH version.
@@ -226,7 +226,7 @@ class Keypair(object):
             proc = module.run_command([ssh, '-Vq'])
             ssh_version = parse_openssh_version(proc[2].strip())
 
-            if module.params['key_format'] == 'auto':
+            if module.params['private_key_format'] == 'auto':
                 if LooseVersion(ssh_version) >= LooseVersion("7.8") and not HAS_OPENSSH_PRIVATE_FORMAT:
                     module.fail_json(
                         msg=missing_required_lib(
@@ -239,7 +239,7 @@ class Keypair(object):
                         if HAS_OPENSSH_PRIVATE_FORMAT:
                             # ed25519 keys are always formatted in the OpenSSH format by ssh-keygen
                             # since their introduction in OpenSSH 6.5
-                            self.key_format = 'SSH'
+                            self.private_key_format = 'SSH'
                         else:
                             module.fail_json(
                                 msg=missing_required_lib(
@@ -250,18 +250,18 @@ class Keypair(object):
                     else:
                         # OpenSSH made SSH formatted private keys available in version 6.5,
                         # but still defaulted to PKCS1 format
-                        self.key_format = 'PKCS1'
+                        self.private_key_format = 'PKCS1'
                 else:
-                    self.key_format = 'SSH'
+                    self.private_key_format = 'SSH'
             else:
-                module.fail_json(msg="The only valid option for 'key_format' is 'auto'")
+                module.fail_json(msg="The only valid option for 'private_key_format' is 'auto'")
 
             if self.type == 'rsa1':
                 module.fail_json(msg="Passphrases are not supported for RSA1 keys.")
 
             self.passphrase = to_bytes(self.passphrase)
         else:
-            self.key_format = None
+            self.private_key_format = None
 
         if self.type in ('rsa', 'rsa1'):
             self.size = 4096 if self.size is None else self.size
@@ -326,7 +326,7 @@ class Keypair(object):
                         f.write(
                             OpenSSH_Keypair.encode_openssh_privatekey(
                                 keypair.asymmetric_keypair,
-                                self.key_format
+                                self.private_key_format
                             )
                         )
                     os.chmod(self.path, stat.S_IWUSR + stat.S_IRUSR)
@@ -582,7 +582,7 @@ def main():
                 choices=['never', 'fail', 'partial_idempotence', 'full_idempotence', 'always']
             ),
             passphrase=dict(type='str', no_log=True),
-            key_format=dict(type='str', default='auto')
+            private_key_format=dict(type='str', default='auto', no_log=False)
         ),
         supports_check_mode=True,
         add_file_common_args=True,

--- a/tests/integration/targets/openssh_keypair/meta/main.yml
+++ b/tests/integration/targets/openssh_keypair/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - setup_ssh_keygen
+  - setup_openssl

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -124,7 +124,7 @@
   register: privatekey7_modified_result
 
 - name: Generate password protected key
-  command: 'ssh-keygen -f {{ output_dir }}/privatekey8 -N password'
+  command: 'ssh-keygen -f {{ output_dir }}/privatekey8 -N {{ passphrase }}'
 
 - name: Try to modify the password protected key - should fail
   openssh_keypair:
@@ -140,6 +140,51 @@
     size: 2048
   register: privatekey8_result_force
 
+- name: Generate another password protected key
+  command: 'ssh-keygen -f {{ output_dir }}/privatekey9 -N {{ passphrase }}'
+
+- name: Try to modify the password protected key with passphrase
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey9'
+    size: 1024
+    passphrase: "{{ passphrase }}"
+  register: privatekey9_modified_result
+
+- name: Generate another unprotected key
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey10'
+    size: 2048
+
+- name: Try to Modify unprotected key with passphrase
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey10'
+    size: 2048
+    passphrase: "{{ passphrase }}"
+  ignore_errors: true
+  register: privatekey10_result
+
+- name: Try to force modify the password protected key with force=true
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey10'
+    size: 2048
+    passphrase: "{{ passphrase }}"
+    force: true
+  register: privatekey10_result_force
+
+- name: Ensure that ssh-keygen can read keys generated with passphrase
+  command: 'ssh-keygen -yf {{ output_dir }}/privatekey10 -P {{ passphrase }}'
+  register: privatekey10_result_sshkeygen
+
+- name: Generate PEM encoded key with passphrase
+  command: 'ssh-keygen -f {{ output_dir }}/privatekey11 -N {{ passphrase }} -m PEM'
+
+- name: Try to verify a PEM encoded key
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey11'
+    size: 2048
+    passphrase: "{{ passphrase }}"
+  register: privatekey11_result
+
 - import_tasks: ../tests/validate.yml
 
 
@@ -152,8 +197,9 @@
     size: 1024
   loop: "{{ regenerate_values }}"
 - name: Regenerate - setup password protected keys
-  command: 'ssh-keygen -f {{ output_dir }}/regenerate-b-{{ item }} -N password'
+  command: 'ssh-keygen -f {{ output_dir }}/regenerate-b-{{ item }} -N {{ passphrase }}'
   loop: "{{ regenerate_values }}"
+
 - name: Regenerate - setup broken keys
   copy:
     dest: '{{ output_dir }}/regenerate-c-{{ item.0 }}{{ item.1 }}'
@@ -162,6 +208,10 @@
   with_nested:
     - "{{ regenerate_values }}"
     - [ '', '.pub' ]
+    -
+- name: Regenerate - setup password protected keys for passphrse test
+  command: 'ssh-keygen -f {{ output_dir }}/regenerate-d-{{ item }} -N {{ passphrase }}'
+  loop: "{{ regenerate_values }}"
 
 - name: Regenerate - modify broken keys (check mode)
   openssh_keypair:
@@ -225,6 +275,26 @@
       - result.results[3] is changed
       - result.results[4] is changed
 
+- name: Regenerate - modify password protected keys with passphrase (check mode)
+  openssh_keypair:
+    path: '{{ output_dir }}/regenerate-b-{{ item }}'
+    type: rsa
+    size: 1024
+    passphrase: "{{ passphrase }}"
+    regenerate: '{{ item }}'
+  check_mode: yes
+  loop: "{{ regenerate_values }}"
+  ignore_errors: yes
+  register: result
+- assert:
+    that:
+      - result.results[0] is success
+      - result.results[1] is failed
+      - "'Key has wrong type and/or size. Will not proceed.' in result.results[1].msg"
+      - result.results[2] is changed
+      - result.results[3] is changed
+      - result.results[4] is changed
+
 - name: Regenerate - modify password protected keys
   openssh_keypair:
     path: '{{ output_dir }}/regenerate-b-{{ item }}'
@@ -242,6 +312,25 @@
       - "'Unable to read the key. The key is protected with a passphrase or broken. Will not proceed.' in result.results[1].msg"
       - result.results[2] is failed
       - "'Unable to read the key. The key is protected with a passphrase or broken. Will not proceed.' in result.results[2].msg"
+      - result.results[3] is changed
+      - result.results[4] is changed
+
+- name: Regenerate - modify password protected keys with passphrase
+  openssh_keypair:
+    path: '{{ output_dir }}/regenerate-d-{{ item }}'
+    type: rsa
+    size: 1024
+    passphrase: "{{ passphrase }}"
+    regenerate: '{{ item }}'
+  loop: "{{ regenerate_values }}"
+  ignore_errors: yes
+  register: result
+- assert:
+    that:
+      - result.results[0] is success
+      - result.results[1] is failed
+      - "'Key has wrong type and/or size. Will not proceed.' in result.results[1].msg"
+      - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
 

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -152,7 +152,7 @@
     size: 1024
     passphrase: "{{ passphrase }}"
   register: privatekey9_modified_result
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Generate another unprotected key
   openssh_keypair:
@@ -166,7 +166,7 @@
     passphrase: "{{ passphrase }}"
   ignore_errors: true
   register: privatekey10_result
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 
 - name: Try to force modify the password protected key with force=true
@@ -176,16 +176,16 @@
     passphrase: "{{ passphrase }}"
     force: true
   register: privatekey10_result_force
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Ensure that ssh-keygen can read keys generated with passphrase
   command: 'ssh-keygen -yf {{ output_dir }}/privatekey10 -P {{ passphrase }}'
   register: privatekey10_result_sshkeygen
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Generate PEM encoded key with passphrase
   command: 'ssh-keygen -f {{ output_dir }}/privatekey11 -N {{ passphrase }} -m PEM'
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Try to verify a PEM encoded key
   openssh_keypair:
@@ -193,7 +193,7 @@
     size: 2048
     passphrase: "{{ passphrase }}"
   register: privatekey11_result
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - import_tasks: ../tests/validate.yml
 
@@ -296,7 +296,7 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - assert:
     that:
@@ -306,7 +306,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Regenerate - modify password protected keys
   openssh_keypair:
@@ -338,7 +338,7 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - assert:
     that:
@@ -348,7 +348,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
-  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')
 
 - name: Regenerate - not modify regular keys (check mode)
   openssh_keypair:

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -4,6 +4,9 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
+# Bumps up cryptography and bcrypt versions to be compatible with OpenSSH >= 7.8
+- import_tasks: ./setup_cryptography.yml
+
 - name: Generate privatekey1 - standard (check mode)
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'
@@ -149,6 +152,7 @@
     size: 1024
     passphrase: "{{ passphrase }}"
   register: privatekey9_modified_result
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Generate another unprotected key
   openssh_keypair:
@@ -162,6 +166,8 @@
     passphrase: "{{ passphrase }}"
   ignore_errors: true
   register: privatekey10_result
+  when: cryptography_version.stdout is version('3.0', '>=')
+
 
 - name: Try to force modify the password protected key with force=true
   openssh_keypair:
@@ -170,13 +176,16 @@
     passphrase: "{{ passphrase }}"
     force: true
   register: privatekey10_result_force
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Ensure that ssh-keygen can read keys generated with passphrase
   command: 'ssh-keygen -yf {{ output_dir }}/privatekey10 -P {{ passphrase }}'
   register: privatekey10_result_sshkeygen
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Generate PEM encoded key with passphrase
   command: 'ssh-keygen -f {{ output_dir }}/privatekey11 -N {{ passphrase }} -m PEM'
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Try to verify a PEM encoded key
   openssh_keypair:
@@ -184,6 +193,7 @@
     size: 2048
     passphrase: "{{ passphrase }}"
   register: privatekey11_result
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - import_tasks: ../tests/validate.yml
 
@@ -286,6 +296,8 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
+  when: cryptography_version.stdout is version('3.0', '>=')
+
 - assert:
     that:
       - result.results[0] is success
@@ -294,6 +306,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Regenerate - modify password protected keys
   openssh_keypair:
@@ -325,6 +338,8 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
+  when: cryptography_version.stdout is version('3.0', '>=')
+
 - assert:
     that:
       - result.results[0] is success
@@ -333,6 +348,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Regenerate - not modify regular keys (check mode)
   openssh_keypair:

--- a/tests/integration/targets/openssh_keypair/tasks/main.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/main.yml
@@ -5,7 +5,7 @@
 ####################################################################
 
 # Bumps up cryptography and bcrypt versions to be compatible with OpenSSH >= 7.8
-- import_tasks: ./setup_cryptography.yml
+- import_tasks: ./setup_bcrypt.yml
 
 - name: Generate privatekey1 - standard (check mode)
   openssh_keypair:
@@ -152,7 +152,7 @@
     size: 1024
     passphrase: "{{ passphrase }}"
   register: privatekey9_modified_result
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Generate another unprotected key
   openssh_keypair:
@@ -166,7 +166,7 @@
     passphrase: "{{ passphrase }}"
   ignore_errors: true
   register: privatekey10_result
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 
 - name: Try to force modify the password protected key with force=true
@@ -176,16 +176,16 @@
     passphrase: "{{ passphrase }}"
     force: true
   register: privatekey10_result_force
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Ensure that ssh-keygen can read keys generated with passphrase
   command: 'ssh-keygen -yf {{ output_dir }}/privatekey10 -P {{ passphrase }}'
   register: privatekey10_result_sshkeygen
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Generate PEM encoded key with passphrase
   command: 'ssh-keygen -f {{ output_dir }}/privatekey11 -N {{ passphrase }} -m PEM'
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Try to verify a PEM encoded key
   openssh_keypair:
@@ -193,7 +193,7 @@
     size: 2048
     passphrase: "{{ passphrase }}"
   register: privatekey11_result
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - import_tasks: ../tests/validate.yml
 
@@ -296,7 +296,7 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - assert:
     that:
@@ -306,7 +306,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Regenerate - modify password protected keys
   openssh_keypair:
@@ -338,7 +338,7 @@
   loop: "{{ regenerate_values }}"
   ignore_errors: yes
   register: result
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - assert:
     that:
@@ -348,7 +348,7 @@
       - result.results[2] is changed
       - result.results[3] is changed
       - result.results[4] is changed
-  when: cryptography_version.stdout is version('3.0', '>=')
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5' '>=')
 
 - name: Regenerate - not modify regular keys (check mode)
   openssh_keypair:

--- a/tests/integration/targets/openssh_keypair/tasks/setup_bcrypt.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/setup_bcrypt.yml
@@ -6,16 +6,6 @@
 
 - name: Attempt to install dependencies for OpenSSH > 7.8
   block:
-    - name: Ensure cryptography >= 3.0 available
-      become: true
-      pip:
-        name: cryptography>=3.0
-        extra_args: "-c {{ remote_constraints }}"
-
-    - name: Register cryptography version
-      command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
-      register: cryptography_version
-
     - name: Ensure bcrypt 3.1.5 available
       become: true
       pip:
@@ -29,5 +19,6 @@
 
 - name: Ensure bcrypt_version is defined
   set_fact:
-    bcrypt_version: 0.0
+    bcrypt_version:
+      stdout: 0.0
   when: bcrypt_version is not defined

--- a/tests/integration/targets/openssh_keypair/tasks/setup_cryptography.yml
+++ b/tests/integration/targets/openssh_keypair/tasks/setup_cryptography.yml
@@ -1,0 +1,33 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Attempt to install dependencies for OpenSSH > 7.8
+  block:
+    - name: Ensure cryptography >= 3.0 available
+      become: true
+      pip:
+        name: cryptography>=3.0
+        extra_args: "-c {{ remote_constraints }}"
+
+    - name: Register cryptography version
+      command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
+      register: cryptography_version
+
+    - name: Ensure bcrypt 3.1.5 available
+      become: true
+      pip:
+        name: bcrypt==3.1.5
+        extra_args: "-c {{ remote_constraints }}"
+
+    - name: Register bcrypt version
+      command: "{{ ansible_python.executable }} -c 'import bcrypt; print(bcrypt.__version__)'"
+      register: bcrypt_version
+  ignore_errors: true
+
+- name: Ensure bcrypt_version is defined
+  set_fact:
+    bcrypt_version: 0.0
+  when: bcrypt_version is not defined

--- a/tests/integration/targets/openssh_keypair/tests/validate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/validate.yml
@@ -138,3 +138,29 @@
   assert:
     that:
       - privatekey8_result_force is changed
+
+- name: Check that password protected key with passphrase was regenerated
+  assert:
+    that:
+      - privatekey9_modified_result is changed
+
+- name: Check that modifying unprotected key with passphrase fails
+  assert:
+    that:
+      - privatekey10_result is failed
+      - "'Unable to read the key. The key is protected with a passphrase or broken.' in privatekey8_result.msg"
+
+- name: Check that unprotected key was regenerated with force=yes and passphrase supplied
+  assert:
+    that:
+      - privatekey10_result_force is changed
+
+- name: Check that ssh-keygen output from passphrase protected key matches openssh_keypair
+  assert:
+    that:
+      - privatekey10_result_force.public_key == privatekey10_result_sshkeygen.stdout
+
+- name: Check that PEM encoded private keys are loaded successfully
+  assert:
+    that:
+      - privatekey11_result is success

--- a/tests/integration/targets/openssh_keypair/tests/validate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/validate.yml
@@ -139,33 +139,30 @@
     that:
       - privatekey8_result_force is changed
 
-- name: Check that password protected key with passphrase was regenerated
-  assert:
-    that:
-      - privatekey9_modified_result is changed
-  when: cryptography_version.stdout is version('3.0', '>=')
+- block:
+    - name: Check that password protected key with passphrase was regenerated
+      assert:
+        that:
+          - privatekey9_modified_result is changed
 
-- name: Check that modifying unprotected key with passphrase fails
-  assert:
-    that:
-      - privatekey10_result is failed
-      - "'Unable to read the key. The key is protected with a passphrase or broken.' in privatekey8_result.msg"
-  when: cryptography_version.stdout is version('3.0', '>=')
+    - name: Check that modifying unprotected key with passphrase fails
+      assert:
+        that:
+          - privatekey10_result is failed
+          - "'Unable to read the key. The key is protected with a passphrase or broken.' in privatekey8_result.msg"
 
-- name: Check that unprotected key was regenerated with force=yes and passphrase supplied
-  assert:
-    that:
-      - privatekey10_result_force is changed
-  when: cryptography_version.stdout is version('3.0', '>=')
+    - name: Check that unprotected key was regenerated with force=yes and passphrase supplied
+      assert:
+        that:
+          - privatekey10_result_force is changed
 
-- name: Check that ssh-keygen output from passphrase protected key matches openssh_keypair
-  assert:
-    that:
-      - privatekey10_result_force.public_key == privatekey10_result_sshkeygen.stdout
-  when: cryptography_version.stdout is version('3.0', '>=')
+    - name: Check that ssh-keygen output from passphrase protected key matches openssh_keypair
+      assert:
+        that:
+          - privatekey10_result_force.public_key == privatekey10_result_sshkeygen.stdout
 
-- name: Check that PEM encoded private keys are loaded successfully
-  assert:
-    that:
-      - privatekey11_result is success
-  when: cryptography_version.stdout is version('3.0', '>=')
+    - name: Check that PEM encoded private keys are loaded successfully
+      assert:
+        that:
+          - privatekey11_result is success
+  when: cryptography_version.stdout is version('3.0', '>=') and bcrypt_version.stdout is version('3.1.5', '>=')

--- a/tests/integration/targets/openssh_keypair/tests/validate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/validate.yml
@@ -143,24 +143,29 @@
   assert:
     that:
       - privatekey9_modified_result is changed
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Check that modifying unprotected key with passphrase fails
   assert:
     that:
       - privatekey10_result is failed
       - "'Unable to read the key. The key is protected with a passphrase or broken.' in privatekey8_result.msg"
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Check that unprotected key was regenerated with force=yes and passphrase supplied
   assert:
     that:
       - privatekey10_result_force is changed
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Check that ssh-keygen output from passphrase protected key matches openssh_keypair
   assert:
     that:
       - privatekey10_result_force.public_key == privatekey10_result_sshkeygen.stdout
+  when: cryptography_version.stdout is version('3.0', '>=')
 
 - name: Check that PEM encoded private keys are loaded successfully
   assert:
     that:
       - privatekey11_result is success
+  when: cryptography_version.stdout is version('3.0', '>=')

--- a/tests/integration/targets/openssh_keypair/vars/main.yml
+++ b/tests/integration/targets/openssh_keypair/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+passphrase: password
 regenerate_values:
   - never
   - fail


### PR DESCRIPTION
##### SUMMARY
Added `passphrase` paramter to `openssh_keypair` for encrypting/decrypting OpenSSH private keys.
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/modules/openssh_keypair
plugins/module_utils/openssh/cryptography_openssh
##### ADDITIONAL INFORMATION 
`openssh_keypair`
- Uses `cryptography` instead of _ssh_keygen_ to avoid passing passphrases over command line
- Maintains consistent formatting with _ssh_keygen_ which changed in version 7.8
- Ensures idempotency checks behave as documented when using passphrase
- Return values are consistent with parsed _ssh_keygen_ output
- `passphrase` is used as a switch so if empty or not supplied behavior will be the same as before this feature (Some more lines are included in `try` blocks, but are really just variable assignments)

`cryptography_openssh`
- Exposes SSH private key formatting capability as a global
- Added option to load a lone private key and automatically generate the corresponding public key
- Added option to explicitly select private key format
- Added logic to reattempt loading a PEM formatted private key if the OpenSSH loader fails
- Made it possible to set null comments
- Added "SHA256:" prefix to fingerprint

Integration tests have been updated as well.

Unfortunately the following containers have system packages of `cryptography` less than what is required to replicate the installed OpenSSH versions and the local pip versions are not able to install an updated version.

For these containers currently only the test cases which do not use the `passphrase` option are executed.
- CentOS 6
- CentOS 8
- openSUSE 15 py3
- Ubuntu 18.04
- RHEL 8.3
- FreeBSD 12.1
- FreeBSD 12.2
- FreeBSD 13.0