### PR TITLE
openssh_keypair: Populate return values when keypair exists and check_mode=true

### DIFF
--- a/changelogs/fragments/230-openssh_keypair-check_mode-return-values.yml
+++ b/changelogs/fragments/230-openssh_keypair-check_mode-return-values.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openssh_keypair - enhanced ``check_mode`` to populate return values for existing keypairs (https://github.com/ansible-collections/community.crypto/pull/230).

--- a/changelogs/fragments/230-openssh_keypair-check_mode-return-values.yml
+++ b/changelogs/fragments/230-openssh_keypair-check_mode-return-values.yml
@@ -1,2 +1,2 @@
-minor_changes:
-  - openssh_keypair - enhanced ``check_mode`` to populate return values for existing keypairs (https://github.com/ansible-collections/community.crypto/pull/230).
+bugfixes:
+  - openssh_keypair - fix ``check_mode`` to populate return values for existing keypairs (https://github.com/ansible-collections/community.crypto/issues/113, https://github.com/ansible-collections/community.crypto/pull/230).

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -590,8 +590,9 @@ def main():
     if keypair.state == 'present':
 
         if module.check_mode:
+            changed = keypair.force or not keypair.isPrivateKeyValid(module) or not keypair.isPublicKeyValid(module)
             result = keypair.dump()
-            result['changed'] = keypair.force or not keypair.isPrivateKeyValid(module) or not keypair.isPublicKeyValid(module)
+            result['changed'] = changed
             module.exit_json(**result)
 
         try:

--- a/tests/integration/targets/openssh_keypair/tests/validate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/validate.yml
@@ -9,6 +9,7 @@
       - privatekey1_result_check is changed
       - privatekey1_result is changed
       - privatekey1_idem_result_check is not changed
+      - privatekey1_idem_result_check.public_key.startswith("ssh-rsa")
       - privatekey1_idem_result is not changed
 
 - name: Validate privatekey1 return fingerprint


### PR DESCRIPTION
##### SUMMARY
Enhancing `check_mode` for `openssh_keypair` with populated return values if keypair already exists.

Fixes #113 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_keypair.py

##### ADDITIONAL INFORMATION
Straight forward change to execute the check logic prior to dumping the return values into the `results` dictionary when `check_mode=true`.
