### PR TITLE
x509_crl_info: allow to not enumerate revoked certificates

### DIFF
--- a/changelogs/fragments/232-x509_crl_info-list_revoked_certificates.yml
+++ b/changelogs/fragments/232-x509_crl_info-list_revoked_certificates.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "x509_crl_info - add ``list_revoked_certificates`` option to avoid enumerating all revoked certificates (https://github.com/ansible-collections/community.crypto/pull/232)."

--- a/plugins/module_utils/crypto/module_backends/crl_info.py
+++ b/plugins/module_utils/crypto/module_backends/crl_info.py
@@ -46,10 +46,11 @@ else:
 
 
 class CRLInfoRetrieval(object):
-    def __init__(self, module, content):
+    def __init__(self, module, content, list_revoked_certificates=True):
         # content must be a bytes string
         self.module = module
         self.content = content
+        self.list_revoked_certificates = list_revoked_certificates
 
     def get_info(self):
         self.crl_pem = identify_pem_format(self.content)
@@ -82,18 +83,19 @@ class CRLInfoRetrieval(object):
         result['issuer'] = {}
         for k, v in issuer:
             result['issuer'][k] = v
-        result['revoked_certificates'] = []
-        for cert in self.crl:
-            entry = cryptography_decode_revoked_certificate(cert)
-            result['revoked_certificates'].append(cryptography_dump_revoked(entry))
+        if self.list_revoked_certificates:
+            result['revoked_certificates'] = []
+            for cert in self.crl:
+                entry = cryptography_decode_revoked_certificate(cert)
+                result['revoked_certificates'].append(cryptography_dump_revoked(entry))
 
         return result
 
 
-def get_crl_info(module, content):
+def get_crl_info(module, content, list_revoked_certificates=True):
     if not CRYPTOGRAPHY_FOUND:
         module.fail_json(msg=missing_required_lib('cryptography >= {0}'.format(MINIMAL_CRYPTOGRAPHY_VERSION)),
                          exception=CRYPTOGRAPHY_IMP_ERR)
 
-    info = CRLInfoRetrieval(module, content)
+    info = CRLInfoRetrieval(module, content, list_revoked_certificates=list_revoked_certificates)
     return info.get_info()

--- a/plugins/module_utils/crypto/module_backends/crl_info.py
+++ b/plugins/module_utils/crypto/module_backends/crl_info.py
@@ -70,7 +70,6 @@ class CRLInfoRetrieval(object):
             'digest': None,
             'issuer_ordered': None,
             'issuer': None,
-            'revoked_certificates': [],
         }
 
         result['last_update'] = self.crl.last_update.strftime(TIMESTAMP_FORMAT)

--- a/plugins/modules/x509_crl_info.py
+++ b/plugins/modules/x509_crl_info.py
@@ -57,6 +57,12 @@ EXAMPLES = r'''
 - name: Print the information
   ansible.builtin.debug:
     msg: "{{ result }}"
+
+- name: Get information on CRL without list of revoked certificates
+  community.crypto.x509_crl_info:
+    path: /etc/ssl/very-large.crl
+    list_revoked_certificates: false
+  register: result
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/x509_crl/tasks/impl.yml
+++ b/tests/integration/targets/x509_crl/tasks/impl.yml
@@ -19,6 +19,7 @@
         revocation_date: 20191001000000Z
   check_mode: yes
   register: crl_1_check
+
 - name: Create CRL 1
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -38,18 +39,22 @@
       - serial_number: 1234
         revocation_date: 20191001000000Z
   register: crl_1
+
 - name: Retrieve CRL 1 infos
   x509_crl_info:
     path: '{{ output_dir }}/ca-crl1.crl'
   register: crl_1_info_1
+
 - name: Retrieve CRL 1 infos via file content
   x509_crl_info:
     content: '{{ lookup("file", output_dir ~ "/ca-crl1.crl") }}'
   register: crl_1_info_2
+
 - name: Retrieve CRL 1 infos via file content (Base64)
   x509_crl_info:
     content: '{{ lookup("file", output_dir ~ "/ca-crl1.crl") | b64encode }}'
   register: crl_1_info_3
+
 - name: Create CRL 1 (idempotent, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -70,6 +75,7 @@
         revocation_date: 20191001000000Z
   check_mode: yes
   register: crl_1_idem_check
+
 - name: Create CRL 1 (idempotent)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -89,6 +95,7 @@
       - serial_number: 1234
         revocation_date: 20191001000000Z
   register: crl_1_idem
+
 - name: Create CRL 1 (idempotent with content, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -109,6 +116,7 @@
         revocation_date: 20191001000000Z
   check_mode: yes
   register: crl_1_idem_content_check
+
 - name: Create CRL 1 (idempotent with content)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -128,6 +136,7 @@
       - serial_number: 1234
         revocation_date: 20191001000000Z
   register: crl_1_idem_content
+
 - name: Create CRL 1 (format, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -149,6 +158,7 @@
         revocation_date: 20191001000000Z
   check_mode: yes
   register: crl_1_format_check
+
 - name: Create CRL 1 (format)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -169,6 +179,7 @@
       - serial_number: 1234
         revocation_date: 20191001000000Z
   register: crl_1_format
+
 - name: Create CRL 1 (format, idempotent, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -190,6 +201,7 @@
         revocation_date: 20191001000000Z
   check_mode: yes
   register: crl_1_format_idem_check
+
 - name: Create CRL 1 (format, idempotent)
   x509_crl:
     path: '{{ output_dir }}/ca-crl1.crl'
@@ -211,14 +223,17 @@
         revocation_date: 20191001000000Z
     return_content: yes
   register: crl_1_format_idem
+
 - name: Retrieve CRL 1 infos via file
   x509_crl_info:
     path: '{{ output_dir }}/ca-crl1.crl'
   register: crl_1_info_4
+
 - name: Read ca-crl1.crl
   slurp:
     src: "{{ output_dir }}/ca-crl1.crl"
   register: content
+
 - name: Retrieve CRL 1 infos via file content (Base64)
   x509_crl_info:
     content: '{{ content.content }}'
@@ -241,6 +256,7 @@
       - serial_number: 1234
   check_mode: yes
   register: crl_2_check
+
 - name: Create CRL 2
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -257,6 +273,7 @@
         invalidity_date: 20191012000000Z
       - serial_number: 1234
   register: crl_2
+
 - name: Create CRL 2 (idempotent, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -275,6 +292,7 @@
     ignore_timestamps: yes
   check_mode: yes
   register: crl_2_idem_check
+
 - name: Create CRL 2 (idempotent)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -292,6 +310,7 @@
       - serial_number: 1234
     ignore_timestamps: yes
   register: crl_2_idem
+
 - name: Create CRL 2 (idempotent update, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -306,6 +325,7 @@
     mode: update
   check_mode: yes
   register: crl_2_idem_update_change_check
+
 - name: Create CRL 2 (idempotent update)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -319,6 +339,7 @@
     ignore_timestamps: yes
     mode: update
   register: crl_2_idem_update_change
+
 - name: Create CRL 2 (idempotent update, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -336,6 +357,7 @@
     mode: update
   check_mode: yes
   register: crl_2_idem_update_check
+
 - name: Create CRL 2 (idempotent update)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -352,6 +374,7 @@
     ignore_timestamps: yes
     mode: update
   register: crl_2_idem_update
+
 - name: Create CRL 2 (changed timestamps, check mode)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -369,6 +392,7 @@
     mode: update
   check_mode: yes
   register: crl_2_change_check
+
 - name: Create CRL 2 (changed timestamps)
   x509_crl:
     path: '{{ output_dir }}/ca-crl2.crl'
@@ -386,3 +410,9 @@
     mode: update
     return_content: yes
   register: crl_2_change
+
+- name: Retrieve CRL 2 infos
+  x509_crl_info:
+    path: '{{ output_dir }}/ca-crl2.crl'
+    list_revoked_certificates: false
+  register: crl_2_info_1

--- a/tests/integration/targets/x509_crl/tests/validate.yml
+++ b/tests/integration/targets/x509_crl/tests/validate.yml
@@ -80,3 +80,8 @@
       - crl_2_change_check is changed
       - crl_2_change is changed
       - crl_2_change.crl == lookup('file', output_dir ~ '/ca-crl2.crl', rstrip=False)
+
+- name: Validate CRL 2 info
+  assert:
+    that:
+      - "'revoked_certificates' not in crl_2_info_1"


### PR DESCRIPTION
##### SUMMARY
For large CRL files, returning the list of all revoked certificates is pretty inefficient. This PR adds an option to avoid returning that information.

CC @JuddTracy-DAS

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
x509_crl_info
