### PR TITLE
openssl_csr_info and x509_certificate_info: return more public key information

### DIFF
--- a/changelogs/fragments/233-public-key-info.yml
+++ b/changelogs/fragments/233-public-key-info.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "openssl_csr_info - now returns ``public_key_type`` and ``public_key_data`` (https://github.com/ansible-collections/community.crypto/pull/233)."
+- "x509_certificate_info - now returns ``public_key_type`` and ``public_key_data`` (https://github.com/ansible-collections/community.crypto/pull/233)."

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -183,6 +183,77 @@ public_key:
     returned: success
     type: str
     sample: "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A..."
+public_key_type:
+    description:
+        - The CSR's public key's type.
+        - One of C(RSA), C(DSA), C(ECC), C(Ed25519), C(X25519), C(Ed448), or C(X448).
+        - Will start with C(unknown) if the key type cannot be determined.
+    returned: success
+    type: str
+    version_added: 1.7.0
+    sample: RSA
+public_key_data:
+    description:
+        - Public key data. Depends on the public key's type.
+    returned: success
+    type: dict
+    version_added: 1.7.0
+    contains:
+        size:
+            description:
+                - Bit size of modulus (RSA) or prime number (DSA).
+            type: int
+            returned: When C(type=RSA) or C(type=DSA)
+        modulus:
+            description:
+                - The RSA key's modulus.
+            type: int
+            returned: When C(type=RSA)
+        exponent:
+            description:
+                - The RSA key's public exponent.
+            type: int
+            returned: When C(type=RSA)
+        p:
+            description:
+                - The C(p) value for DSA.
+                - This is the prime modulus upon which arithmetic takes place.
+            type: int
+            returned: When C(type=DSA)
+        q:
+            description:
+                - The C(q) value for DSA.
+                - This is a prime that divides C(p - 1), and at the same time the order of the subgroup of the
+                  multiplicative group of the prime field used.
+            type: int
+            returned: When C(type=DSA)
+        g:
+            description:
+                - The C(g) value for DSA.
+                - This is the element spanning the subgroup of the multiplicative group of the prime field used.
+            type: int
+            returned: When C(type=DSA)
+        curve:
+            description:
+                - The curve's name for ECC.
+            type: str
+            returned: When C(type=ECC)
+        exponent_size:
+            description:
+                - The maximum number of bits of a private key. This is basically the bit size of the subgroup used.
+            type: int
+            returned: When C(type=ECC)
+        x:
+            description:
+                - The C(x) coordinate for the public point on the elliptic curve.
+            type: int
+            returned: When C(type=ECC)
+        y:
+            description:
+                - For C(type=ECC), this is the C(y) coordinate for the public point on the elliptic curve.
+                - For C(type=DSA), this is the publicly known group element whose discrete logarithm w.r.t. C(g) is the private key.
+            type: int
+            returned: When C(type=DSA) or C(type=ECC)
 public_key_fingerprints:
     description:
         - Fingerprints of CSR's public key.

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -227,6 +227,77 @@ public_key:
     returned: success
     type: str
     sample: "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A..."
+public_key_type:
+    description:
+        - The certificate's public key's type.
+        - One of C(RSA), C(DSA), C(ECC), C(Ed25519), C(X25519), C(Ed448), or C(X448).
+        - Will start with C(unknown) if the key type cannot be determined.
+    returned: success
+    type: str
+    version_added: 1.7.0
+    sample: RSA
+public_key_data:
+    description:
+        - Public key data. Depends on the public key's type.
+    returned: success
+    type: dict
+    version_added: 1.7.0
+    contains:
+        size:
+            description:
+                - Bit size of modulus (RSA) or prime number (DSA).
+            type: int
+            returned: When C(type=RSA) or C(type=DSA)
+        modulus:
+            description:
+                - The RSA key's modulus.
+            type: int
+            returned: When C(type=RSA)
+        exponent:
+            description:
+                - The RSA key's public exponent.
+            type: int
+            returned: When C(type=RSA)
+        p:
+            description:
+                - The C(p) value for DSA.
+                - This is the prime modulus upon which arithmetic takes place.
+            type: int
+            returned: When C(type=DSA)
+        q:
+            description:
+                - The C(q) value for DSA.
+                - This is a prime that divides C(p - 1), and at the same time the order of the subgroup of the
+                  multiplicative group of the prime field used.
+            type: int
+            returned: When C(type=DSA)
+        g:
+            description:
+                - The C(g) value for DSA.
+                - This is the element spanning the subgroup of the multiplicative group of the prime field used.
+            type: int
+            returned: When C(type=DSA)
+        curve:
+            description:
+                - The curve's name for ECC.
+            type: str
+            returned: When C(type=ECC)
+        exponent_size:
+            description:
+                - The maximum number of bits of a private key. This is basically the bit size of the subgroup used.
+            type: int
+            returned: When C(type=ECC)
+        x:
+            description:
+                - The C(x) coordinate for the public point on the elliptic curve.
+            type: int
+            returned: When C(type=ECC)
+        y:
+            description:
+                - For C(type=ECC), this is the C(y) coordinate for the public point on the elliptic curve.
+                - For C(type=DSA), this is the publicly known group element whose discrete logarithm w.r.t. C(g) is the private key.
+            type: int
+            returned: When C(type=DSA) or C(type=ECC)
 public_key_fingerprints:
     description:
         - Fingerprints of certificate's public key.

--- a/tests/integration/targets/openssl_csr_info/tasks/impl.yml
+++ b/tests/integration/targets/openssl_csr_info/tasks/impl.yml
@@ -14,6 +14,8 @@
       - result.subject.organizationalUnitName == 'ACME Department'
       - "['organizationalUnitName', 'Crypto Department'] in result.subject_ordered"
       - "['organizationalUnitName', 'ACME Department'] in result.subject_ordered"
+      - result.public_key_type == 'RSA'
+      - result.public_key_data.size == default_rsa_key_size
 
 - name: "({{ select_crypto_backend }}) Check SubjectKeyIdentifier and AuthorityKeyIdentifier"
   assert:

--- a/tests/integration/targets/x509_certificate_info/tasks/impl.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/impl.yml
@@ -17,6 +17,8 @@
       - result.subject.organizationalUnitName == 'ACME Department'
       - "['organizationalUnitName', 'Crypto Department'] in result.subject_ordered"
       - "['organizationalUnitName', 'ACME Department'] in result.subject_ordered"
+      - result.public_key_type == 'RSA'
+      - result.public_key_data.size == default_rsa_key_size_certifiates
 
 - name: Check SubjectKeyIdentifier and AuthorityKeyIdentifier
   assert:


### PR DESCRIPTION
##### SUMMARY
Returns the information of openssl_publickey_info for the public key in openssl_csr_info and x509_certificate_info.

Fixes #227.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_csr_info
x509_certificate_info
