### PR TITLE
openssl_pkcs12: add cryptography backend

### DIFF
--- a/changelogs/fragments/234-openssl_pkcs12-cryptography.yml
+++ b/changelogs/fragments/234-openssl_pkcs12-cryptography.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- "openssl_pkcs12 - added option ``select_crypto_backend`` and a ``cryptography`` backend.
+  This requires cryptography 3.0 or newer, and does not support the ``iter_size`` and ``maciter_size`` options
+  (https://github.com/ansible-collections/community.crypto/pull/234)."

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -369,9 +369,9 @@ class Pkcs(OpenSSLObject):
             if self.privatekey_passphrase:
                 try:
                     load_privatekey(self.privatekey_path, self.privatekey_passphrase, backend=self.backend)
-                except OpenSSLObjectError:
-                    return False
                 except OpenSSLBadPassphraseError:
+                    return False
+                except OpenSSLObjectError:
                     return False
             return True
 

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -16,6 +16,12 @@ author:
 short_description: Generate OpenSSL PKCS#12 archive
 description:
     - This module allows one to (re-)generate PKCS#12.
+    - The module can use the cryptography Python library, or the pyOpenSSL Python
+      library. By default, it tries to detect which one is available, assuming none of the
+      I(iter_size) and I(maciter_size) options are used. This can be overridden with the
+      I(select_crypto_backend) option.
+    # Please note that the C(pyopenssl) backend has been deprecated in community.crypto x.y.0,
+    # and will be removed in community.crypto (x+1).0.0.
 requirements:
     - PyOpenSSL >= 0.15 or cryptography >= 3.0
 options:

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -601,10 +601,9 @@ class PkcsCryptography(Pkcs):
             if certificate:
                 # See https://github.com/pyca/cryptography/issues/5760#issuecomment-842687238
                 maybe_name = certificate._backend._lib.X509_alias_get0(
-                    certificate._x509, certificate._backend._ffi.NULL
-                )
+                    certificate._x509, certificate._backend._ffi.NULL)
                 if maybe_name != certificate._backend._ffi.NULL:
-                     friendly_name = certificate._backend._ffi.string(maybe_name)
+                    friendly_name = certificate._backend._ffi.string(maybe_name)
 
             return (pkey, crt, other_certs, friendly_name)
         except ValueError as exc:

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -383,8 +383,6 @@ class Pkcs(OpenSSLObject):
             if self.privatekey_passphrase:
                 try:
                     load_privatekey(self.privatekey_path, self.privatekey_passphrase, backend=self.backend)
-                except OpenSSLBadPassphraseError:
-                    return False
                 except OpenSSLObjectError:
                     return False
             return True

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -600,11 +600,11 @@ class PkcsCryptography(Pkcs):
             friendly_name = None
             if certificate:
                 # See https://github.com/pyca/cryptography/issues/5760#issuecomment-842687238
-                friendly_name = certificate._backend._ffi.string(
-                    certificate._backend._lib.X509_alias_get0(
-                        certificate._x509, certificate._backend._ffi.new("int *")
-                    )
+                maybe_name = certificate._backend._lib.X509_alias_get0(
+                    certificate._x509, certificate._backend._ffi.NULL
                 )
+                if maybe_name != certificate._backend._ffi.NULL:
+                     friendly_name = certificate._backend._ffi.string(maybe_name)
 
             return (pkey, crt, other_certs, friendly_name)
         except ValueError as exc:

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -581,7 +581,7 @@ class PkcsCryptography(Pkcs):
             cert,
             self.other_certificates,
             serialization.BestAvailableEncryption(to_bytes(self.passphrase))
-            if self.passphrase is not None else serialization.NoEncryption(),
+            if self.passphrase else serialization.NoEncryption(),
         )
 
     def parse_bytes(self, pkcs12_content):

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -252,7 +252,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import
 )
 
 MINIMAL_CRYPTOGRAPHY_VERSION = '3.0'
-MINIMAL_PYOPENSSL_VERSION = '17.1.0'
+MINIMAL_PYOPENSSL_VERSION = '0.15'
 
 PYOPENSSL_IMP_ERR = None
 try:

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -1,246 +1,237 @@
 - block:
-  - name: Generate privatekey
-    openssl_privatekey:
-      path: '{{ output_dir }}/ansible_pkey.pem'
-      size: '{{ default_rsa_key_size_certifiates }}'
-  - name: Generate privatekey2
-    openssl_privatekey:
-      path: '{{ output_dir }}/ansible_pkey2.pem'
-      size: '{{ default_rsa_key_size_certifiates }}'
-  - name: Generate privatekey3
-    openssl_privatekey:
-      path: '{{ output_dir }}/ansible_pkey3.pem'
-      size: '{{ default_rsa_key_size_certifiates }}'
-  - name: Generate CSR
-    openssl_csr:
-      path: '{{ output_dir }}/ansible.csr'
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      commonName: www.ansible.com
-  - name: Generate CSR 2
-    openssl_csr:
-      path: '{{ output_dir }}/ansible2.csr'
-      privatekey_path: '{{ output_dir }}/ansible_pkey2.pem'
-      commonName: www2.ansible.com
-  - name: Generate CSR 3
-    openssl_csr:
-      path: '{{ output_dir }}/ansible3.csr'
-      privatekey_path: '{{ output_dir }}/ansible_pkey3.pem'
-      commonName: www3.ansible.com
-  - name: Generate certificate
-    x509_certificate:
-      path: '{{ output_dir }}/{{ item.name }}.crt'
-      privatekey_path: '{{ output_dir }}/{{ item.pkey }}'
-      csr_path: '{{ output_dir }}/{{ item.name }}.csr'
-      provider: selfsigned
-    loop:
-    - name: ansible
-      pkey: ansible_pkey.pem
-    - name: ansible2
-      pkey: ansible_pkey2.pem
-    - name: ansible3
-      pkey: ansible_pkey3.pem
-  - name: Generate concatenated PEM file
-    copy:
-      dest: '{{ output_dir }}/ansible23.crt'
-      content: |
-        {{ lookup("file", output_dir ~ "/ansible2.crt") }}
-        {{ lookup("file", output_dir ~ "/ansible3.crt") }}
-  - name: Generate PKCS#12 file
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       return_content: true
     register: p12_standard
-  - name: Generate PKCS#12 file again, idempotency
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file again, idempotency"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       return_content: true
     register: p12_standard_idempotency
-  - name: Read ansible.p12
+
+  - name: "({{ select_crypto_backend }}) Read ansible.p12"
     slurp:
       src: '{{ output_dir }}/ansible.p12'
     register: ansible_p12_content
-  - name: Validate PKCS#12
+
+  - name: "({{ select_crypto_backend }}) Validate PKCS#12"
     assert:
       that:
       - p12_standard.pkcs12 == ansible_p12_content.content
       - p12_standard_idempotency.pkcs12 == p12_standard.pkcs12
-  - name: Generate PKCS#12 file (force)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (force)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       force: true
     register: p12_force
-  - name: Generate PKCS#12 file (force + change mode)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (force + change mode)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       force: true
       mode: '0644'
     register: p12_force_and_mode
-  - name: Dump PKCS#12
+
+  - name: "({{ select_crypto_backend }}) Dump PKCS#12"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible.p12'
       path: '{{ output_dir }}/ansible_parse.pem'
       action: parse
       state: present
     register: p12_dumped
-  - name: Dump PKCS#12 file again, idempotency
+
+  - name: "({{ select_crypto_backend }}) Dump PKCS#12 file again, idempotency"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible.p12'
       path: '{{ output_dir }}/ansible_parse.pem'
       action: parse
       state: present
     register: p12_dumped_idempotency
-  - name: Dump PKCS#12, check mode
+
+  - name: "({{ select_crypto_backend }}) Dump PKCS#12, check mode"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible.p12'
       path: '{{ output_dir }}/ansible_parse.pem'
       action: parse
       state: present
     check_mode: true
     register: p12_dumped_check_mode
-  - name: Generate PKCS#12 file with multiple certs
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_multi_certs.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       other_certificates:
       - '{{ output_dir }}/ansible2.crt'
       - '{{ output_dir }}/ansible3.crt'
       state: present
     register: p12_multiple_certs
-  - name: Generate PKCS#12 file with multiple certs, again (idempotency)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs, again (idempotency)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_multi_certs.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       other_certificates:
       - '{{ output_dir }}/ansible2.crt'
       - '{{ output_dir }}/ansible3.crt'
       state: present
     register: p12_multiple_certs_idempotency
-  - name: Dump PKCS#12 with multiple certs
+
+  - name: "({{ select_crypto_backend }}) Dump PKCS#12 with multiple certs"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible_multi_certs.p12'
       path: '{{ output_dir }}/ansible_parse_multi_certs.pem'
       action: parse
       state: present
-  - name: Generate privatekey with password
-    openssl_privatekey:
-      path: '{{ output_dir }}/privatekeypw.pem'
-      passphrase: hunter2
-      cipher: auto
-      size: '{{ default_rsa_key_size }}'
-      select_crypto_backend: cryptography
-  - name: Generate PKCS#12 file (password fail 1)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (password fail 1)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_pw1.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
       privatekey_passphrase: hunter2
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
     ignore_errors: true
     register: passphrase_error_1
-  - name: Generate PKCS#12 file (password fail 2)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (password fail 2)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_pw2.p12'
       friendly_name: abracadabra
       privatekey_path: '{{ output_dir }}/privatekeypw.pem'
       privatekey_passphrase: wrong_password
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
     ignore_errors: true
     register: passphrase_error_2
-  - name: Generate PKCS#12 file (password fail 3)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (password fail 3)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_pw3.p12'
       friendly_name: abracadabra
       privatekey_path: '{{ output_dir }}/privatekeypw.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
     ignore_errors: true
     register: passphrase_error_3
-  - name: Generate PKCS#12 file, no privatekey
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file, no privatekey"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_no_pkey.p12'
       friendly_name: abracadabra
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
     register: p12_no_pkey
-  - name: Create broken PKCS#12
+
+  - name: "({{ select_crypto_backend }}) Create broken PKCS#12"
     copy:
       dest: '{{ output_dir }}/broken.p12'
       content: broken
-  - name: Regenerate broken PKCS#12
+
+  - name: "({{ select_crypto_backend }}) Regenerate broken PKCS#12"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/broken.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       force: true
       mode: '0644'
     register: output_broken
-  - name: Generate PKCS#12 file
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_backup.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       backup: true
     register: p12_backup_1
-  - name: Generate PKCS#12 file (idempotent)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (idempotent)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_backup.p12'
       friendly_name: abracadabra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       backup: true
     register: p12_backup_2
-  - name: Generate PKCS#12 file (change)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (change)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_backup.p12'
       friendly_name: abra
-      privatekey_path: '{{ output_dir }}/ansible_pkey.pem'
-      certificate_path: '{{ output_dir }}/ansible.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
       state: present
       force: true
       backup: true
     register: p12_backup_3
-  - name: Generate PKCS#12 file (remove)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (remove)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_backup.p12'
       state: absent
       backup: true
       return_content: true
     register: p12_backup_4
-  - name: Generate PKCS#12 file (remove, idempotent)
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file (remove, idempotent)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_backup.p12'
       state: absent
       backup: true
     register: p12_backup_5
-  - name: Generate 'empty' PKCS#12 file
+
+  - name: "({{ select_crypto_backend }}) Generate 'empty' PKCS#12 file"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_empty.p12'
       friendly_name: abracadabra
       other_certificates:
@@ -248,8 +239,11 @@
       - '{{ output_dir }}/ansible3.crt'
       state: present
     register: p12_empty
-  - name: Generate 'empty' PKCS#12 file (idempotent)
+
+
+  - name: "({{ select_crypto_backend }}) Generate 'empty' PKCS#12 file (idempotent)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_empty.p12'
       friendly_name: abracadabra
       other_certificates:
@@ -257,8 +251,10 @@
       - '{{ output_dir }}/ansible2.crt'
       state: present
     register: p12_empty_idem
-  - name: Generate 'empty' PKCS#12 file (idempotent, concatenated other certificates)
+
+  - name: "({{ select_crypto_backend }}) Generate 'empty' PKCS#12 file (idempotent, concatenated other certificates)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_empty.p12'
       friendly_name: abracadabra
       other_certificates:
@@ -266,14 +262,18 @@
       other_certificates_parse_all: true
       state: present
     register: p12_empty_concat_idem
-  - name: Generate 'empty' PKCS#12 file (parse)
+
+  - name: "({{ select_crypto_backend }}) Generate 'empty' PKCS#12 file (parse)"
     openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible_empty.p12'
       path: '{{ output_dir }}/ansible_empty.pem'
       action: parse
+
   - import_tasks: ../tests/validate.yml
+
   always:
-  - name: Delete PKCS#12 file
+  - name: "({{ select_crypto_backend }}) Delete PKCS#12 file"
     openssl_pkcs12:
       state: absent
       path: '{{ output_dir }}/{{ item }}.p12'

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -4,6 +4,78 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- name: Run tests
-  include_tasks: impl.yml
-  when: pyopenssl_version.stdout is version('17.1.0', '>=')
+- name: Generate private keys
+  openssl_privatekey:
+    path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
+    size: '{{ default_rsa_key_size_certifiates }}'
+  loop:
+    - 1
+    - 2
+    - 3
+
+- name: Generate privatekey with password
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekeypw.pem'
+    passphrase: hunter2
+    cipher: auto
+    size: '{{ default_rsa_key_size }}'
+
+- name: Generate CSRs
+  openssl_csr:
+    path: '{{ output_dir }}/ansible{{ item }}.csr'
+    privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
+    commonName: www{{ item }}.ansible.com
+  loop:
+    - 1
+    - 2
+    - 3
+
+- name: Generate certificate
+  x509_certificate:
+    path: '{{ output_dir }}/{{ item.name }}.crt'
+    privatekey_path: '{{ output_dir }}/{{ item.pkey }}'
+    csr_path: '{{ output_dir }}/{{ item.name }}.csr'
+    provider: selfsigned
+  loop:
+  - name: ansible1
+    pkey: ansible_pkey1.pem
+  - name: ansible2
+    pkey: ansible_pkey2.pem
+  - name: ansible3
+    pkey: ansible_pkey3.pem
+
+- name: Generate concatenated PEM file
+  copy:
+    dest: '{{ output_dir }}/ansible23.crt'
+    content: |
+      {{ lookup("file", output_dir ~ "/ansible2.crt") }}
+      {{ lookup("file", output_dir ~ "/ansible3.crt") }}
+
+- name: Generate PKCS#12 file with backend autodetection
+  openssl_pkcs12:
+    path: '{{ output_dir }}/ansible.p12'
+    friendly_name: abracadabra
+    privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+    certificate_path: '{{ output_dir }}/ansible1.crt'
+    state: present
+
+- name: Delete result
+  file:
+    path: '{{ output_dir }}/ansible.p12'
+    state: absent
+
+- block:
+  - name: Running tests with pyOpenSSL backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: pyopenssl
+
+  when: pyopenssl_version.stdout is version('1.5', '>=')
+
+- block:
+  - name: Running tests with cryptography backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: cryptography
+
+  when: cryptography_version.stdout is version('3.0', '>=')

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -4,78 +4,81 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- name: Generate private keys
-  openssl_privatekey:
-    path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
-    size: '{{ default_rsa_key_size_certifiates }}'
-  loop:
-    - 1
-    - 2
-    - 3
-
-- name: Generate privatekey with password
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekeypw.pem'
-    passphrase: hunter2
-    cipher: auto
-    size: '{{ default_rsa_key_size }}'
-
-- name: Generate CSRs
-  openssl_csr:
-    path: '{{ output_dir }}/ansible{{ item }}.csr'
-    privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
-    commonName: www{{ item }}.ansible.com
-  loop:
-    - 1
-    - 2
-    - 3
-
-- name: Generate certificate
-  x509_certificate:
-    path: '{{ output_dir }}/{{ item.name }}.crt'
-    privatekey_path: '{{ output_dir }}/{{ item.pkey }}'
-    csr_path: '{{ output_dir }}/{{ item.name }}.csr'
-    provider: selfsigned
-  loop:
-  - name: ansible1
-    pkey: ansible_pkey1.pem
-  - name: ansible2
-    pkey: ansible_pkey2.pem
-  - name: ansible3
-    pkey: ansible_pkey3.pem
-
-- name: Generate concatenated PEM file
-  copy:
-    dest: '{{ output_dir }}/ansible23.crt'
-    content: |
-      {{ lookup("file", output_dir ~ "/ansible2.crt") }}
-      {{ lookup("file", output_dir ~ "/ansible3.crt") }}
-
-- name: Generate PKCS#12 file with backend autodetection
-  openssl_pkcs12:
-    path: '{{ output_dir }}/ansible.p12'
-    friendly_name: abracadabra
-    privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
-    certificate_path: '{{ output_dir }}/ansible1.crt'
-    state: present
-
-- name: Delete result
-  file:
-    path: '{{ output_dir }}/ansible.p12'
-    state: absent
-
 - block:
-  - name: Running tests with pyOpenSSL backend
-    include_tasks: impl.yml
-    vars:
-      select_crypto_backend: pyopenssl
+  - name: Generate private keys
+    openssl_privatekey:
+      path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
+      size: '{{ default_rsa_key_size_certifiates }}'
+    loop:
+      - 1
+      - 2
+      - 3
 
-  when: pyopenssl_version.stdout is version('1.5', '>=')
+  - name: Generate privatekey with password
+    openssl_privatekey:
+      path: '{{ output_dir }}/privatekeypw.pem'
+      passphrase: hunter2
+      cipher: auto
+      size: '{{ default_rsa_key_size }}'
 
-- block:
-  - name: Running tests with cryptography backend
-    include_tasks: impl.yml
-    vars:
-      select_crypto_backend: cryptography
+  - name: Generate CSRs
+    openssl_csr:
+      path: '{{ output_dir }}/ansible{{ item }}.csr'
+      privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
+      commonName: www{{ item }}.ansible.com
+    loop:
+      - 1
+      - 2
+      - 3
 
-  when: cryptography_version.stdout is version('3.0', '>=')
+  - name: Generate certificate
+    x509_certificate:
+      path: '{{ output_dir }}/{{ item.name }}.crt'
+      privatekey_path: '{{ output_dir }}/{{ item.pkey }}'
+      csr_path: '{{ output_dir }}/{{ item.name }}.csr'
+      provider: selfsigned
+    loop:
+    - name: ansible1
+      pkey: ansible_pkey1.pem
+    - name: ansible2
+      pkey: ansible_pkey2.pem
+    - name: ansible3
+      pkey: ansible_pkey3.pem
+
+  - name: Generate concatenated PEM file
+    copy:
+      dest: '{{ output_dir }}/ansible23.crt'
+      content: |
+        {{ lookup("file", output_dir ~ "/ansible2.crt") }}
+        {{ lookup("file", output_dir ~ "/ansible3.crt") }}
+
+  - name: Generate PKCS#12 file with backend autodetection
+    openssl_pkcs12:
+      path: '{{ output_dir }}/ansible.p12'
+      friendly_name: abracadabra
+      privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ output_dir }}/ansible1.crt'
+      state: present
+
+  - name: Delete result
+    file:
+      path: '{{ output_dir }}/ansible.p12'
+      state: absent
+
+  - block:
+    - name: Running tests with pyOpenSSL backend
+      include_tasks: impl.yml
+      vars:
+        select_crypto_backend: pyopenssl
+
+    when: pyopenssl_version.stdout is version('17.1.0', '>=')
+
+  - block:
+    - name: Running tests with cryptography backend
+      include_tasks: impl.yml
+      vars:
+        select_crypto_backend: cryptography
+
+    when: cryptography_version.stdout is version('3.0', '>=')
+
+  when: pyopenssl_version.stdout is version('17.1.0', '>=') or cryptography_version.stdout is version('3.0', '>=')

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -71,7 +71,7 @@
       vars:
         select_crypto_backend: pyopenssl
 
-    when: pyopenssl_version.stdout is version('17.1.0', '>=')
+    when: pyopenssl_version.stdout is version('0.15', '>=')
 
   - block:
     - name: Running tests with cryptography backend
@@ -81,4 +81,4 @@
 
     when: cryptography_version.stdout is version('3.0', '>=')
 
-  when: pyopenssl_version.stdout is version('17.1.0', '>=') or cryptography_version.stdout is version('3.0', '>=')
+  when: pyopenssl_version.stdout is version('0.15', '>=') or cryptography_version.stdout is version('3.0', '>=')

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -9,7 +9,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
       size: '{{ default_rsa_key_size_certifiates }}'
-    loop: "{{ range(1, 4) }}"
+    loop: "{{ range(1, 4) | list }}"
 
   - name: Generate privatekey with password
     openssl_privatekey:
@@ -23,7 +23,7 @@
       path: '{{ output_dir }}/ansible{{ item }}.csr'
       privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
       commonName: www{{ item }}.ansible.com
-    loop: "{{ range(1, 4) }}"
+    loop: "{{ range(1, 4) | list }}"
 
   - name: Generate certificate
     x509_certificate:
@@ -31,7 +31,7 @@
       privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
       csr_path: '{{ output_dir }}/ansible{{ item }}.csr'
       provider: selfsigned
-    loop: "{{ range(1, 4) }}"
+    loop: "{{ range(1, 4) | list }}"
 
   - name: Generate concatenated PEM file
     copy:

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -9,10 +9,7 @@
     openssl_privatekey:
       path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
       size: '{{ default_rsa_key_size_certifiates }}'
-    loop:
-      - 1
-      - 2
-      - 3
+    loop: "{{ range(1, 4) }}"
 
   - name: Generate privatekey with password
     openssl_privatekey:
@@ -26,24 +23,15 @@
       path: '{{ output_dir }}/ansible{{ item }}.csr'
       privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
       commonName: www{{ item }}.ansible.com
-    loop:
-      - 1
-      - 2
-      - 3
+    loop: "{{ range(1, 4) }}"
 
   - name: Generate certificate
     x509_certificate:
-      path: '{{ output_dir }}/{{ item.name }}.crt'
-      privatekey_path: '{{ output_dir }}/{{ item.pkey }}'
-      csr_path: '{{ output_dir }}/{{ item.name }}.csr'
+      path: '{{ output_dir }}/ansible{{ item }}.crt'
+      privatekey_path: '{{ output_dir }}/ansible_pkey{{ item }}.pem'
+      csr_path: '{{ output_dir }}/ansible{{ item }}.csr'
       provider: selfsigned
-    loop:
-    - name: ansible1
-      pkey: ansible_pkey1.pem
-    - name: ansible2
-      pkey: ansible_pkey2.pem
-    - name: ansible3
-      pkey: ansible_pkey3.pem
+    loop: "{{ range(1, 4) }}"
 
   - name: Generate concatenated PEM file
     copy:

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -1,17 +1,17 @@
 ---
-- name: 'Validate PKCS#12'
+- name: '({{ select_crypto_backend }}) Validate PKCS#12'
   command: "{{ openssl_binary }} pkcs12 -info -in {{ output_dir }}/ansible.p12 -nodes -passin pass:''"
   register: p12
 
-- name: 'Validate PKCS#12 with no private key'
+- name: '({{ select_crypto_backend }}) Validate PKCS#12 with no private key'
   command: "{{ openssl_binary }} pkcs12 -info -in {{ output_dir }}/ansible_no_pkey.p12 -nodes -passin pass:''"
   register: p12_validate_no_pkey
 
-- name: 'Validate PKCS#12 with multiple certs'
+- name: '({{ select_crypto_backend }}) Validate PKCS#12 with multiple certs'
   shell: "{{ openssl_binary }} pkcs12 -info -in {{ output_dir }}/ansible_multi_certs.p12 -nodes -passin pass:'' | grep subject"
   register: p12_validate_multi_certs
 
-- name: 'Validate PKCS#12 (assert)'
+- name: '({{ select_crypto_backend }}) Validate PKCS#12 (assert)'
   assert:
     that:
       - p12.stdout_lines[2].split(':')[-1].strip() == 'abracadabra'
@@ -25,11 +25,11 @@
       - not p12_multiple_certs_idempotency.changed
       - not p12_dumped_idempotency.changed
       - not p12_dumped_check_mode.changed
-      - "'www.' in p12_validate_multi_certs.stdout"
+      - "'www1.' in p12_validate_multi_certs.stdout"
       - "'www2.' in p12_validate_multi_certs.stdout"
       - "'www3.' in p12_validate_multi_certs.stdout"
 
-- name: Check passphrase on private key
+- name: '({{ select_crypto_backend }}) Check passphrase on private key'
   assert:
     that:
       - passphrase_error_1 is failed
@@ -39,12 +39,12 @@
       - passphrase_error_3 is failed
       - "'assphrase' in passphrase_error_3.msg or 'assword' in passphrase_error_3.msg or 'serializ' in passphrase_error_3.msg"
 
-- name: "Verify that broken PKCS#12 will be regenerated"
+- name: '({{ select_crypto_backend }}) Verify that broken PKCS#12 will be regenerated'
   assert:
     that:
       - output_broken is changed
 
-- name: Check backup
+- name: '({{ select_crypto_backend }}) Check backup'
   assert:
     that:
       - p12_backup_1 is changed
@@ -59,10 +59,16 @@
       - p12_backup_5.backup_file is undefined
       - p12_backup_4.pkcs12 is none
 
-- name: Check 'empty' file
+- name: '({{ select_crypto_backend }}) Load "empty" file'
+  set_fact:
+    empty_contents: "{{ lookup('file', output_dir ~ '/ansible_empty.pem') }}"
+    empty_expected_pyopenssl: "{{ lookup('file', output_dir ~ '/ansible3.crt') ~ '\n' ~ lookup('file', output_dir ~ '/ansible2.crt') }}"
+    empty_expected_cryptography: "{{ lookup('file', output_dir ~ '/ansible2.crt') ~ '\n' ~ lookup('file', output_dir ~ '/ansible3.crt') }}"
+
+- name: '({{ select_crypto_backend }}) Check "empty" file'
   assert:
     that:
       - p12_empty is changed
       - p12_empty_idem is not changed
       - p12_empty_concat_idem is not changed
-      - "lookup('file', output_dir ~ '/ansible_empty.pem') == lookup('file', output_dir ~ '/ansible3.crt') ~ '\n' ~ lookup('file', output_dir ~ '/ansible2.crt')"
+      - empty_contents == (empty_expected_pyopenssl if select_crypto_backend == 'pyopenssl' else empty_expected_cryptography)


### PR DESCRIPTION
##### SUMMARY
This requires cryptography 3.0 and @Ajpantuso's [hack](https://github.com/pyca/cryptography/issues/5760#issuecomment-842687238), so we can't deprecate pyOpenSSL anytime soon.

Also this is at the moment pretty ugly, I'll have to do a lot more cleanup...

Finally, `iter_size` and `maciter_size` are not supported. Also, the cryptography docs say `PKCS12 encryption is not secure and should not be used as a security mechanism. Wrap a PKCS12 blob in a more secure envelope if you need to store or send it safely. Encryption is provided for compatibility reasons only.`.

Fixes #21.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_pkcs12
