### PR TITLE
openssl_publickey_info: remove unnecessary and undocumented return values

### DIFF
--- a/plugins/module_utils/crypto/module_backends/publickey_info.py
+++ b/plugins/module_utils/crypto/module_backends/publickey_info.py
@@ -210,10 +210,7 @@ class PublicKeyInfoRetrieval(object):
         pass
 
     def get_info(self):
-        result = dict(
-            can_parse_key=False,
-            key_is_consistent=None,
-        )
+        result = dict()
         if self.key is None:
             try:
                 self.key = load_publickey(content=self.content, backend=self.backend)


### PR DESCRIPTION
##### SUMMARY
The code fails anyway when not being able to load and parse public keys.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_publickey_info
