### PR TITLE
[WIP] openssh_cert - add passphrase option for signing key

### DIFF
--- a/changelogs/fragments/239-openssh_cert-passphrase.yml
+++ b/changelogs/fragments/239-openssh_cert-passphrase.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openssh_cert - added ``passphrase`` parameter for encrypting/decrypting signing keys (https://github.com/ansible-collections/community.crypto/pull/239).

--- a/tests/integration/targets/openssh_cert/meta/main.yml
+++ b/tests/integration/targets/openssh_cert/meta/main.yml
@@ -2,3 +2,4 @@ dependencies:
   - setup_ssh_keygen
   - setup_ssh_agent
   - setup_openssl
+  - setup_bcrypt

--- a/tests/integration/targets/openssh_cert/meta/main.yml
+++ b/tests/integration/targets/openssh_cert/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - setup_ssh_keygen
   - setup_ssh_agent
+  - setup_openssl

--- a/tests/integration/targets/openssh_cert/tasks/main.yml
+++ b/tests/integration/targets/openssh_cert/tasks/main.yml
@@ -342,6 +342,15 @@
       that:
         - rc_serial_number_ignored is not changed
       msg: OpenSSH certificate generation with omitted serial number is idempotent.
+  - name: Generate cert using passphrase option with unencrypted private key
+    openssh_cert:
+      type: user
+      signing_key: '{{ output_dir }}/id_key'
+      passphrase:
+      public_key: '{{ output_dir }}/id_key.pub'
+      path: '{{ output_dir }}/id_cert_unencrypted_key'
+      valid_from: always
+      valid_to: forever
   - name: Remove certificate (check mode)
     openssh_cert:
       state: absent
@@ -380,9 +389,9 @@
       #valid_from: "2001-01-21"
       #valid_to: "2019-01-21"
     check_mode: yes
-  - name: Remove keypair
+  - name: Remove keypairs
     openssh_keypair:
-      path: '{{ output_dir }}/id_key'
+      path: "{{ output_dir }}/id_key"
       state: absent
 
 - name: openssh_cert integration tests that require ssh-agent
@@ -465,3 +474,28 @@
     openssh_cert:
       state: absent
       path: '{{ output_dir }}/id_cert_with_agent'
+
+  - block:
+    - name: Generate keypair with encrypted private key
+      openssh_keypair:
+        path: '{{ private_key_path }}'
+        passphrase: '{{ passphrase }}'
+        type: rsa
+        size: 2048
+    - name: Generate cert using encrypted signing key
+      openssh_cert:
+        type: user
+        signing_key: '{{ private_key_path }}'
+        passphrase: '{{ passphrase }}'
+        public_key: '{{ private_key_path }}.pub'
+        path: '{{ output_dir }}/id_cert_encrypted_key'
+        valid_from: always
+        valid_to: forever
+    - name: Remove keypair with encrypted private key
+      openssh_keypair:
+        path: '{{ output_dir }}/id_encrypted_key'
+        state: absent
+    when: cryptography_version.stdout is version("2.6", ">=")
+    vars:
+      private_key_path: '{{ output_dir }}/id_encrypted_key'
+      passphrase: password


### PR DESCRIPTION
##### SUMMARY
Adding `passphrase` option to `openssh_cert` so that an encrypted signing key may be used during certificate generation. `cryptography >= 2.6` is required on the target host to utilize this new feature.

Fixes #195 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_cert.py

##### ADDITIONAL INFORMATION
- The encrypted key passed by the user is opened with `cryptography`, decrypted, and written to a temp location already setup in previous versions of this module.
- After `ssh-keygen` is invoked with the decrypted password the temp directory containing any sensitive data is recursively removed.
- No other functional changes are included/intended with this PR.