### PR TITLE
Fix openssl_pkcs12 crash with cryptography backend when loading passphrase-protected files

### DIFF
--- a/changelogs/fragments/248-openssl_pkcs12-passphrase-fix.yml
+++ b/changelogs/fragments/248-openssl_pkcs12-passphrase-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_pkcs12 - fix crash when loading passphrase-protected PKCS#12 files with ``cryptography`` backend (https://github.com/ansible-collections/community.crypto/issues/247, https://github.com/ansible-collections/community.crypto/pull/248)."

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -23,7 +23,7 @@ import base64
 import binascii
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 from ._asn1 import serialize_asn1_string_as_der
 
 try:
@@ -444,7 +444,8 @@ def parse_pkcs12(pkcs12_bytes, passphrase=None):
     '''
     if _load_key_and_certificates is None:
         raise ValueError('load_key_and_certificates() not present in the current cryptography version')
-    private_key, certificate, additional_certificates = _load_key_and_certificates(pkcs12_bytes, passphrase)
+    private_key, certificate, additional_certificates = _load_key_and_certificates(
+        pkcs12_bytes, to_bytes(passphrase) if passphrase is not None else None)
 
     friendly_name = None
     if certificate:

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -107,11 +107,12 @@
     check_mode: true
     register: p12_dumped_check_mode
 
-  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs"
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs and passphrase"
     openssl_pkcs12:
       select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_multi_certs.p12'
       friendly_name: abracadabra
+      passphrase: hunter3
       privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
       certificate_path: '{{ output_dir }}/ansible1.crt'
       other_certificates:
@@ -120,11 +121,12 @@
       state: present
     register: p12_multiple_certs
 
-  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs, again (idempotency)"
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file with multiple certs and passphrase, again (idempotency)"
     openssl_pkcs12:
       select_crypto_backend: '{{ select_crypto_backend }}'
       path: '{{ output_dir }}/ansible_multi_certs.p12'
       friendly_name: abracadabra
+      passphrase: hunter3
       privatekey_path: '{{ output_dir }}/ansible_pkey1.pem'
       certificate_path: '{{ output_dir }}/ansible1.crt'
       other_certificates:
@@ -133,11 +135,12 @@
       state: present
     register: p12_multiple_certs_idempotency
 
-  - name: "({{ select_crypto_backend }}) Dump PKCS#12 with multiple certs"
+  - name: "({{ select_crypto_backend }}) Dump PKCS#12 with multiple certs and passphrase"
     openssl_pkcs12:
       select_crypto_backend: '{{ select_crypto_backend }}'
       src: '{{ output_dir }}/ansible_multi_certs.p12'
       path: '{{ output_dir }}/ansible_parse_multi_certs.pem'
+      passphrase: hunter3
       action: parse
       state: present
 

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -8,7 +8,7 @@
   register: p12_validate_no_pkey
 
 - name: '({{ select_crypto_backend }}) Validate PKCS#12 with multiple certs'
-  shell: "{{ openssl_binary }} pkcs12 -info -in {{ output_dir }}/ansible_multi_certs.p12 -nodes -passin pass:'' | grep subject"
+  shell: "{{ openssl_binary }} pkcs12 -info -in {{ output_dir }}/ansible_multi_certs.p12 -nodes -passin pass:'hunter3' | grep subject"
   register: p12_validate_multi_certs
 
 - name: '({{ select_crypto_backend }}) Validate PKCS#12 (assert)'


### PR DESCRIPTION
##### SUMMARY
Fixes #247. Also adds tests for this case to prevent regressions in the future.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/crypto/cryptography_support.py
