### PR TITLE
Fix module name in docs

### DIFF
--- a/plugins/modules/openssl_privatekey_pipe.py
+++ b/plugins/modules/openssl_privatekey_pipe.py
@@ -68,7 +68,7 @@ EXAMPLES = r'''
       no_log: true  # make sure that private key data is not accidentally revealed in logs!
 
     - name: Update encrypted key when openssl_privatekey_pipe reported a change
-      community.sops.encrypt_sops:
+      community.sops.sops_encrypt:
         path: private_key.pem.sops
         content_text: "{{ output.privatekey }}"
       when: output is changed


### PR DESCRIPTION
##### SUMMARY
The module is called `sops_encrypt`, not `encrypt_sops` (https://docs.ansible.com/ansible/latest/collections/community/sops/sops_encrypt_module.html).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/openssl_privatekey_pipe.py
