### PR TITLE
Replace ansible.module_utils._text by ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/ansible-core-_text.yml
+++ b/changelogs/fragments/ansible-core-_text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Avoid internal ansible-core module_utils in favor of equivalent public API available since at least Ansible 2.9 (https://github.com/ansible-collections/community.crypto/pull/253)."

--- a/plugins/action/openssl_privatekey_pipe.py
+++ b/plugins/action/openssl_privatekey_pipe.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import base64
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 from ansible_collections.community.crypto.plugins.plugin_utils.action_module import ActionModuleBase
 

--- a/plugins/module_utils/acme/__init__.py
+++ b/plugins/module_utils/acme/__init__.py
@@ -25,7 +25,7 @@ import traceback
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import unquote
-from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.acme import (
     get_default_argspec,

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -15,7 +15,7 @@ import locale
 
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.backend_openssl_cli import (
     OpenSSLCLIBackend,

--- a/plugins/module_utils/acme/backend_cryptography.py
+++ b/plugins/module_utils/acme/backend_cryptography.py
@@ -14,7 +14,7 @@ import datetime
 import os
 import sys
 
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.backends import (
     CryptoBackend,

--- a/plugins/module_utils/acme/backend_openssl_cli.py
+++ b/plugins/module_utils/acme/backend_openssl_cli.py
@@ -16,7 +16,7 @@ import re
 import tempfile
 import traceback
 
-from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.backends import (
     CryptoBackend,

--- a/plugins/module_utils/acme/challenges.py
+++ b/plugins/module_utils/acme/challenges.py
@@ -14,7 +14,7 @@ import json
 import re
 import time
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.compat import ipaddress as compat_ipaddress
 

--- a/plugins/module_utils/acme/errors.py
+++ b/plugins/module_utils/acme/errors.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import binary_type
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 def format_error_problem(problem, subproblem_prefix=''):

--- a/plugins/module_utils/acme/io.py
+++ b/plugins/module_utils/acme/io.py
@@ -14,7 +14,7 @@ import shutil
 import tempfile
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.errors import ModuleFailException
 

--- a/plugins/module_utils/acme/utils.py
+++ b/plugins/module_utils/acme/utils.py
@@ -13,7 +13,7 @@ import re
 import textwrap
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves.urllib.parse import unquote
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.errors import ModuleFailException

--- a/plugins/module_utils/crypto/_asn1.py
+++ b/plugins/module_utils/crypto/_asn1.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import re
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 """

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -23,7 +23,7 @@ import base64
 import binascii
 import re
 
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 from ._asn1 import serialize_asn1_string_as_der
 
 try:

--- a/plugins/module_utils/crypto/module_backends/certificate_acme.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_acme.py
@@ -12,7 +12,7 @@ import os
 import tempfile
 import traceback
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.certificate import (
     CertificateError,

--- a/plugins/module_utils/crypto/module_backends/certificate_assertonly.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_assertonly.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 import abc
 import datetime
 
-from ansible.module_utils._text import to_native, to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.support import (
     parse_name_field,

--- a/plugins/module_utils/crypto/module_backends/certificate_entrust.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_entrust.py
@@ -12,7 +12,7 @@ import datetime
 import time
 import os
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.ecs.api import ECSClient, RestOperationException, SessionConfigurationException
 

--- a/plugins/module_utils/crypto/module_backends/certificate_info.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_info.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.support import (
     load_certificate,

--- a/plugins/module_utils/crypto/module_backends/certificate_ownca.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_ownca.py
@@ -13,7 +13,7 @@ import os
 from distutils.version import LooseVersion
 from random import randrange
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLBadPassphraseError,

--- a/plugins/module_utils/crypto/module_backends/certificate_selfsigned.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_selfsigned.py
@@ -12,7 +12,7 @@ import os
 
 from random import randrange
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.support import (
     get_relative_time_option,

--- a/plugins/module_utils/crypto/module_backends/csr.py
+++ b/plugins/module_utils/crypto/module_backends/csr.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/module_utils/crypto/module_backends/csr_info.py
+++ b/plugins/module_utils/crypto/module_backends/csr_info.py
@@ -17,7 +17,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.support import (
     load_certificate_request,

--- a/plugins/module_utils/crypto/module_backends/privatekey.py
+++ b/plugins/module_utils/crypto/module_backends/privatekey.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     CRYPTOGRAPHY_HAS_X25519,

--- a/plugins/module_utils/crypto/module_backends/privatekey_info.py
+++ b/plugins/module_utils/crypto/module_backends/privatekey_info.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     CRYPTOGRAPHY_HAS_ED25519,

--- a/plugins/module_utils/crypto/module_backends/publickey_info.py
+++ b/plugins/module_utils/crypto/module_backends/publickey_info.py
@@ -14,7 +14,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     CRYPTOGRAPHY_HAS_X25519,

--- a/plugins/module_utils/crypto/pyopenssl_support.py
+++ b/plugins/module_utils/crypto/pyopenssl_support.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 import base64
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.compat import ipaddress as compat_ipaddress
 

--- a/plugins/module_utils/crypto/support.py
+++ b/plugins/module_utils/crypto/support.py
@@ -27,7 +27,7 @@ import os
 import re
 
 from ansible.module_utils import six
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 try:
     from OpenSSL import crypto

--- a/plugins/module_utils/ecs/api.py
+++ b/plugins/module_utils/ecs/api.py
@@ -37,7 +37,7 @@ import re
 import time
 import traceback
 
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.six.moves.urllib.error import HTTPError

--- a/plugins/modules/acme_challenge_cert_helper.py
+++ b/plugins/modules/acme_challenge_cert_helper.py
@@ -143,7 +143,7 @@ import sys
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.errors import ModuleFailException
 

--- a/plugins/modules/acme_inspect.py
+++ b/plugins/modules/acme_inspect.py
@@ -241,7 +241,7 @@ output_json:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.acme import (
     create_backend,

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -122,7 +122,7 @@ import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import (
     split_pem_list,

--- a/plugins/modules/ecs_certificate.py
+++ b/plugins/modules/ecs_certificate.py
@@ -522,7 +522,7 @@ import traceback
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     write_file,

--- a/plugins/modules/ecs_domain.py
+++ b/plugins/modules/ecs_domain.py
@@ -202,7 +202,7 @@ import datetime
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.ecs.api import (
     ecs_client_argument_spec,

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -165,7 +165,7 @@ from socket import create_connection, setdefaulttimeout, socket
 from ssl import get_server_certificate, DER_cert_to_PEM_cert, CERT_NONE, CERT_REQUIRED
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.cryptography_support import (
     cryptography_oid_to_name,

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -226,7 +226,7 @@ from distutils.version import LooseVersion
 from shutil import copy2, rmtree
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.support import convert_relative_to_datetime
 from ansible_collections.community.crypto.plugins.module_utils.openssh.utils import parse_openssh_version

--- a/plugins/modules/openssl_csr.py
+++ b/plugins/modules/openssl_csr.py
@@ -236,7 +236,7 @@ csr:
 
 import os
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.csr import (
     select_backend,

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -297,7 +297,7 @@ authority_cert_serial_number:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/modules/openssl_csr_pipe.py
+++ b/plugins/modules/openssl_csr_pipe.py
@@ -115,7 +115,7 @@ csr:
     type: str
 '''
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.csr import (
     select_backend,

--- a/plugins/modules/openssl_dhparam.py
+++ b/plugins/modules/openssl_dhparam.py
@@ -131,7 +131,7 @@ import traceback
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     load_file_if_exists,

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -242,7 +242,7 @@ import traceback
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     load_file_if_exists,

--- a/plugins/modules/openssl_privatekey.py
+++ b/plugins/modules/openssl_privatekey.py
@@ -144,7 +144,7 @@ privatekey:
 import os
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     load_file_if_exists,

--- a/plugins/modules/openssl_privatekey_info.py
+++ b/plugins/modules/openssl_privatekey_info.py
@@ -195,7 +195,7 @@ private_data:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/modules/openssl_publickey.py
+++ b/plugins/modules/openssl_publickey.py
@@ -185,7 +185,7 @@ import traceback
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     load_file_if_exists,

--- a/plugins/modules/openssl_publickey_info.py
+++ b/plugins/modules/openssl_publickey_info.py
@@ -157,7 +157,7 @@ public_data:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/modules/openssl_signature.py
+++ b/plugins/modules/openssl_signature.py
@@ -139,7 +139,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.support im
     load_privatekey,
 )
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 

--- a/plugins/modules/openssl_signature_info.py
+++ b/plugins/modules/openssl_signature_info.py
@@ -139,7 +139,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.support im
     load_certificate,
 )
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 

--- a/plugins/modules/x509_certificate.py
+++ b/plugins/modules/x509_certificate.py
@@ -362,7 +362,7 @@ certificate:
 
 import os
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.certificate import (
     select_backend,

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -377,7 +377,7 @@ ocsp_uri:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/modules/x509_certificate_pipe.py
+++ b/plugins/modules/x509_certificate_pipe.py
@@ -125,7 +125,7 @@ certificate:
 
 import os
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.certificate import (
     select_backend,

--- a/plugins/modules/x509_crl.py
+++ b/plugins/modules/x509_crl.py
@@ -370,7 +370,7 @@ import traceback
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.io import (
     write_file,

--- a/plugins/modules/x509_crl_info.py
+++ b/plugins/modules/x509_crl_info.py
@@ -152,7 +152,7 @@ import base64
 import binascii
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
     OpenSSLObjectError,

--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -60,7 +60,7 @@ from ansible.module_utils.six import (
     string_types,
     text_type,
 )
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.action import ActionBase
 
 


### PR DESCRIPTION
##### SUMMARY
While the private API `ansible.module_utils._text` was the default place to get `to_text`, `to_bytes` and `to_native` for a long time, at least since Ansible 2.9 there's a non-private alternative: `ansible.module_utils.common.text.converters`. So let's use it :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various plugins
