### PR TITLE
fix custom file attributes for public keys

### DIFF
--- a/changelogs/fragments/257-openssh-keypair-fix-pubkey-permissions.yml
+++ b/changelogs/fragments/257-openssh-keypair-fix-pubkey-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openssh_keypair - fixed a bug that prevented custom file attributes being applied to public keys (https://github.com/ansible-collections/community.crypto/pull/257).

--- a/plugins/module_utils/openssh/backends/keypair_backend.py
+++ b/plugins/module_utils/openssh/backends/keypair_backend.py
@@ -118,7 +118,9 @@ class KeypairBackend(object):
                     self.module.fail_json(msg='Unable to update the comment for the public key.')
                 self._update_comment()
 
-        if self._permissions_changed() or self._permissions_changed(public_key=True):
+        private_key_perms_changed = self._permissions_changed()
+        public_key_perms_changed = self._permissions_changed(public_key=True)
+        if private_key_perms_changed or public_key_perms_changed:
             self.changed = True
 
     def is_private_key_valid(self, perms_required=True):

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -122,6 +122,7 @@ notes:
     - In case the ssh key is broken or password protected, the module will fail.
       Set the I(force) option to C(yes) if you want to regenerate the keypair.
     - Supports C(check_mode).
+    - In the case a custom C(mode), C(group), C(owner), or other file attribute is provided it will be applied to both key files.
 
 extends_documentation_fragment: files
 '''


### PR DESCRIPTION
Use of the confusingly-named _permissions_changed() on both
sides of an `or` was resulting in the second invocation not
being reached if the first invocation returned True.

This is fixed by explicitly running both invocations
before evaluating the return values.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
