### PR TITLE
Improve CI: fix certificate_complete_chain tests

### DIFF
--- a/tests/integration/targets/certificate_complete_chain/meta/main.yml
+++ b/tests/integration/targets/certificate_complete_chain/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - setup_openssl
   - setup_remote_tmp_dir

--- a/tests/integration/targets/certificate_complete_chain/tasks/main.yml
+++ b/tests/integration/targets/certificate_complete_chain/tasks/main.yml
@@ -3,9 +3,6 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- name: register cryptography version
-  command: '{{ ansible_python.executable }} -c "import cryptography; print(cryptography.__version__)"'
-  register: cryptography_version
 - block:
   - name: Make sure testhost directory exists
     file:


### PR DESCRIPTION
##### SUMMARY
Currently they assume that `cryptography` is already installed, which works fine in the current system, but fails miserably with split-controller testing on RHEL 7.9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
certificate_complete_chain
