### PR TITLE
openssh_cert - adding signature_algorithm option

### DIFF
--- a/plugins/module_utils/openssh/backends/common.py
+++ b/plugins/module_utils/openssh/backends/common.py
@@ -160,7 +160,8 @@ class KeygenCommand(object):
         self._run_command = module.run_command
 
     def generate_certificate(self, certificate_path, identifier, options, pkcs11_provider, principals,
-                             serial_number, signing_key_path, type, time_parameters, use_agent, **kwargs):
+                             serial_number, signature_algorithm, signing_key_path, type,
+                             time_parameters, use_agent, **kwargs):
         args = [self._bin_path, '-s', signing_key_path, '-P', '', '-I', identifier]
 
         if options:
@@ -178,6 +179,8 @@ class KeygenCommand(object):
             args.extend(['-U'])
         if time_parameters.validity_string:
             args.extend(['-V', time_parameters.validity_string])
+        if signature_algorithm:
+            args.extend(['-t', signature_algorithm])
         args.append(certificate_path)
 
         return self._run_command(args, **kwargs)

--- a/plugins/module_utils/openssh/certificate.py
+++ b/plugins/module_utils/openssh/certificate.py
@@ -555,6 +555,11 @@ class OpensshCertificate(object):
     def signing_key(self):
         return to_text(self._cert_info.signing_key_fingerprint())
 
+    @property
+    def signature_type(self):
+        signature_data = OpensshParser.signature_data(self.signature)
+        return to_text(signature_data['signature_type'])
+
     @staticmethod
     def _parse_cert_info(pub_key_type, parser):
         cert_info = get_cert_info_object(pub_key_type)

--- a/plugins/module_utils/openssh/utils.py
+++ b/plugins/module_utils/openssh/utils.py
@@ -201,8 +201,9 @@ class OpensshParser(object):
         signature_blob = parser.string()
 
         blob_parser = cls(signature_blob)
-        if signature_type == b'ssh-rsa':
+        if signature_type in (b'ssh-rsa', b'rsa-sha2-256', b'rsa-sha2-512'):
             # https://datatracker.ietf.org/doc/html/rfc4253#section-6.6
+            # https://datatracker.ietf.org/doc/html/rfc8332#section-3
             signature_data['s'] = cls._big_int(signature_blob, "big")
         elif signature_type == b'ssh-dss':
             # https://datatracker.ietf.org/doc/html/rfc4253#section-6.6

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -49,7 +49,7 @@ options:
             - When C(fail) the task will fail if a certificate already exists at I(path) and does not
               match the module's options.
             - When C(partial_idempotence) an existing certificate will be regenerated based on
-              I(serial), I(type), I(valid_from), I(valid_to), I(valid_at), and I(principals).
+              I(serial), I(signature_algorithm), I(type), I(valid_from), I(valid_to), I(valid_at), and I(principals).
             - When C(full_idempotence) I(identifier), I(options), I(public_key), and I(signing_key)
               are also considered when compared against an existing certificate.
             - C(always) is equivalent to I(force=true).

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -73,7 +73,8 @@ options:
               can be used when generating host certificates (a corresponding change to the sshd_config to add C(ssh-rsa)
               to the C(CASignatureAlgorithms) keyword is also required).
             - Using any value for this option with a non-RSA I(signing_key) will cause this module to fail.
-            - "Note: OpenSSH versions prior to 7.2 do not support SHA-2 signature algorithms for RSA keys."
+            - "Note: OpenSSH versions prior to 7.2 do not support SHA-2 signature algorithms for RSA keys and OpenSSH
+               versions prior to 7.3 do not support SHA-2 signature algorithms for certificates."
             - See U(https://www.openssh.com/txt/release-8.2) for more information.
         type: str
         choices:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -93,7 +93,7 @@
         valid_from: always
         valid_to: forever
         regenerate: always
-  when: openssh_version is version("7.2", ">=")
+  when: openssh_version is version("7.3", ">=")
 
 - name: Generate cert with new signing key
   openssh_cert:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -20,6 +20,81 @@
     valid_from: always
     valid_to: forever
 
+- block:
+    - name: Generate cert with updated signature algorithm
+      openssh_cert:
+        type: user
+        path: "{{ certificate_path }}"
+        public_key: "{{ public_key }}"
+        signing_key: "{{ signing_key }}"
+        signature_algorithm: rsa-sha2-256
+        valid_from: always
+        valid_to: forever
+      register: updated_signature_algorithm
+
+    - name: Assert signature algorithm update causes change
+      assert:
+        that:
+          - updated_signature_algorithm is changed
+
+    - name: Generate cert with updated signature algorithm (idempotent)
+      openssh_cert:
+        type: user
+        path: "{{ certificate_path }}"
+        public_key: "{{ public_key }}"
+        signing_key: "{{ signing_key }}"
+        signature_algorithm: rsa-sha2-256
+        valid_from: always
+        valid_to: forever
+      register: updated_signature_algorithm_idempotent
+
+    - name: Assert signature algorithm update is idempotent
+      assert:
+        that:
+          - updated_signature_algorithm_idempotent is not changed
+
+    - name: Generate cert with original signature algorithm
+      openssh_cert:
+        type: user
+        path: "{{ certificate_path }}"
+        public_key: "{{ public_key }}"
+        signing_key: "{{ signing_key }}"
+        signature_algorithm: ssh-rsa
+        valid_from: always
+        valid_to: forever
+      register: second_signature_algorithm
+
+    - name: Assert second signature algorithm update causes change
+      assert:
+        that:
+          - second_signature_algorithm is changed
+
+    - name: Omit signature algorithm
+      openssh_cert:
+        type: user
+        path: "{{ certificate_path }}"
+        public_key: "{{ public_key }}"
+        signing_key: "{{ signing_key }}"
+        valid_from: always
+        valid_to: forever
+      register: omitted_signature_algorithm
+
+    - name: Assert omitted_signature_algorithm does not cause change
+      assert:
+        that:
+          - omitted_signature_algorithm is not changed
+
+    - name: Revert to original certificate
+      openssh_cert:
+        type: user
+        path: "{{ certificate_path }}"
+        public_key: "{{ public_key }}"
+        signing_key: "{{ signing_key }}"
+        valid_from: always
+        valid_to: forever
+        regenerate: always
+  when: openssh_version is version("7.2", ">=")
+
 - name: Generate cert with new signing key
   openssh_cert:
     type: user


### PR DESCRIPTION
##### SUMMARY
Adding a `signature_algorithm` option to `openssh_cert` to handle compatibility issues caused by the disabling of SHA-1 RSA keys with `OpenSSH` 8.2.

Closes #276

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_cert.py

##### ADDITIONAL INFORMATION
- Idempotency was maintained and should remain compatible with existing playbooks.