### PR TITLE
acme_challenge_cert_helper: fail better to avoid crashes in Ansible

### DIFF
--- a/changelogs/fragments/282-acme_challenge_cert_helper-error.yml
+++ b/changelogs/fragments/282-acme_challenge_cert_helper-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_challenge_cert_helper - only return exception when cryptography is not installed, not when a too old version of it is installed. This prevents Ansible's callback to crash (https://github.com/ansible-collections/community.crypto/pull/281)."

--- a/plugins/modules/acme_challenge_cert_helper.py
+++ b/plugins/modules/acme_challenge_cert_helper.py
@@ -202,7 +202,10 @@ def main():
         ),
     )
     if not HAS_CRYPTOGRAPHY:
-        module.fail_json(msg=missing_required_lib('cryptography >= 1.3'), exception=CRYPTOGRAPHY_IMP_ERR)
+        # Some callbacks die when exception is provided with value None
+        if CRYPTOGRAPHY_IMP_ERR:
+            module.fail_json(msg=missing_required_lib('cryptography >= 1.3'), exception=CRYPTOGRAPHY_IMP_ERR)
+        module.fail_json(msg=missing_required_lib('cryptography >= 1.3'))
 
     try:
         # Get parameters


### PR DESCRIPTION
##### SUMMARY
Modules which return `exception=None` in fail_json risk the Ansible callback to crash when trying to process the exception. Prevent this by only returning `exception` if it is not `None`. (It can be `None` if cryptography was found, but a version before 1.3.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_challenge_cert_helper
