### PR TITLE
openssh_keypair integration tests - Fix remote_tmp_dir cleanup task

### DIFF
--- a/tests/integration/targets/openssh_keypair/tests/regenerate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/regenerate.yml
@@ -5,12 +5,18 @@
 ####################################################################
 
 # Ensures no conflicts from previous test runs
+- name: "({{ backend }}) Find old test artifacts"
+  ansible.builtin.find:
+    paths: "{{ remote_tmp_dir }}"
+    patterns:
+      - "regenerate*"
+  register: old_test_artifacts
+
 - name: "({{ backend }}) Cleanup Output Directory"
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: absent
-  with_fileglob:
-    - "{{ remote_tmp_dir }}/regenerate*"
+  loop: "{{ old_test_artifacts.files }}"
 
 - name: "({{ backend }}) Regenerate - setup simple keys"
   openssh_keypair:


### PR DESCRIPTION
##### SUMMARY
Addresses a necessary fix to support split-controller testing as brought up [here](https://github.com/ansible-collections/community.crypto/pull/284#issuecomment-926090473)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/openssh_keypair/tests/regenerate.yml

##### ADDITIONAL INFORMATION
N/A