### PR TITLE
Update CI matrix to include ansible-core's stable-2.12 branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
-  - stage: Ansible_2.12
+  - stage: Ansible_2_12
     displayName: Sanity & Units 2.12
     dependsOn: []
     jobs:
@@ -126,7 +126,7 @@ stages:
               test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
-  - stage: Docker_2.12
+  - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
     jobs:
@@ -212,7 +212,7 @@ stages:
               test: freebsd/12.2
             - name: FreeBSD 13.0
               test: freebsd/13.0
-  - stage: Remote_2.12
+  - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
     jobs:
@@ -282,7 +282,7 @@ stages:
             - test: 3.8
             - test: 3.9
             - test: "3.10"
-  - stage: Cloud_2.12
+  - stage: Cloud_2_12
     displayName: Cloud 2.12
     dependsOn: []
     jobs:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -55,6 +55,17 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
+  - stage: Ansible_2.12
+    displayName: Sanity & Units 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.12/sanity/1'
+            - name: Units
+              test: '2.12/units/1'
   - stage: Ansible_2_11
     displayName: Sanity & Units 2.11
     dependsOn: []
@@ -115,6 +126,22 @@ stages:
               test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
+  - stage: Docker_2.12
+    displayName: Docker 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/linux/{0}/1
+          targets:
+            - name: CentOS 8
+              test: centos8
+            - name: Fedora 33
+              test: fedora33
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 20.04
+              test: ubuntu2004
   - stage: Docker_2_11
     displayName: Docker 2.11
     dependsOn: []
@@ -131,12 +158,8 @@ stages:
               test: fedora32
             - name: openSUSE 15 py2
               test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
             - name: Ubuntu 18.04
               test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
   - stage: Docker_2_10
     displayName: Docker 2.10
     dependsOn: []
@@ -147,22 +170,10 @@ stages:
           targets:
             - name: CentOS 6
               test: centos6
-            - name: CentOS 7
-              test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 31
               test: fedora31
-            - name: Fedora 32
-              test: fedora32
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
             - name: Ubuntu 16.04
               test: ubuntu1604
-            - name: Ubuntu 18.04
-              test: ubuntu1804
   - stage: Docker_2_9
     displayName: Docker 2.9
     dependsOn: []
@@ -175,16 +186,8 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
-            - name: Fedora 30
-              test: fedora30
             - name: Fedora 31
               test: fedora31
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
             - name: Ubuntu 16.04
               test: ubuntu1604
             - name: Ubuntu 18.04
@@ -209,6 +212,20 @@ stages:
               test: freebsd/12.2
             - name: FreeBSD 13.0
               test: freebsd/13.0
+  - stage: Remote_2.12
+    displayName: Remote 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/{0}/1
+          targets:
+            - name: macOS 11.1
+              test: macos/11.1
+            - name: RHEL 8.4
+              test: rhel/8.4
+            - name: FreeBSD 13.0
+              test: freebsd/13.0
   - stage: Remote_2_11
     displayName: Remote 2.11
     dependsOn: []
@@ -221,8 +238,6 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
-            - name: macOS 11.1
-              test: macos/11.1
             - name: FreeBSD 12.2
               test: freebsd/12.2
   - stage: Remote_2_10
@@ -233,8 +248,6 @@ stages:
         parameters:
           testFormat: 2.10/{0}/1
           targets:
-            - name: RHEL 7.8
-              test: rhel/7.8
             - name: OS X 10.11
               test: osx/10.11
             - name: macOS 10.15
@@ -269,6 +282,16 @@ stages:
             - test: 3.8
             - test: 3.9
             - test: "3.10"
+  - stage: Cloud_2.12
+    displayName: Cloud 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.12/cloud/{0}/1
+          targets:
+            - test: 3.9
   - stage: Cloud_2_11
     displayName: Cloud 2.11
     dependsOn: []
@@ -306,20 +329,24 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_12
       - Ansible_2_11
       - Ansible_2_10
       - Ansible_2_9
       - Remote_devel
-      - Docker_devel
-      - Cloud_devel
+      - Remote_2_12
       - Remote_2_11
-      - Docker_2_11
-      - Cloud_2_11
       - Remote_2_10
-      - Docker_2_10
-      - Cloud_2_10
       - Remote_2_9
+      - Docker_devel
+      - Docker_2_12
+      - Docker_2_11
+      - Docker_2_10
       - Docker_2_9
+      - Cloud_devel
+      - Cloud_2_12
+      - Cloud_2_11
+      - Cloud_2_10
       - Cloud_2_9
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Update CI matrix to include ansible-core's stable-2.12 branch. Reduces testing for older Ansible versions to avoid increasing CI load (too much).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
