### PR TITLE
Support cryptography 35.0.0 for all modules except openssl_pkcs12

### DIFF
--- a/changelogs/fragments/294-cryptography-35.0.0.yml
+++ b/changelogs/fragments/294-cryptography-35.0.0.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "get_certificate - fix compatibility with the cryptography 35.0.0 release (https://github.com/ansible-collections/community.crypto/pull/294)."
+  - "openssl_csr_info - fix compatibility with the cryptography 35.0.0 release (https://github.com/ansible-collections/community.crypto/pull/294)."
+  - "x509_certificate_info - fix compatibility with the cryptography 35.0.0 release (https://github.com/ansible-collections/community.crypto/pull/294)."

--- a/plugins/module_utils/crypto/_obj2txt.py
+++ b/plugins/module_utils/crypto/_obj2txt.py
@@ -20,6 +20,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+# WARNING: this function no longer works with cryptography 35.0.0 and newer!
+#          It must **ONLY** be used in compatibility code for older
+#          cryptography versions!
+
 def obj2txt(openssl_lib, openssl_ffi, obj):
     # Set to 80 on the recommendation of
     # https://www.openssl.org/docs/crypto/OBJ_nid2ln.html#return_values

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -70,6 +70,13 @@ def cryptography_get_extensions_from_cert(cert):
     # (that is only stored for unrecognized extensions), we have to re-do
     # the extension parsing outselves.
     backend = default_backend()
+    try:
+        # For certain old versions of cryptography, backend is a MultiBackend object,
+        # which has no _lib attribute. In that case, revert to the old approach.
+        x = backend._lib
+    except AttributeError:
+        backend = cert._backend
+
     result = dict()
     try:
         x509_obj = cert._x509
@@ -118,6 +125,12 @@ def cryptography_get_extensions_from_csr(csr):
     # the extension parsing outselves.
     result = dict()
     backend = default_backend()
+    try:
+        # For certain old versions of cryptography, backend is a MultiBackend object,
+        # which has no _lib attribute. In that case, revert to the old approach.
+        x = backend._lib
+    except AttributeError:
+        backend = csr._backend
 
     extensions = backend._lib.X509_REQ_get_extensions(csr._x509_req)
     extensions = backend._ffi.gc(
@@ -533,6 +546,12 @@ def parse_pkcs12(pkcs12_bytes, passphrase=None):
     if certificate:
         # See https://github.com/pyca/cryptography/issues/5760#issuecomment-842687238
         backend = default_backend()
+        try:
+            # For certain old versions of cryptography, backend is a MultiBackend object,
+            # which has no _lib attribute. In that case, revert to the old approach.
+            x = backend._lib
+        except AttributeError:
+            backend = certificate._backend
         maybe_name = backend._lib.X509_alias_get0(certificate._x509, backend._ffi.NULL)
         if maybe_name != backend._ffi.NULL:
             friendly_name = backend._ffi.string(maybe_name)

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -73,7 +73,7 @@ def cryptography_get_extensions_from_cert(cert):
     try:
         # For certain old versions of cryptography, backend is a MultiBackend object,
         # which has no _lib attribute. In that case, revert to the old approach.
-        x = backend._lib
+        backend._lib
     except AttributeError:
         backend = cert._backend
 
@@ -128,7 +128,7 @@ def cryptography_get_extensions_from_csr(csr):
     try:
         # For certain old versions of cryptography, backend is a MultiBackend object,
         # which has no _lib attribute. In that case, revert to the old approach.
-        x = backend._lib
+        backend._lib
     except AttributeError:
         backend = csr._backend
 
@@ -549,7 +549,7 @@ def parse_pkcs12(pkcs12_bytes, passphrase=None):
         try:
             # For certain old versions of cryptography, backend is a MultiBackend object,
             # which has no _lib attribute. In that case, revert to the old approach.
-            x = backend._lib
+            backend._lib
         except AttributeError:
             backend = certificate._backend
         maybe_name = backend._lib.X509_alias_get0(certificate._x509, backend._ffi.NULL)

--- a/tests/integration/targets/openssl_pkcs12/aliases
+++ b/tests/integration/targets/openssl_pkcs12/aliases
@@ -1,3 +1,4 @@
 shippable/cloud/group1
 shippable/posix/group1
 destructive
+disabled  # TMP

--- a/tests/integration/targets/openssl_pkcs12/aliases
+++ b/tests/integration/targets/openssl_pkcs12/aliases
@@ -1,4 +1,3 @@
 shippable/cloud/group1
 shippable/posix/group1
 destructive
-disabled  # TMP


### PR DESCRIPTION
##### SUMMARY
The latest cryptography release, 35.0.0 (released today), uses a lot more Rust code than previous relesaes. Unfortunately this breaks some of our 'workarounds' which access some internals to gather some information that cryptography unfortunately does not provide. These are in particular:

1. Getting hold of raw extension data (DER encoded bytes) for all CSR and X.509 certificate extensions (needed for the openssl_csr_info, x509_certificate_info, and get_certificate modules);
2. Getting hold of the 'friendly name' of the 'main' certificate in a PKCS#12 file (needed for the openssl_pkcs12 module).

I've been able to work around 1 in some ugly fashion, but didn't find a working solution for 2 yet. It seems that the friendly name is somehow stripped from the certificate.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cryptography support

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
