### PR TITLE
Support cryptography 35.0.0 for the openssl_pkcs12 module

### DIFF
--- a/changelogs/fragments/296-openssl_pkcs12-cryptography-35.yml
+++ b/changelogs/fragments/296-openssl_pkcs12-cryptography-35.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_pkcs12 - fix compatibility with the cryptography 35.0.0 release (https://github.com/ansible-collections/community.crypto/pull/296)."


### PR DESCRIPTION
##### SUMMARY
Follow-up to #294, ~~which right now includes #294. Will rebase once #294 is merged.~~

Fixes #293.

Due to the friendly name being stored as the 'alias' of the X.509 cert, which isn't supported by cryptography's Rust code, we need to re-parse the PKCS#12 and extract the friendly name from the OpenSSL X.509 object directly. Once https://github.com/pyca/cryptography/pull/6348 or something similar lands in cryptography we can get rid of this crutch...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
