### PR TITLE
x509_certificate: document that *notBefore/*notAfter are not used for idempotency

### DIFF
--- a/plugins/doc_fragments/module_certificate.py
+++ b/plugins/doc_fragments/module_certificate.py
@@ -451,8 +451,8 @@ options:
             - Time will always be interpreted as UTC.
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-            - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will start being valid from now.
+            - Note that this value is B(not used for idempotency checks).
             - This is only used by the C(ownca) provider.
         type: str
         default: +0s
@@ -464,8 +464,8 @@ options:
             - Time will always be interpreted as UTC.
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-            - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will stop being valid 10 years from now.
+            - Note that this value is B(not used for idempotency checks).
             - This is only used by the C(ownca) provider.
             - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
               Please see U(https://support.apple.com/en-us/HT210176) for more details.
@@ -542,8 +542,8 @@ options:
             - Time will always be interpreted as UTC.
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-            - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will start being valid from now.
+            - Note that this value is B(not used for idempotency checks).
             - This is only used by the C(selfsigned) provider.
         type: str
         default: +0s
@@ -556,8 +556,8 @@ options:
             - Time will always be interpreted as UTC.
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-            - Note that if using relative time this module is NOT idempotent.
             - If this value is not specified, the certificate will stop being valid 10 years from now.
+            - Note that this value is B(not used for idempotency checks).
             - This is only used by the C(selfsigned) provider.
             - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
               Please see U(https://support.apple.com/en-us/HT210176) for more details.

--- a/plugins/doc_fragments/module_certificate.py
+++ b/plugins/doc_fragments/module_certificate.py
@@ -452,7 +452,7 @@ options:
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
             - If this value is not specified, the certificate will start being valid from now.
-            - Note that this value is B(not used for idempotency checks).
+            - Note that this value is B(not used to determine whether an existing certificate should be regenerated).
             - This is only used by the C(ownca) provider.
         type: str
         default: +0s
@@ -465,7 +465,7 @@ options:
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
             - If this value is not specified, the certificate will stop being valid 10 years from now.
-            - Note that this value is B(not used for idempotency checks).
+            - Note that this value is B(not used to determine whether an existing certificate should be regenerated).
             - This is only used by the C(ownca) provider.
             - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
               Please see U(https://support.apple.com/en-us/HT210176) for more details.
@@ -543,7 +543,7 @@ options:
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
             - If this value is not specified, the certificate will start being valid from now.
-            - Note that this value is B(not used for idempotency checks).
+            - Note that this value is B(not used to determine whether an existing certificate should be regenerated).
             - This is only used by the C(selfsigned) provider.
         type: str
         default: +0s
@@ -557,7 +557,7 @@ options:
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
             - If this value is not specified, the certificate will stop being valid 10 years from now.
-            - Note that this value is B(not used for idempotency checks).
+            - Note that this value is B(not used to determine whether an existing certificate should be regenerated).
             - This is only used by the C(selfsigned) provider.
             - On macOS 10.15 and onwards, TLS server certificates must have a validity period of 825 days or fewer.
               Please see U(https://support.apple.com/en-us/HT210176) for more details.


### PR DESCRIPTION
##### SUMMARY
Documents the current behavior (which has been true since creation of the module) that *_not_before and *_not_after are not used for idempotency.

(See #295.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
x509_certificate
x509_certificate_pipe
