### PR TITLE
Add warning for ASN.1 encoded extension values returned by some modules

### DIFF
--- a/changelogs/fragments/318-extension-value-note.yml
+++ b/changelogs/fragments/318-extension-value-note.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+  - "get_certificate, openssl_csr_info, x509_certificate_info - depending on the ``cryptography`` version used,
+     the modules might not return the ASN.1 value for an extension as contained in the certificate respectively CSR,
+     but a re-encoded version of it. This should usually be identical to the value contained in the source file,
+     unless the value was malformed. For extensions not handled by C(cryptography) always the value contained in
+     the source file is returned (https://github.com/ansible-collections/community.crypto/pull/318)."

--- a/changelogs/fragments/318-extension-value-note.yml
+++ b/changelogs/fragments/318-extension-value-note.yml
@@ -2,5 +2,5 @@ breaking_changes:
   - "get_certificate, openssl_csr_info, x509_certificate_info - depending on the ``cryptography`` version used,
      the modules might not return the ASN.1 value for an extension as contained in the certificate respectively CSR,
      but a re-encoded version of it. This should usually be identical to the value contained in the source file,
-     unless the value was malformed. For extensions not handled by C(cryptography) always the value contained in
-     the source file is returned (https://github.com/ansible-collections/community.crypto/pull/318)."
+     unless the value was malformed. For extensions not handled by C(cryptography) the value contained in
+     the source file is always returned unaltered (https://github.com/ansible-collections/community.crypto/pull/318)."

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -99,7 +99,13 @@ extensions:
         asn1_data:
             returned: success
             type: str
-            description: The Base64 encoded ASN.1 content of the extnesion.
+            description:
+              - The Base64 encoded ASN.1 content of the extension.
+              - B(Note) that depending on the C(cryptography) version used, it is
+                not possible to extract the ASN.1 content of the extension, but only
+                to provide the re-encoded content of the extension in case it was
+                parsed by C(cryptography). This should usually result in exactly the
+                same value, except if the original extension value was malformed.
         name:
             returned: success
             type: str

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -103,7 +103,13 @@ extensions_by_oid:
             returned: success
             type: bool
         value:
-            description: The Base64 encoded value (in DER format) of the extension
+            description:
+              - The Base64 encoded value (in DER format) of the extension
+              - B(Note) that depending on the C(cryptography) version used, it is
+                not possible to extract the ASN.1 content of the extension, but only
+                to provide the re-encoded content of the extension in case it was
+                parsed by C(cryptography). This should usually result in exactly the
+                same value, except if the original extension value was malformed.
             returned: success
             type: str
             sample: "MAMCAQU="

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -104,7 +104,7 @@ extensions_by_oid:
             type: bool
         value:
             description:
-              - The Base64 encoded value (in DER format) of the extension
+              - The Base64 encoded value (in DER format) of the extension.
               - B(Note) that depending on the C(cryptography) version used, it is
                 not possible to extract the ASN.1 content of the extension, but only
                 to provide the re-encoded content of the extension in case it was

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -147,7 +147,13 @@ extensions_by_oid:
             returned: success
             type: bool
         value:
-            description: The Base64 encoded value (in DER format) of the extension.
+            description:
+              - The Base64 encoded value (in DER format) of the extension.
+              - B(Note) that depending on the C(cryptography) version used, it is
+                not possible to extract the ASN.1 content of the extension, but only
+                to provide the re-encoded content of the extension in case it was
+                parsed by C(cryptography). This should usually result in exactly the
+                same value, except if the original extension value was malformed.
             returned: success
             type: str
             sample: "MAMCAQU="


### PR DESCRIPTION
##### SUMMARY
Add warning that ASN.1 encoded extension values returned by some modules might not reflect the exact byte sequence in the source file anymore depending on the cryptography version.

(Related to https://github.com/pyca/cryptography/pull/6346.)

We can potentially continue to use the current approach (using cffi and cryptography internals), but that might stop working at any moment and the functions we need for that might be removed from the cffi/cryptography exposed parts of OpenSSL.

On the other hand, once there is a stable interface to encode extension values, we have a lot less to worry about, and can also finally implement a feature which allows to specify arbitrary extension values for CSRs. (There was a feature request for that, but I can't find it anymore.)

I think it is important to announce this now (as a potentially **breaking change**) since we still haven't released 2.0.0 and thus can still have breaking changes "for free". Having them later in a bugfix or feature release is something we should really avoid.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
get_certificate
openssl_csr_info
x509_certificate_info
