### PR TITLE
acme_certificate: fix crash when using fullchain_dest

### DIFF
--- a/changelogs/fragments/324-acme_certificate-fullchain.yml
+++ b/changelogs/fragments/324-acme_certificate-fullchain.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "acme_certificate - if ``fullchain_dest`` is specified and the ``cryptography`` backend is used with cryptography 35.0.0 or newer, the module crashed when trying to read the certificate from the chain, as cryptography no longer ignores the concatenated other PEM certificates. The module now removes the concatenated PEM certificates before loading the main certificate (https://github.com/ansible-collections/community.crypto/pull/324)."
+  - "acme_certificate - avoid passing multiple certificates to ``cryptography``'s X.509 certificate loader when ``fullchain_dest`` is used. Doing so potentially produces an error when cryptography 36.0.0 is used (https://github.com/ansible-collections/community.crypto/pull/324)."

--- a/changelogs/fragments/324-acme_certificate-fullchain.yml
+++ b/changelogs/fragments/324-acme_certificate-fullchain.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acme_certificate - if ``fullchain_dest`` is specified and the ``cryptography`` backend is used with cryptography 35.0.0 or newer, the module crashed when trying to read the certificate from the chain, as cryptography no longer ignores the concatenated other PEM certificates. The module now removes the concatenated PEM certificates before loading the main certificate (https://github.com/ansible-collections/community.crypto/pull/324)."

--- a/plugins/module_utils/acme/backend_cryptography.py
+++ b/plugins/module_utils/acme/backend_cryptography.py
@@ -361,7 +361,7 @@ class CryptographyBackend(CryptoBackend):
         if cert_content is None:
             return -1
 
-        # Make sure we have at most one PEM. Otherwise cryptography 35.0.0 will barf.
+        # Make sure we have at most one PEM. Otherwise cryptography 36.0.0 will barf.
         cert_content = to_bytes(extract_first_pem(to_text(cert_content)) or '')
 
         try:

--- a/plugins/module_utils/acme/backend_cryptography.py
+++ b/plugins/module_utils/acme/backend_cryptography.py
@@ -14,7 +14,7 @@ import datetime
 import os
 import sys
 
-from ansible.module_utils.common.text.converters import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.backends import (
     CryptoBackend,
@@ -39,6 +39,10 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.support im
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.cryptography_support import (
     cryptography_name_to_oid,
+)
+
+from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import (
+    extract_first_pem,
 )
 
 try:
@@ -356,6 +360,9 @@ class CryptographyBackend(CryptoBackend):
 
         if cert_content is None:
             return -1
+
+        # Make sure we have at most one PEM. Otherwise cryptography 35.0.0 will barf.
+        cert_content = to_bytes(extract_first_pem(to_text(cert_content)) or '')
 
         try:
             cert = cryptography.x509.load_pem_x509_certificate(cert_content, _cryptography_backend)

--- a/plugins/module_utils/crypto/pem.py
+++ b/plugins/module_utils/crypto/pem.py
@@ -72,3 +72,13 @@ def split_pem_list(text, keep_inbetween=False):
                     result.append(''.join(current))
                     current = [] if keep_inbetween else None
     return result
+
+
+def extract_first_pem(text):
+    '''
+    Given one PEM or multiple concatenated PEM objects, return only the first one, or None if there is none.
+    '''
+    all_pems = split_pem_list(text)
+    if not all_pems:
+        return None
+    return all_pems[0]


### PR DESCRIPTION
##### SUMMARY
I noticed that acme_certificate crashes when using the cryptography backend when renewing certificates if the `fullchain_dest` option is used, since it passes the content of the fullchain file to cryptography's `load_pem_x509_certificate` function. Since that one no longer calls libssl but uses its own parser (since cryptography 35.0.0), this leads to an error raised.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
