### PR TITLE
luks_device: add built-in signature wiper to work around older wipefs versions with LUKS2 containers

### DIFF
--- a/changelogs/fragments/327-luks_device-wipe.yml
+++ b/changelogs/fragments/327-luks_device-wipe.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "luks_device - on ``state=absent`` now also runs ``cryptsetup erase`` to make sure the device is no longer accepted as a LUKS device (https://github.com/ansible-collections/community.crypto/issues/326, https://github.com/ansible-collections/community.crypto/pull/327)."
+  - "luks_device - on ``state=absent`` now also runs ``cryptsetup erase`` as well as a built-in LUKS signature cleaner to make sure the device is no longer accepted as a LUKS device (https://github.com/ansible-collections/community.crypto/issues/326, https://github.com/ansible-collections/community.crypto/pull/327)."

--- a/changelogs/fragments/327-luks_device-wipe.yml
+++ b/changelogs/fragments/327-luks_device-wipe.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "luks_device - on ``state=absent`` now also runs ``cryptsetup erase`` to make sure the device is no longer accepted as a LUKS device (https://github.com/ansible-collections/community.crypto/issues/326, https://github.com/ansible-collections/community.crypto/pull/327)."

--- a/changelogs/fragments/327-luks_device-wipe.yml
+++ b/changelogs/fragments/327-luks_device-wipe.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "luks_device - on ``state=absent`` now also runs ``cryptsetup erase`` as well as a built-in LUKS signature cleaner to make sure the device is no longer accepted as a LUKS device (https://github.com/ansible-collections/community.crypto/issues/326, https://github.com/ansible-collections/community.crypto/pull/327)."
+  - "luks_device - now also runs a built-in LUKS signature cleaner on ``state=absent`` to make sure that also the secondary LUKS2 header is wiped when older versions of wipefs are used (https://github.com/ansible-collections/community.crypto/issues/326, https://github.com/ansible-collections/community.crypto/pull/327)."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -535,18 +535,12 @@ class CryptHandler(Handler):
         if result[RETURN_CODE] != 0:
             raise ValueError('Error while closing LUKS container %s' % (name))
 
-    def run_luks_erase(self, device, ignore_errors=False):
-        result = self._run_command([self._cryptsetup_bin, 'erase', '-q', device])
-        if result[RETURN_CODE] != 0 and not ignore_errors:
-            raise ValueError('Error while erasing LUKS container %s' % (device))
-
     def run_luks_remove(self, device):
         wipefs_bin = self._module.get_bin_path('wipefs', True)
 
         name = self.get_container_name_by_device(device)
         if name is not None:
             self.run_luks_close(name)
-        self.run_luks_erase(device, ignore_errors=True)
         result = self._run_command([wipefs_bin, '--all', device])
         if result[RETURN_CODE] != 0:
             raise ValueError('Error while wiping luks container %s: %s'

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -507,12 +507,18 @@ class CryptHandler(Handler):
         if result[RETURN_CODE] != 0:
             raise ValueError('Error while closing LUKS container %s' % (name))
 
+    def run_luks_erase(self, device, ignore_errors=False):
+        result = self._run_command([self._cryptsetup_bin, 'erase', device])
+        if result[RETURN_CODE] != 0 and not ignore_errors:
+            raise ValueError('Error while erasing LUKS container %s' % (device))
+
     def run_luks_remove(self, device):
         wipefs_bin = self._module.get_bin_path('wipefs', True)
 
         name = self.get_container_name_by_device(device)
         if name is not None:
             self.run_luks_close(name)
+        self.run_luks_erase(device, ignore_errors=True)
         result = self._run_command([wipefs_bin, '--all', device])
         if result[RETURN_CODE] != 0:
             raise ValueError('Error while wiping luks container %s: %s'

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -543,7 +543,7 @@ class CryptHandler(Handler):
             self.run_luks_close(name)
         result = self._run_command([wipefs_bin, '--all', device])
         if result[RETURN_CODE] != 0:
-            raise ValueError('Error while wiping luks container %s: %s'
+            raise ValueError('Error while wiping LUKS container signatures for %s: %s'
                              % (device, result[STDERR]))
 
         # For LUKS2, sometimes both `cryptsetup erase` and `wipefs` do **not**
@@ -552,7 +552,7 @@ class CryptHandler(Handler):
         try:
             wipe_luks_headers(device)
         except Exception as exc:
-            raise ValueError('Error while wiping luks container %s: %s' % (device, exc))
+            raise ValueError('Error while wiping LUKS container signatures for %s: %s' % (device, exc))
 
     def run_luks_add_key(self, device, keyfile, passphrase, new_keyfile,
                          new_passphrase, pbkdf):

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -356,8 +356,10 @@ LUKS_NAME_REGEX = re.compile(r'\s*crypt\s+([^\s]*)\s*')
 LUKS_DEVICE_REGEX = re.compile(r'\s*device:\s+([^\s]*)\s*')
 
 
+# See https://gitlab.com/cryptsetup/cryptsetup/-/wikis/LUKS-standard/on-disk-format.pdf
 LUKS_HEADER = b'LUKS\xba\xbe'
 LUKS_HEADER_L = 6
+# See https://gitlab.com/cryptsetup/LUKS2-docs/-/blob/master/luks2_doc_wip.pdf
 LUKS2_HEADER_OFFSETS = [0x4000, 0x8000, 0x10000, 0x20000, 0x40000, 0x80000, 0x100000, 0x200000, 0x400000]
 LUKS2_HEADER2 = b'SKUL\xba\xbe'
 

--- a/tests/unit/plugins/modules/test_luks_device.py
+++ b/tests/unit/plugins/modules/test_luks_device.py
@@ -65,6 +65,9 @@ def test_run_luks_remove(monkeypatch):
     monkeypatch.setattr(luks_device.Handler,
                         "_run_command",
                         run_command_check)
+    monkeypatch.setattr(luks_device,
+                        "wipe_luks_headers",
+                        lambda device: True)
     crypt = luks_device.CryptHandler(module)
     crypt.run_luks_remove("dummy")
 

--- a/tests/unit/plugins/modules/test_luks_device.py
+++ b/tests/unit/plugins/modules/test_luks_device.py
@@ -46,16 +46,9 @@ def test_get_container_device_by_name(monkeypatch):
 
 
 def test_run_luks_remove(monkeypatch):
-    counter = [0]
-
     def run_command_check(self, command):
-        # check that 'cryptsetup erase' and 'wipefs' commands are actually called
-        if counter[0] == 0:
-            assert command[0] == "cryptsetup"
-            assert command[1] == "erase"
-        if counter[0] == 1:
-            assert command[0] == "wipefs"
-        counter[0] += 1
+        # check that wipefs command is actually called
+        assert command[0] == "wipefs"
         return [0, "", ""]
 
     module = DummyModule()

--- a/tests/unit/plugins/modules/test_luks_device.py
+++ b/tests/unit/plugins/modules/test_luks_device.py
@@ -46,9 +46,16 @@ def test_get_container_device_by_name(monkeypatch):
 
 
 def test_run_luks_remove(monkeypatch):
+    counter = [0]
+
     def run_command_check(self, command):
-        # check that wipefs command is actually called
-        assert command[0] == "wipefs"
+        # check that 'cryptsetup erase' and 'wipefs' commands are actually called
+        if counter[0] == 0:
+            assert command[0] == "cryptsetup"
+            assert command[1] == "erase"
+        if counter[0] == 1:
+            assert command[0] == "wipefs"
+        counter[0] += 1
         return [0, "", ""]
 
     module = DummyModule()


### PR DESCRIPTION
##### SUMMARY
Fixes #326.

~~In the end I decided to keep `wipefs`, in case `cryptsetup erase` fails for some reason.~~

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
luks_device
