### PR TITLE
Fix CSR copy/paste error

### DIFF
--- a/docs/docsite/rst/guide_ownca.rst
+++ b/docs/docsite/rst/guide_ownca.rst
@@ -71,7 +71,7 @@ In the following example, we assume that the certificate to sign (including its 
 
     - name: Sign certificate with our CA
       community.crypto.x509_certificate_pipe:
-        csr_content: "{{ ca_csr.csr }}"
+        csr_content: "{{ csr.csr }}"
         provider: ownca
         ownca_path: /path/to/ca-certificate.pem
         ownca_privatekey_path: /path/to/ca-certificate.key
@@ -128,7 +128,7 @@ Please note that the above procedure is **not idempotent**. The following extend
     - name: Sign certificate with our CA
       community.crypto.x509_certificate_pipe:
         content: "{{ (certificate.content | b64decode) if certificate_exists.stat.exists else omit }}"
-        csr_content: "{{ ca_csr.csr }}"
+        csr_content: "{{ csr.csr }}"
         provider: ownca
         ownca_path: /path/to/ca-certificate.pem
         ownca_privatekey_path: /path/to/ca-certificate.key


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The first case about ca_csr has been copy/pasted.
But in the following cases, the CSR must be the certificate csr.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Example

##### ADDITIONAL INFORMATION
