### PR TITLE
Fix module reference in example

### DIFF
--- a/plugins/modules/openssl_publickey_info.py
+++ b/plugins/modules/openssl_publickey_info.py
@@ -54,7 +54,7 @@ EXAMPLES = r'''
     path: /etc/ssl/private/ansible.com.pem
 
 - name: Create public key from private key
-  community.crypto.openssl_privatekey:
+  community.crypto.openssl_publickey:
     privatekey_path: /etc/ssl/private/ansible.com.pem
     path: /etc/ssl/ansible.com.pub
 


### PR DESCRIPTION
##### SUMMARY

While reading I noticed one of the examples didn't "click" in my brain. Upon further inspection it was the module name.

openssl_privatekey -> openssl_publickey

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openssl_publickey_info

##### ADDITIONAL INFORMATION
This change can be verified by seeing that the [openssl_publickey_module](https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_publickey_module.html) takes a `privatekey_path` while the [openssl_privatekey_module](https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_privatekey_module.html) does not.


