### PR TITLE
Added 'ignore_timestamps' parameter

### DIFF
--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -110,16 +110,16 @@ options:
         description:
             - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
-               where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent."
+               where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
+               Note that if using relative time this module is NOT idempotent. To change default behaviour use I(ignore_timestamps) is C(true)."
             - Required if I(state) is C(present).
         type: str
     valid_to:
         description:
             - "The point in time the certificate is valid to. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
-               where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent."
+               where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
+               Note that if using relative time this module is NOT idempotent. To change default behaviour use I(ignore_timestamps) is C(true)."
             - Required if I(state) is C(present).
         type: str
     valid_at:
@@ -128,6 +128,12 @@ options:
                Time will always be interpreted as UTC. Mainly to be used with relative timespec for I(valid_from) and / or I(valid_to).
                Note that if using relative time this module is NOT idempotent."
         type: str
+    ignore_timestamps:
+        description:
+            - "Whether the "I(valid_from)" and "I(valid_to)" timestamps should be ignored for idempotency checks."
+        type: bool
+        default: false
+        version_added: 2.2.0
     principals:
         description:
             - "Certificates may be limited to be valid for a set of principal (user/host) names.
@@ -258,11 +264,10 @@ info:
 '''
 
 import os
+from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native, to_text
-
-from ansible_collections.community.crypto.plugins.module_utils.version import LooseVersion
 
 from ansible_collections.community.crypto.plugins.module_utils.openssh.backends.common import (
     KeygenCommand,
@@ -296,6 +301,7 @@ class Certificate(OpensshModule):
         self.type = self.module.params['type']
         self.use_agent = self.module.params['use_agent']
         self.valid_at = self.module.params['valid_at']
+        self.ignore_timestamps = self.module.params['ignore_timestamps']
 
         self._check_if_base_dir(self.path)
 
@@ -403,10 +409,13 @@ class Certificate(OpensshModule):
         except ValueError as e:
             return self.module.fail_json(msg=to_native(e))
 
-        return all([
-            original_time_parameters == self.time_parameters,
-            original_time_parameters.within_range(self.valid_at)
-        ])
+        if self.ignore_timestamps:
+            return original_time_parameters.within_range(self.valid_at)
+        else:
+            return all([
+                original_time_parameters == self.time_parameters,
+                original_time_parameters.within_range(self.valid_at)
+            ])
 
     def _compare_options(self):
         try:
@@ -537,6 +546,8 @@ def main():
             valid_at=dict(type='str'),
             valid_from=dict(type='str'),
             valid_to=dict(type='str'),
+            ignore_timestamps=dict(type='bool', default=False),
+
         ),
         supports_check_mode=True,
         add_file_common_args=True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added 'ignore_timestamps' parameter to openssh_cert so it can be used semi-idempotent with relative timestamps in valid_to/valid_from.

Defaults to false (to be consistent with older versions)

Fixes #379
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It´s my first pull-request and I´m new to python, so please be gentle ;)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
