### PR TITLE
Added 'ignore_timestamps' parameter

### DIFF
--- a/changelogs/fragments/381_openssh_cert_add_ignore_timestamps.yml
+++ b/changelogs/fragments/381_openssh_cert_add_ignore_timestamps.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - openssh_cert - added 'ignore_timestamps' parameter so it can be used semi-idempotent with relative timestamps in valid_to/valid_from (https://github.com/ansible-collections/community.crypto/issues/379).

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -112,8 +112,7 @@ options:
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
                Note that if using relative time this module is NOT idempotent."
-            - "To ignore this value during comparison with an existing certificate set."
-               I(ignore_timestamps=true)."
+            - "To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_to:
@@ -122,8 +121,7 @@ options:
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
                Note that if using relative time this module is NOT idempotent."
-            - "To ignore this value during comparison with an existing certificate set."
-               I(ignore_timestamps=true)."
+            - "To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_at:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -412,11 +412,11 @@ class Certificate(OpensshModule):
 
         if self.ignore_timestamps:
             return original_time_parameters.within_range(self.valid_at)
-        else:
-            return all([
-                original_time_parameters == self.time_parameters,
-                original_time_parameters.within_range(self.valid_at)
-            ])
+        
+        return all([
+            original_time_parameters == self.time_parameters,
+            original_time_parameters.within_range(self.valid_at)
+        ])
 
     def _compare_options(self):
         try:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -111,7 +111,7 @@ options:
             - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To change default behaviour use I(ignore_timestamps) is C(true)."
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_to:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -50,6 +50,7 @@ options:
               match the module's options.
             - When C(partial_idempotence) an existing certificate will be regenerated based on
               I(serial), I(signature_algorithm), I(type), I(valid_from), I(valid_to), I(valid_at), and I(principals).
+              I(valid_from) and I(valid_to) can be excluded by I(ignore_timestamps=true).
             - When C(full_idempotence) I(identifier), I(options), I(public_key), and I(signing_key)
               are also considered when compared against an existing certificate.
             - C(always) is equivalent to I(force=true).

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -119,7 +119,7 @@ options:
             - "The point in time the certificate is valid to. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To change default behaviour use I(ignore_timestamps) is C(true)."
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_at:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -198,6 +198,7 @@ EXAMPLES = '''
     valid_from: +0s
     valid_to: +32w
     valid_at: +2w
+    ignore_timestamps: true
 
 - name: Generate an OpenSSH host certificate that is valid forever and only for example.com and examplehost
   community.crypto.openssh_cert:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -111,7 +111,8 @@ options:
             - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set
+               Note that if using relative time this module is NOT idempotent."
+            - "To ignore this value during comparison with an existing certificate set."
                I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
@@ -120,7 +121,8 @@ options:
             - "The point in time the certificate is valid to. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set
+               Note that if using relative time this module is NOT idempotent."
+            - "To ignore this value during comparison with an existing certificate set."
                I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -111,7 +111,7 @@ options:
             - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set 
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set
                I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
@@ -120,7 +120,7 @@ options:
             - "The point in time the certificate is valid to. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set 
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set
                I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -111,7 +111,8 @@ options:
             - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | always)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set 
+               I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_to:
@@ -119,7 +120,8 @@ options:
             - "The point in time the certificate is valid to. Time can be specified either as relative time or as absolute timestamp.
                Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | YYYY-MM-DD | YYYY-MM-DDTHH:MM:SS | YYYY-MM-DD HH:MM:SS | forever)
                where timespec can be an integer + C([w | d | h | m | s]) (for example C(+32w1d2h)).
-               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set I(ignore_timestamps=true)."
+               Note that if using relative time this module is NOT idempotent. To ignore this value during comparison with an existing certificate set 
+               I(ignore_timestamps=true)."
             - Required if I(state) is C(present).
         type: str
     valid_at:
@@ -414,7 +416,7 @@ class Certificate(OpensshModule):
 
         if self.ignore_timestamps:
             return original_time_parameters.within_range(self.valid_at)
-        
+
         return all([
             original_time_parameters == self.time_parameters,
             original_time_parameters.within_range(self.valid_at)

--- a/tests/integration/targets/openssh_cert/tests/options_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/options_idempotency.yml
@@ -86,6 +86,57 @@
     regenerate: full_idempotence
   register: default_options
 
+- name: Generate cert with relative timestamp
+  openssh_cert:
+    type: user
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: +0s
+    valid_to: +32w
+    valid_at: +2w
+    regenerate: full_idempotence
+  register: relative_timestamp
+
+- name: Generate cert with ignore_timestamp true
+  openssh_cert:
+    type: user
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: +0s
+    valid_to: +32w
+    valid_at: +2w
+    ignore_timestamps: true
+    regenerate: full_idempotence
+  register: relative_timestamp_true
+
+- name: Generate cert with ignore_timestamp false
+  openssh_cert:
+    type: user
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: +0s
+    valid_to: +32w
+    valid_at: +2w
+    ignore_timestamps: false
+    regenerate: full_idempotence
+  register: relative_timestamp_false
+
+- name: Generate cert with ignore_timestamp true
+  openssh_cert:
+    type: user
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: +0s
+    valid_to: +32w
+    valid_at: +50w
+    ignore_timestamps: true
+    regenerate: full_idempotence
+  register: relative_timestamp_invalid_at
+
 - name: Assert options results
   assert:
     that:
@@ -95,6 +146,10 @@
       - explicit_extension_after is not changed
       - explicit_extension_and_directive is changed
       - default_options is not changed
+      - relative_timestamp is changed
+      - relative_timestamp_true is not changed
+      - relative_timestamp_false is changed
+      - relative_timestamp_invalid_at is changed
 
 - name: Remove certificate
   openssh_cert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added 'ignore_timestamps' parameter to openssh_cert so it can be used semi-idempotent with relative timestamps in valid_to/valid_from.

Defaults to false (to be consistent with older versions)

Fixes #379
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It´s my (second try on the) first pull-request and I´m new to python, so please be gentle ;)
<!--- Paste verbatim command output below, e.g. before and after your change -->

