### PR TITLE
PyOpenSSL 22.0.0 no longer supports Python 2.7

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -7,5 +7,6 @@ idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna 
 requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
+pyopenssl < 22.0.0 ; python_version < '3.6' # pyOpenSSL 22.0.0 and later require python 3.6 or later
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:


### PR DESCRIPTION
##### SUMMARY
Currently CI fails because of that.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
