### PR TITLE
luks_device: set LANG and similar env variables to prevent translated cryptsetup output

### DIFF
--- a/changelogs/fragments/388-luks_device-i18n.yml
+++ b/changelogs/fragments/388-luks_device-i18n.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "luks_devices - set ``LANG`` and similar environment variables to avoid translated output, which can break some of the module's functionality like key management (https://github.com/ansible-collections/community.crypto/pull/388, https://github.com/ansible-collections/community.crypto/issues/385)."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -821,6 +821,7 @@ def run_module():
     module = AnsibleModule(argument_spec=module_args,
                            supports_check_mode=True,
                            mutually_exclusive=mutually_exclusive)
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     if module.params['device'] is not None:
         try:


### PR DESCRIPTION
##### SUMMARY
Fixes #385 (I hope).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
luks_device
