### PR TITLE
Drop CentOS 8 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -137,8 +137,6 @@ stages:
           targets:
             - name: CentOS 6
               test: centos6
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: openSUSE 15 py3
@@ -155,8 +153,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
             - name: openSUSE 15 py2


### PR DESCRIPTION
##### SUMMARY
The nice way didn't work (#392), so let's do it the hard way and simply remove CentOS 8 from CI.

See also https://github.com/ansible-collections/news-for-maintainers/issues/3.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
