### PR TITLE
openssh_cert - fix full_idempotence for host certificates

### DIFF
--- a/changelogs/fragments/396-openssh_cert-host-cert-idempotence-fix.yml
+++ b/changelogs/fragments/396-openssh_cert-host-cert-idempotence-fix.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - openssh_cert - fixed false ``changed`` status for ``host`` certificates when using ``full_idempotence``
+    (https://github.com/ansible-collections/community.crypto/issues/395,
+    https://github.com/ansible-collections/community.crypto/pull/396).

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -391,7 +391,7 @@ class Certificate(OpensshModule):
 
     def _is_fully_valid(self):
         return self._is_partially_valid() and all([
-            self._compare_options(),
+            self._compare_options() if self.original_data.type == 'user' else True,
             self.original_data.key_id == self.identifier,
             self.original_data.public_key == self._get_key_fingerprint(self.public_key),
             self.original_data.signing_key == self._get_key_fingerprint(self.signing_key),

--- a/tests/integration/targets/openssh_cert/tests/options_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/options_idempotency.yml
@@ -137,6 +137,27 @@
     regenerate: full_idempotence
   register: relative_timestamp_invalid_at
 
+- name: Generate host cert full_idempotence
+  openssh_cert:
+    type: host
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: always
+    valid_to: forever
+    regenerate: full_idempotence
+
+- name: Generate host cert full_idempotence again
+  openssh_cert:
+    type: host
+    path: "{{ certificate_path }}"
+    public_key: "{{ public_key }}"
+    signing_key: "{{ signing_key }}"
+    valid_from: always
+    valid_to: forever
+    regenerate: full_idempotence
+  register: host_cert_full_idempotence
+
 - name: Assert options results
   assert:
     that:
@@ -150,6 +171,7 @@
       - relative_timestamp_true is not changed
       - relative_timestamp_false is changed
       - relative_timestamp_invalid_at is changed
+      - host_cert_full_idempotence is not changed
 
 - name: Remove certificate
   openssh_cert:


### PR DESCRIPTION
##### SUMMARY
Ensures options are only checked for idempotence when the certificate is of type `user`.

Fixed #395 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/openssh_cert.py

##### ADDITIONAL INFORMATION
N/A
