### PR TITLE
CI: add community ansible-test images

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -190,6 +190,22 @@ stages:
             - name: Ubuntu 18.04
               test: ubuntu1804
 
+### Community Docker
+  - stage: Docker_community_devel
+    displayName: Docker (community images) devel
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/linux-community/{0}/1
+          targets:
+            - name: Debian Bullseye
+              test: debian-bullseye
+            - name: ArchLinux
+              test: archlinux
+            - name: CentOS Stream 8
+              test: centos-stream8
+
 ### Remote
   - stage: Remote_devel
     displayName: Remote devel
@@ -340,6 +356,7 @@ stages:
       - Docker_2_11
       - Docker_2_10
       - Docker_2_9
+      - Docker_community_devel
       - Cloud_devel
       - Cloud_2_12
       - Cloud_2_11

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -200,11 +200,11 @@ stages:
           testFormat: devel/linux-community/{0}/1
           targets:
             - name: Debian Bullseye
-              test: debian-bullseye
+              test: debian-bullseye/3.9
             - name: ArchLinux
-              test: archlinux
+              test: archlinux/3.10
             - name: CentOS Stream 8
-              test: centos-stream8
+              test: centos-stream8/3.8
 
 ### Remote
   - stage: Remote_devel

--- a/tests/integration/targets/setup_openssl/vars/Archlinux.yml
+++ b/tests/integration/targets/setup_openssl/vars/Archlinux.yml
@@ -1,0 +1,4 @@
+---
+openssl_package_name: openssl
+cryptography_package_name: python-cryptography
+cryptography_package_name_python3: python-cryptography

--- a/tests/integration/targets/setup_pyopenssl/vars/Archlinux.yml
+++ b/tests/integration/targets/setup_pyopenssl/vars/Archlinux.yml
@@ -1,3 +1,3 @@
 ---
-pyopenssl_package_name: python-openssl
-pyopenssl_package_name_python3: python-openssl
+pyopenssl_package_name: python-pyopenssl
+pyopenssl_package_name_python3: python-pyopenssl

--- a/tests/integration/targets/setup_pyopenssl/vars/Archlinux.yml
+++ b/tests/integration/targets/setup_pyopenssl/vars/Archlinux.yml
@@ -1,0 +1,3 @@
+---
+pyopenssl_package_name: python-openssl
+pyopenssl_package_name_python3: python-openssl

--- a/tests/integration/targets/setup_python_info/vars/main.yml
+++ b/tests/integration/targets/setup_python_info/vars/main.yml
@@ -57,7 +57,7 @@ system_python_version_data:
       - '3.10'
   Debian:
     '11':
-      - '2.9'
+      - '3.9'
 
 cannot_upgrade_cryptography:
   FreeBSD:

--- a/tests/integration/targets/setup_python_info/vars/main.yml
+++ b/tests/integration/targets/setup_python_info/vars/main.yml
@@ -52,6 +52,12 @@ system_python_version_data:
     '15':
       - '2.7'
       - '3.6'
+  Archlinux:
+    'NA':
+      - '3.10'
+  Debian:
+    '11':
+      - '2.9'
 
 cannot_upgrade_cryptography:
   FreeBSD:

--- a/tests/integration/targets/setup_ssh_keygen/vars/Archlinux.yml
+++ b/tests/integration/targets/setup_ssh_keygen/vars/Archlinux.yml
@@ -1,0 +1,1 @@
+openssh_client_package_name: openssh

--- a/tests/utils/shippable/linux-community.sh
+++ b/tests/utils/shippable/linux-community.sh
@@ -6,13 +6,14 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 image="${args[1]}"
+python="${args[2]}"
 
-if [ "${#args[@]}" -gt 2 ]; then
-    target="shippable/posix/group${args[2]}/"
+if [ "${#args[@]}" -gt 3 ]; then
+    target="shippable/posix/group${args[3]}/"
 else
     target="shippable/posix/"
 fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --docker "quay.io/ansible-community/test-image:${image}"
+    --docker "quay.io/ansible-community/test-image:${image}" --python "${python}"

--- a/tests/utils/shippable/linux-community.sh
+++ b/tests/utils/shippable/linux-community.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o pipefail -eux
+
+declare -a args
+IFS='/:' read -ra args <<< "$1"
+
+image="${args[1]}"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="shippable/posix/group${args[2]}/"
+else
+    target="shippable/posix/"
+fi
+
+# shellcheck disable=SC2086
+ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    --docker "quay.io/ansible-community/test-image:${image}"


### PR DESCRIPTION
##### SUMMARY
Now that we have some more OS-specific images (https://github.com/ansible-community/images/tree/main/ansible-test), let's try to use them :-)

(`tests/utils/shippable/linux-community.sh` is a copy of `tests/utils/shippable/linux.sh` with `"${image}"` replaced by `"quay.io/ansible-community/test-image:${image}"`.)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
