### PR TITLE
x509_certificate: check existing certificate's signature for selfsigned and ownca provider

### DIFF
--- a/changelogs/fragments/407-x509_certificate-signature.yml
+++ b/changelogs/fragments/407-x509_certificate-signature.yml
@@ -1,3 +1,4 @@
 bugfixes:
+  - "x509_certificate - for the ``ownca`` provider, check whether the CA private key actually belongs to the CA certificate (https://github.com/ansible-collections/community.crypto/pull/407)."
   - "x509_certificate - regenerate certificate when the CA's public key changes for ``provider=ownca`` (https://github.com/ansible-collections/community.crypto/pull/407)."
   - "x509_certificate - regenerate certificate when the private key changes for ``provider=selfsigned`` (https://github.com/ansible-collections/community.crypto/pull/407)."

--- a/changelogs/fragments/407-x509_certificate-signature.yml
+++ b/changelogs/fragments/407-x509_certificate-signature.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "x509_certificate - regenerate certificate when the CA's public key changes for ``provider=ownca`` (https://github.com/ansible-collections/community.crypto/pull/407)."
+  - "x509_certificate - regenerate certificate when the private key changes for ``provider=selfsigned`` (https://github.com/ansible-collections/community.crypto/pull/407)."

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -42,23 +42,23 @@ except ImportError:
     pass
 
 try:
-    cryptography.hazmat.primitives.asymmetric.rsa
+    import cryptography.hazmat.primitives.asymmetric.rsa
 except ImportError:
     pass
 try:
-    cryptography.hazmat.primitives.asymmetric.ec
+    import cryptography.hazmat.primitives.asymmetric.ec
 except ImportError:
     pass
 try:
-    cryptography.hazmat.primitives.asymmetric.dsa
+    import cryptography.hazmat.primitives.asymmetric.dsa
 except ImportError:
     pass
 try:
-    cryptography.hazmat.primitives.asymmetric.ed25519
+    import cryptography.hazmat.primitives.asymmetric.ed25519
 except ImportError:
     pass
 try:
-    cryptography.hazmat.primitives.asymmetric.ed448
+    import cryptography.hazmat.primitives.asymmetric.ed448
 except ImportError:
     pass
 

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -32,11 +32,34 @@ from ansible_collections.community.crypto.plugins.module_utils.version import Lo
 try:
     import cryptography
     from cryptography import x509
+    from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
     import ipaddress
 except ImportError:
     # Error handled in the calling module.
+    pass
+
+try:
+    cryptography.hazmat.primitives.asymmetric.rsa
+except ImportError:
+    pass
+try:
+    cryptography.hazmat.primitives.asymmetric.ec
+except ImportError:
+    pass
+try:
+    cryptography.hazmat.primitives.asymmetric.dsa
+except ImportError:
+    pass
+try:
+    cryptography.hazmat.primitives.asymmetric.ed25519
+except ImportError:
+    pass
+try:
+    cryptography.hazmat.primitives.asymmetric.ed448
+except ImportError:
     pass
 
 try:
@@ -58,8 +81,13 @@ except ImportError:
     _load_pkcs12 = None
 
 from .basic import (
+    CRYPTOGRAPHY_HAS_DSA_SIGN,
+    CRYPTOGRAPHY_HAS_EC_SIGN,
     CRYPTOGRAPHY_HAS_ED25519,
+    CRYPTOGRAPHY_HAS_ED25519_SIGN,
     CRYPTOGRAPHY_HAS_ED448,
+    CRYPTOGRAPHY_HAS_ED448_SIGN,
+    CRYPTOGRAPHY_HAS_RSA_SIGN,
     CRYPTOGRAPHY_HAS_X25519,
     CRYPTOGRAPHY_HAS_X25519_FULL,
     CRYPTOGRAPHY_HAS_X448,
@@ -664,3 +692,47 @@ def _parse_pkcs12_legacy(pkcs12_bytes, passphrase=None):
         if maybe_name != backend._ffi.NULL:
             friendly_name = backend._ffi.string(maybe_name)
     return private_key, certificate, additional_certificates, friendly_name
+
+
+def cryptography_verify_certificate_signature(certificate, signer_public_key):
+    '''
+    Check whether the given X509 certificate object was signed by the given public key object.
+    '''
+    try:
+        if CRYPTOGRAPHY_HAS_RSA and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey):
+            signer_public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                certificate.signature_hash_algorithm,
+            )
+            return True
+        if CRYPTOGRAPHY_HAS_EC_SIGN and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey):
+            signer_public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                cryptography.hazmat.primitives.asymmetric.ec.ECDSA(certificate.signature_hash_algorithm),
+            )
+            return True
+        if CRYPTOGRAPHY_HAS_DSA_SIGN and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey):
+            signer_public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                certificate.signature_hash_algorithm,
+            )
+            return True
+        if CRYPTOGRAPHY_HAS_ED25519_SIGN and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey):
+            signer_public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+            )
+            return True
+        if CRYPTOGRAPHY_HAS_ED448_SIGN and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.ed448.Ed448PublicKey):
+            signer_public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+            )
+            return True
+        raise OpenSSLObjectError(u'Unsupported public key type {0}'.format(type(signer_public_key)))
+    except InvalidSignature:
+        return False

--- a/plugins/module_utils/crypto/cryptography_support.py
+++ b/plugins/module_utils/crypto/cryptography_support.py
@@ -699,7 +699,7 @@ def cryptography_verify_certificate_signature(certificate, signer_public_key):
     Check whether the given X509 certificate object was signed by the given public key object.
     '''
     try:
-        if CRYPTOGRAPHY_HAS_RSA and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey):
+        if CRYPTOGRAPHY_HAS_RSA_SIGN and isinstance(signer_public_key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey):
             signer_public_key.verify(
                 certificate.signature,
                 certificate.tbs_certificate_bytes,

--- a/plugins/module_utils/crypto/module_backends/certificate_ownca.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_ownca.py
@@ -28,6 +28,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.support im
 )
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.cryptography_support import (
+    cryptography_compare_public_keys,
     cryptography_key_needs_digest_for_signing,
     cryptography_serial_number_of_cert,
     cryptography_verify_certificate_signature,
@@ -107,6 +108,9 @@ class OwnCACertificateBackendCryptography(CertificateBackend):
             )
         except OpenSSLBadPassphraseError as exc:
             module.fail_json(msg=str(exc))
+
+        if not cryptography_compare_public_keys(self.ca_cert.public_key(), self.ca_private_key.public_key()):
+            raise CertificateError('The CA private key does not belong to the CA certificate')
 
         if cryptography_key_needs_digest_for_signing(self.ca_private_key):
             if self.digest is None:

--- a/plugins/module_utils/crypto/module_backends/certificate_ownca.py
+++ b/plugins/module_utils/crypto/module_backends/certificate_ownca.py
@@ -30,6 +30,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.support im
 from ansible_collections.community.crypto.plugins.module_utils.crypto.cryptography_support import (
     cryptography_key_needs_digest_for_signing,
     cryptography_serial_number_of_cert,
+    cryptography_verify_certificate_signature,
 )
 
 from ansible_collections.community.crypto.plugins.module_utils.crypto.module_backends.certificate import (
@@ -174,6 +175,10 @@ class OwnCACertificateBackendCryptography(CertificateBackend):
             return True
 
         self._ensure_existing_certificate_loaded()
+
+        # Check whether certificate is signed by CA certificate
+        if not cryptography_verify_certificate_signature(self.existing_certificate, self.ca_cert.public_key()):
+            return True
 
         # Check subject
         if self.ca_cert.subject != self.existing_certificate.issuer:

--- a/tests/integration/targets/x509_certificate/tasks/ownca.yml
+++ b/tests/integration/targets/x509_certificate/tasks/ownca.yml
@@ -344,7 +344,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_backup.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     backup: yes
@@ -355,7 +355,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_backup.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     backup: yes
@@ -366,7 +366,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_backup.pem'
     csr_path: '{{ remote_tmp_dir }}/csr.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     backup: yes
@@ -394,7 +394,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_ski.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_subject_key_identifier: always_create
@@ -406,7 +406,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_ski.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_subject_key_identifier: always_create
@@ -418,7 +418,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_ski.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_subject_key_identifier: never_create
@@ -430,7 +430,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_ski.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_subject_key_identifier: never_create
@@ -442,7 +442,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_ski.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_subject_key_identifier: always_create
@@ -454,7 +454,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_aki.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_authority_key_identifier: yes
@@ -466,7 +466,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_aki.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_authority_key_identifier: yes
@@ -478,7 +478,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_aki.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_authority_key_identifier: no
@@ -490,7 +490,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_aki.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_authority_key_identifier: no
@@ -502,7 +502,7 @@
     path: '{{ remote_tmp_dir }}/ownca_cert_aki.pem'
     csr_path: '{{ remote_tmp_dir }}/csr_ecc.csr'
     ownca_path: '{{ remote_tmp_dir }}/ca_cert.pem'
-    ownca_privatekey_path: '{{ remote_tmp_dir }}/privatekey.pem'
+    ownca_privatekey_path: '{{ remote_tmp_dir }}/ca_privatekey.pem'
     provider: ownca
     ownca_digest: sha256
     ownca_create_authority_key_identifier: yes


### PR DESCRIPTION
##### SUMMARY
In stable-1 with the PyOpenSSL backend, this causes #406 to fail.

Can be replicated with the cryptography backend when `ownca_create_authority_key_identifier=false`. I will add tests for this later, that's why it's WIP now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
x509_certificate
