### PR TITLE
openssh_keypair - Fix documentation for public_key return value

### DIFF
--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -178,7 +178,7 @@ public_key:
     description: The public key of the generated SSH private key.
     returned: changed or success
     type: str
-    sample: ssh-rsa AAAAB3Nza(...omitted...)veL4E3Xcw== test_key
+    sample: ssh-rsa AAAAB3Nza(...omitted...)veL4E3Xcw==
 comment:
     description: The comment of the generated key.
     returned: changed or success


### PR DESCRIPTION
##### SUMMARY
Removes comment from `public_key` return value example to avoid confusion.

Fixes #411

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/openssh_keypair.py

##### ADDITIONAL INFORMATION
N/A
