### PR TITLE
Remove begin format for private key

### DIFF
--- a/tests/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/tests/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -88,6 +88,13 @@
     size: '{{ default_rsa_key_size }}'
     select_crypto_backend: '{{ select_crypto_backend }}'
 
+- name: "({{ select_crypto_backend }}) Generate privatekey7 - only_key"
+  openssl_privatekey:
+    path: '{{ remote_tmp_dir }}/privatekey7.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+    only_key: yes
+  register: privatekey7
+
 - set_fact:
     ecc_types:
     - curve: secp384r1

--- a/tests/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/tests/integration/targets/openssl_privatekey/tests/validate.yml
@@ -2,10 +2,10 @@
 - set_fact:
     system_potentially_has_no_algorithm_support: "{{ ansible_os_family == 'FreeBSD' }}"
 
-- name: "({{ select_crypto_backend }}) Read private key"
+- name: "({{ select_crypto_backend }}) Read private key (privatekey1)"
   slurp:
     src: '{{ remote_tmp_dir }}/privatekey1.pem'
-  register: slurp
+  register: slurp1
 
 - name: "({{ select_crypto_backend }}) Validate privatekey1 idempotency and content returned"
   assert:
@@ -14,7 +14,7 @@
       - privatekey1 is changed
       - privatekey1_idempotence_check is not changed
       - privatekey1_idempotence is not changed
-      - privatekey1.privatekey == (slurp.content | b64decode)
+      - privatekey1.privatekey == (slurp1.content | b64decode)
       - privatekey1.privatekey == privatekey1_idempotence.privatekey
 
 
@@ -95,6 +95,16 @@
     that:
       - privatekey6.stdout == '{{ default_rsa_key_size }}'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
+
+- name: "({{ select_crypto_backend }}) Read private key (privatekey7)"
+  slurp:
+    src: '{{ remote_tmp_dir }}/privatekey7.pem'
+  register: slurp7
+
+- name: "({{ select_crypto_backend }}) Validate privatekey7 (assert - Contains only the key and no format prefix)"
+  assert:
+    that:
+      - not (slurp7.content | b64decode).startswith('----')
 
 - name: "({{ select_crypto_backend }}) Validate ECC generation (dump with OpenSSL)"
   shell: "{{ openssl_binary }} ec -in {{ remote_tmp_dir }}/privatekey-{{ item.item.curve }}.pem -noout -text | grep 'ASN1 OID: ' | sed 's/ASN1 OID: \\([^ ]*\\)/\\1/'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request add the parameter `only_key` to the component `openssl_privatekey`.    
The goal is to only retrieve the key and not the prefix and suffit.
Prefix: `----BEGIN <format> PRIVATE KEY----`   
Suffix `-----END <format> PRIVATE KEY-----`

This could be useful if you need a key for _mongo_:
<details>
  <summary>Example of mongodb config where private key is needed</summary>
  <pre>
# ...
net:
    bindIp: 0.0.0.0
# ...
security:
    authorization: enabled
    keyFile: private_key.pem  </pre>
</details>

The format of the key must be the following:
```
MIIEowIBAAKCAQEAxVz9nMEWyI+2CHLHxOi7YRX+S3IndvqJYPNYhvwXww86v28T\nzjMYjVwiN4yvF6v8SYDPYXwqcxtrTIleprm7GZVnXD/BbB2gWMuu9vqS3+VKr/uG\nkcz8DE1Y6bQ9CbgU9gtHNYCk/xYkbsKM95MakA6DKTKEo3KV/LK7rnzsKifDN+BV\n43ROdzC/Wn2+E/rMjB6/UUEmgOj84zpugNJ/S3c6FGMlAufrpQQuLWzYgQzab4LE\n5lFpgXIQAXIpjNGWiQ9rYMGlxpn5+tW56a7oFFk7YbzTvH2o+Am/F5Uj7FMbWmwk\nU0LiI+NduWcHZBZOc/3kr3+1dvRE9QYWW21NMwIDAQABAoIBAQCO4GbpGA+6We9Z\n5l4geqtL+XQCgj13sJ/Lg99OuSkqmNfaxjr8R5k6nLxYoowPAv6853c6B31jnzHq\nUngnEsYUG0icS7tm3Xu7TJj5SyUQ2RlclSYyXscI0OXRKh4V7yGdjUSbwumvkQQG\n+ui6QdA1AYyKQnwrJ0TVjz63btA5IxI3a4UL9xY1DMyFDInQbFFyPPBIaKY3A7nN\nfN02mp8UxTLldRGwTEu4/eakgCb9+2T9enkT959WWnqe96to6Jw8nkVEhfc7IZpi\nr5VsK7gqzOrT9kozFx3yte83H59XcQaraQqoiBGOgtlFG4ab+THEq2RKuog8ypGp\nofOSn1IBAoGBAOr0ifX+x2LNr8jTc/u3HLk5pJc3HDL7p4IAoNSQflHJH62nBEiQ\nPfqtnBCiFkeslltMdkZJpjARVEYfJuhf5yJLpyfSzk5mB1e8lzOAvaFehAsZ382O\nK5HEtiqJ6iZdtGCJULfaU63EKgxAZOif3PeA+YkY7LSr6pd2+CclUstBAoGBANcK\nej5bBCYQ3ypycSDDWvJUO/CapYJRVl5H2so+w3lVrz5TCgAChxWFi7raMEeWDXTA\nKCaPdMBz4jac7zBWWxHbO5OBdTsu+ELzfZHDm6G2sLQ3Bbf6IAL9FpNLvLJzvy4B\nN8tuPGWc+ajMkx5b7zEEbbNrwlzOedrLdFG8dz9zAoGARaagj1AsA1o+ViZ5J5Gs\n7ivsYvdvYJ3BloRhKSJ8j/ozbeMpHenEtd9peHTUbgL3v7D3DvceUPmSJgduHUzw\n0/XhY6jWh98vJg8+M4JitMe0FSZidilDOT87UXj49M6qfkO2rgoG7GhOnrsoLt3V\nP3n4f2/oG9crACPAhLpHxQECgYAUObQNsVnOir+yqljhj/451Jpeouz2ONg6vd9i\nLk0MWHbHEeBa5+H0sD7YMDViRka1uG0OU2fTwhKAuHn2veiK4WfVE9QG4QAQq/4f\ne5pjt18fVB2BlFD2dv9sky8IScKtfQfWZmPf2sfQjI05ycPRhG0c9wGs4O6tGX2z\nQlqk6QKBgD1/W21D2PhjQwWW6svsAb8LEz6rjCfJC2Dgvg796rtjFJDpaF4W6IMt\nLT9JlDiN9dlmF6868uXvPTs5r29LQ6pJWPd3haraYgWKlLRQtZ5UmcSLfW2YxD5q\nASTRob5WoYReuZGZUE9bCtgHF7bL8SNIUCGSg3JgqsYX1fFsVp4b
```

And not this one:
````
-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAxVz9nMEWyI+2CHLHxOi7YRX+S3IndvqJYPNYhvwXww86v28T\nzjMYjVwiN4yvF6v8SYDPYXwqcxtrTIleprm7GZVnXD/BbB2gWMuu9vqS3+VKr/uG\nkcz8DE1Y6bQ9CbgU9gtHNYCk/xYkbsKM95MakA6DKTKEo3KV/LK7rnzsKifDN+BV\n43ROdzC/Wn2+E/rMjB6/UUEmgOj84zpugNJ/S3c6FGMlAufrpQQuLWzYgQzab4LE\n5lFpgXIQAXIpjNGWiQ9rYMGlxpn5+tW56a7oFFk7YbzTvH2o+Am/F5Uj7FMbWmwk\nU0LiI+NduWcHZBZOc/3kr3+1dvRE9QYWW21NMwIDAQABAoIBAQCO4GbpGA+6We9Z\n5l4geqtL+XQCgj13sJ/Lg99OuSkqmNfaxjr8R5k6nLxYoowPAv6853c6B31jnzHq\nUngnEsYUG0icS7tm3Xu7TJj5SyUQ2RlclSYyXscI0OXRKh4V7yGdjUSbwumvkQQG\n+ui6QdA1AYyKQnwrJ0TVjz63btA5IxI3a4UL9xY1DMyFDInQbFFyPPBIaKY3A7nN\nfN02mp8UxTLldRGwTEu4/eakgCb9+2T9enkT959WWnqe96to6Jw8nkVEhfc7IZpi\nr5VsK7gqzOrT9kozFx3yte83H59XcQaraQqoiBGOgtlFG4ab+THEq2RKuog8ypGp\nofOSn1IBAoGBAOr0ifX+x2LNr8jTc/u3HLk5pJc3HDL7p4IAoNSQflHJH62nBEiQ\nPfqtnBCiFkeslltMdkZJpjARVEYfJuhf5yJLpyfSzk5mB1e8lzOAvaFehAsZ382O\nK5HEtiqJ6iZdtGCJULfaU63EKgxAZOif3PeA+YkY7LSr6pd2+CclUstBAoGBANcK\nej5bBCYQ3ypycSDDWvJUO/CapYJRVl5H2so+w3lVrz5TCgAChxWFi7raMEeWDXTA\nKCaPdMBz4jac7zBWWxHbO5OBdTsu+ELzfZHDm6G2sLQ3Bbf6IAL9FpNLvLJzvy4B\nN8tuPGWc+ajMkx5b7zEEbbNrwlzOedrLdFG8dz9zAoGARaagj1AsA1o+ViZ5J5Gs\n7ivsYvdvYJ3BloRhKSJ8j/ozbeMpHenEtd9peHTUbgL3v7D3DvceUPmSJgduHUzw\n0/XhY6jWh98vJg8+M4JitMe0FSZidilDOT87UXj49M6qfkO2rgoG7GhOnrsoLt3V\nP3n4f2/oG9crACPAhLpHxQECgYAUObQNsVnOir+yqljhj/451Jpeouz2ONg6vd9i\nLk0MWHbHEeBa5+H0sD7YMDViRka1uG0OU2fTwhKAuHn2veiK4WfVE9QG4QAQq/4f\ne5pjt18fVB2BlFD2dv9sky8IScKtfQfWZmPf2sfQjI05ycPRhG0c9wGs4O6tGX2z\nQlqk6QKBgD1/W21D2PhjQwWW6svsAb8LEz6rjCfJC2Dgvg796rtjFJDpaF4W6IMt\nLT9JlDiN9dlmF6868uXvPTs5r29LQ6pJWPd3haraYgWKlLRQtZ5UmcSLfW2YxD5q\nASTRob5WoYReuZGZUE9bCtgHF7bL8SNIUCGSg3JgqsYX1fFsVp4b\n-----END RSA PRIVATE KEY-----\n
````

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssl_privatekey

**Example of use:**
```YAML
- name: Generate private key for mongo
  community.crypto.openssl_privatekey:
    path: "/etc/local/mongodb/key"
    size: 512
    only_key: yes
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**Test**   
I try to add a test but I don't think it is a good test...  I can write other tests if you give me some "idea" to correctly do it 😉 

**Version**   
I don't know what I need to specified for the field `version_added`.  So I set the version `2.3.0`


<!--- Paste verbatim command output below, e.g. before and after your change -->
