### PR TITLE
Add stable-2.13 to CI, thin out older version matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -200,12 +200,8 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 31
               test: fedora31
-            - name: openSUSE 15 py3
-              test: opensuse15
             - name: Ubuntu 18.04
               test: ubuntu1804
 
@@ -268,8 +264,6 @@ stages:
               test: macos/11.1
             - name: RHEL 8.4
               test: rhel/8.4
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
   - stage: Remote_2_11
     displayName: Remote 2.11
     dependsOn: []
@@ -335,12 +329,7 @@ stages:
           testFormat: 2.13/cloud/{0}/1
           targets:
             - test: 2.7
-            - test: 3.5
-            - test: 3.6
             - test: 3.7
-            - test: 3.8
-            - test: 3.9
-            - test: "3.10"
   - stage: Cloud_2_12
     displayName: Cloud 2.12
     dependsOn: []

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -60,6 +60,17 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
+  - stage: Ansible_2_13
+    displayName: Sanity & Units 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.13/sanity/1'
+            - name: Units
+              test: '2.13/units/1'
   - stage: Ansible_2_12
     displayName: Sanity & Units 2.12
     dependsOn: []
@@ -129,6 +140,20 @@ stages:
               test: ubuntu2004
             - name: Alpine 3
               test: alpine3
+  - stage: Docker_2_13
+    displayName: Docker 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/linux/{0}/1
+          targets:
+            - name: Fedora 34
+              test: fedora34
+            - name: Ubuntu 18.04
+              test: ubuntu1804
+            - name: Alpine 3
+              test: alpine3
   - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
@@ -141,10 +166,6 @@ stages:
               test: centos6
             - name: Fedora 33
               test: fedora33
-            - name: openSUSE 15 py3
-              test: opensuse15
-            - name: Ubuntu 20.04
-              test: ubuntu2004
   - stage: Docker_2_11
     displayName: Docker 2.11
     dependsOn: []
@@ -157,10 +178,6 @@ stages:
               test: centos7
             - name: Fedora 32
               test: fedora32
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: Ubuntu 18.04
-              test: ubuntu1804
             - name: Alpine 3
               test: alpine3
   - stage: Docker_2_10
@@ -183,8 +200,6 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}/1
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: Fedora 31
@@ -229,6 +244,18 @@ stages:
               test: freebsd/12.3
             - name: FreeBSD 13.0
               test: freebsd/13.0
+  - stage: Remote_2_13
+    displayName: Remote 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/{0}/1
+          targets:
+            - name: macOS 12.0
+              test: macos/12.0
+            - name: RHEL 8.5
+              test: rhel/8.5
   - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
@@ -298,6 +325,22 @@ stages:
             - test: 3.8
             - test: 3.9
             - test: "3.10"
+  - stage: Cloud_2_13
+    displayName: Cloud 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.13/cloud/{0}/1
+          targets:
+            - test: 2.7
+            - test: 3.5
+            - test: 3.6
+            - test: 3.7
+            - test: 3.8
+            - test: 3.9
+            - test: "3.10"
   - stage: Cloud_2_12
     displayName: Cloud 2.12
     dependsOn: []
@@ -346,22 +389,26 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_13
       - Ansible_2_12
       - Ansible_2_11
       - Ansible_2_10
       - Ansible_2_9
       - Remote_devel
+      - Remote_2_13
       - Remote_2_12
       - Remote_2_11
       - Remote_2_10
       - Remote_2_9
       - Docker_devel
+      - Docker_2_13
       - Docker_2_12
       - Docker_2_11
       - Docker_2_10
       - Docker_2_9
       - Docker_community_devel
       - Cloud_devel
+      - Cloud_2_13
       - Cloud_2_12
       - Cloud_2_11
       - Cloud_2_10

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12 and ansible-core 2.13 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,1 @@
+.azure-pipelines/scripts/publish-codecov.py replace-urlopen


### PR DESCRIPTION
##### SUMMARY
Add stable-2.13 to CI, thin out older version matrix to avoid costs to grow (too much).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
