### PR TITLE
Add ssh-ed25519 signature algorithm

### DIFF
--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -82,6 +82,7 @@ options:
             - ssh-rsa
             - rsa-sha2-256
             - rsa-sha2-512
+            - ssh-ed25519
         version_added: 1.10.0
     signing_key:
         description:
@@ -543,7 +544,7 @@ def main():
                 default='partial_idempotence',
                 choices=['never', 'fail', 'partial_idempotence', 'full_idempotence', 'always']
             ),
-            signature_algorithm=dict(type='str', choices=['ssh-rsa', 'rsa-sha2-256', 'rsa-sha2-512']),
+            signature_algorithm=dict(type='str', choices=['ssh-rsa', 'rsa-sha2-256', 'rsa-sha2-512', 'ssh-ed25519']),
             signing_key=dict(type='path'),
             serial_number=dict(type='int'),
             state=dict(type='str', default='present', choices=['absent', 'present']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #430.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Successful invocation with the patch:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  info:
  - 'Type: ssh-ed25519-cert-v01@openssh.com host certificate'
  - 'Public key: ED25519-CERT SHA256:x'
  - 'Signing CA: ED25519 SHA256:x'
  - 'Key ID: "keyid-20220329"'
  - 'Serial: 0'
  - 'Valid: from 2021-01-01T07:00:00 to 2023-03-01T00:00:00'
  - 'Principals: host.example.com'
  - 'Critical Options: (none)'
  - 'Extensions: (none)'
```
