### PR TITLE
openssl_pkcs12: add privatekey_content option

### DIFF
--- a/changelogs/fragments/452-openssl_pkcs12-private-key-content.yml
+++ b/changelogs/fragments/452-openssl_pkcs12-private-key-content.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "openssl_pkcs12 - allow to provide the private key as text instead of having to read it from a file.
+     This allows to store the private key in an encrypted form, for example in Ansible Vault
+     (https://github.com/ansible-collections/community.crypto/pull/452)."

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -45,6 +45,22 @@
       return_content: true
     register: p12_standard_idempotency
 
+  - name: "({{ select_crypto_backend }}) Read ansible_pkey1.pem"
+    slurp:
+      src: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+    register: ansible_pkey_content
+
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file again, idempotency (private key from file)"
+    openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
+      path: '{{ remote_tmp_dir }}/ansible.p12'
+      friendly_name: abracadabra
+      privatekey_content: '{{ ansible_pkey_content.content | b64decode }}'
+      certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+      state: present
+      return_content: true
+    register: p12_standard_idempotency_2
+
   - name: "({{ select_crypto_backend }}) Read ansible.p12"
     slurp:
       src: '{{ remote_tmp_dir }}/ansible.p12'

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -25,6 +25,7 @@
       - p12_dumped is changed
       - p12_standard_idempotency is not changed
       - p12_standard_idempotency_check is not changed
+      - p12_standard_idempotency_2 is not changed
       - p12_multiple_certs_idempotency is not changed
       - p12_dumped_idempotency is not changed
       - p12_dumped_check_mode is not changed


### PR DESCRIPTION
##### SUMMARY
This allows to store the private key in another form, like in Ansible vault, or encrypted with sops.

Right now it has to be present as a file, which in my setup requires me to write it to a temporary file (unprotected), use it in this module, and then wipe the temporary file in a `always:` part of a `block:`. That's a lot of extra code and also dangerous.

(Not that PKCS12 passphrases offer *that* much more protection...)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_pkcs12
