### PR TITLE
Deprecate Ansible 2.9 and ansible-base 2.10 support

### DIFF
--- a/changelogs/fragments/deprecate-ansible-2.9-2.10.yml
+++ b/changelogs/fragments/deprecate-ansible-2.9-2.10.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- Support for Ansible 2.9 and ansible-base 2.10 is deprecated, and will be removed in the next major release (community.crypto 3.0.0). Some modules might still work with these versions afterwards, but we will no longer keep compatibility code that was needed to support them (https://github.com/ansible-collections/community.crypto/pull/460).


### PR DESCRIPTION
##### SUMMARY
It's about time. Both versions are EOL by the end of this month.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
collection
