### PR TITLE
ci: enable rhel9.0 tests for openssh_cert

### DIFF
--- a/tests/integration/targets/openssh_cert/aliases
+++ b/tests/integration/targets/openssh_cert/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group1
 destructive
-skip/rhel9.0  # TODO figure out why and fix

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -63,13 +63,13 @@
         valid_from: always
         valid_to: forever
       register: second_signature_algorithm
-      when: openssh_version is version("8.7", "<")
+      when: openssh_version is version("8.7", "!=")
 
     - name: Assert second signature algorithm update causes change
       assert:
         that:
           - second_signature_algorithm is changed
-      when: openssh_version is version("8.7", "<")
+      when: openssh_version is version("8.7", "!=")
 
     - name: Omit signature algorithm
       openssh_cert:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -63,11 +63,13 @@
         valid_from: always
         valid_to: forever
       register: second_signature_algorithm
+      when: openssh_version is version("8.7", "<")
 
     - name: Assert second signature algorithm update causes change
       assert:
         that:
           - second_signature_algorithm is changed
+      when: openssh_version is version("8.7", "<")
 
     - name: Omit signature algorithm
       openssh_cert:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -63,13 +63,13 @@
         valid_from: always
         valid_to: forever
       register: second_signature_algorithm
-      when: openssh_version is version("8.7", "!=")
+      when: not (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "9")
 
     - name: Assert second signature algorithm update causes change
       assert:
         that:
           - second_signature_algorithm is changed
-      when: openssh_version is version("8.7", "!=")
+      when: not (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "9")
 
     - name: Omit signature algorithm
       openssh_cert:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -53,23 +53,25 @@
         that:
           - updated_signature_algorithm_idempotent is not changed
 
-    - name: Generate cert with original signature algorithm
-      openssh_cert:
-        type: user
-        path: "{{ certificate_path }}"
-        public_key: "{{ public_key }}"
-        signing_key: "{{ signing_key }}"
-        signature_algorithm: ssh-rsa
-        valid_from: always
-        valid_to: forever
-      register: second_signature_algorithm
-      when: not (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "9")
+    - block:
+      - name: Generate cert with original signature algorithm
+        openssh_cert:
+          type: user
+          path: "{{ certificate_path }}"
+          public_key: "{{ public_key }}"
+          signing_key: "{{ signing_key }}"
+          signature_algorithm: ssh-rsa
+          valid_from: always
+          valid_to: forever
+        register: second_signature_algorithm
 
-    - name: Assert second signature algorithm update causes change
-      assert:
-        that:
-          - second_signature_algorithm is changed
-      when: not (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "9")
+      - name: Assert second signature algorithm update causes change
+        assert:
+          that:
+            - second_signature_algorithm is changed
+      # RHEL9 disables SHA-1 algorithms by default making this test fail with a 'libcrypt' error. Other systems which
+      # impose a similar restriction may also need to skip this block in the future.
+      when: not (ansible_facts['distribution'] == "RedHat" and (ansible_facts['distribution_major_version'] | int) >= 9)
 
     - name: Omit signature algorithm
       openssh_cert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Re-enables RHEL9.0 tests for `openssh_cert`
Fixes #462

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/openssh_cert.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
