### PR TITLE
[WIP] Bump AZP container version

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -41,7 +41,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.9.0
+      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
 
 pool: Standard
 


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/news-for-maintainers/issues/18

We **do not** drop ansible-base 2.10 and Ansible 2.9 from CI since we still support these versions.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
