### PR TITLE
Fix ValueError: excluded_subtrees must be a non-empty list or None

### DIFF
--- a/changelogs/fragments/481-fix-excluded_subtrees-must-be-a-non-empty-list-or-None.yml
+++ b/changelogs/fragments/481-fix-excluded_subtrees-must-be-a-non-empty-list-or-None.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_csr - the module no longer crashes with 'permitted_subtrees/excluded_subtrees must be a non-empty list or None' if only one of ``name_constraints_permitted`` and ``name_constraints_excluded`` is provided (https://github.com/ansible-collections/community.crypto/issues/481)."

--- a/plugins/module_utils/crypto/module_backends/csr.py
+++ b/plugins/module_utils/crypto/module_backends/csr.py
@@ -345,8 +345,8 @@ class CertificateSigningRequestCryptographyBackend(CertificateSigningRequestBack
         if self.name_constraints_permitted or self.name_constraints_excluded:
             try:
                 csr = csr.add_extension(cryptography.x509.NameConstraints(
-                    [cryptography_get_name(name, 'name constraints permitted') for name in self.name_constraints_permitted],
-                    [cryptography_get_name(name, 'name constraints excluded') for name in self.name_constraints_excluded],
+                    [cryptography_get_name(name, 'name constraints permitted') for name in self.name_constraints_permitted] or None,
+                    [cryptography_get_name(name, 'name constraints excluded') for name in self.name_constraints_excluded] or None,
                 ), critical=self.name_constraints_critical)
             except TypeError as e:
                 raise OpenSSLObjectError('Error while parsing name constraint: {0}'.format(e))
@@ -498,8 +498,8 @@ class CertificateSigningRequestCryptographyBackend(CertificateSigningRequestBack
 
         def _check_nameConstraints(extensions):
             current_nc_ext = _find_extension(extensions, cryptography.x509.NameConstraints)
-            current_nc_perm = [to_text(altname) for altname in current_nc_ext.value.permitted_subtrees] if current_nc_ext else []
-            current_nc_excl = [to_text(altname) for altname in current_nc_ext.value.excluded_subtrees] if current_nc_ext else []
+            current_nc_perm = [to_text(altname) for altname in current_nc_ext.value.permitted_subtrees or []] if current_nc_ext else []
+            current_nc_excl = [to_text(altname) for altname in current_nc_ext.value.excluded_subtrees or []] if current_nc_ext else []
             nc_perm = [to_text(cryptography_get_name(altname, 'name constraints permitted')) for altname in self.name_constraints_permitted]
             nc_excl = [to_text(cryptography_get_name(altname, 'name constraints excluded')) for altname in self.name_constraints_excluded]
             if set(nc_perm) != set(current_nc_perm) or set(nc_excl) != set(current_nc_excl):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes excluded_subtrees must be a non-empty list or None

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssl_csr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When config `community.crypto.openssl_csr` with `name_constraints_permitted` option, the error occur as follow:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: excluded_subtrees must be a non-empty list or None
fatal: [centos7-cert-1 -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):
  File \"/root/.ansible/tmp/ansible-tmp-1655431760.3878613-15371-172134621846530/AnsiballZ_openssl_csr.py\", line 107, in <module>
    _ansiballz_main()
  File \"/root/.ansible/tmp/ansible-tmp-1655431760.3878613-15371-172134621846530/AnsiballZ_openssl_csr.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/root/.ansible/tmp/ansible-tmp-1655431760.3878613-15371-172134621846530/AnsiballZ_openssl_csr.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.crypto.plugins.modules.openssl_csr', init_globals=dict(_module_fqn='ansible_collections.community.crypto.plugins.modules.openssl_csr', _modlib_path=modlib_path),
  File \"/usr/lib/python3.10/runpy.py\", line 209, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_community.crypto.openssl_csr_payload_0mr5hlnk/ansible_community.crypto.openssl_csr_payload.zip/ansible_collections/community/crypto/plugins/modules/openssl_csr.py\", line 348, in <module>
  File \"/tmp/ansible_community.crypto.openssl_csr_payload_0mr5hlnk/ansible_community.crypto.openssl_csr_payload.zip/ansible_collections/community/crypto/plugins/modules/openssl_csr.py\", line 337, in main
  File \"/tmp/ansible_community.crypto.openssl_csr_payload_0mr5hlnk/ansible_community.crypto.openssl_csr_payload.zip/ansible_collections/community/crypto/plugins/modules/openssl_csr.py\", line 281, in generate
  File \"/tmp/ansible_community.crypto.openssl_csr_payload_0mr5hlnk/ansible_community.crypto.openssl_csr_payload.zip/ansible_collections/community/crypto/plugins/module_utils/crypto/module_backends/csr.py\", line 347, in generate_csr
  File \"/usr/lib/python3.10/site-packages/cryptography/x509/extensions.py\", line 1274, in __init__
    raise ValueError(
ValueError: excluded_subtrees must be a non-empty list or None
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```
