### PR TITLE
openssl_pkcs12: fix crash when trying to get non-existing other certificates

### DIFF
--- a/changelogs/fragments/487-openssl_pkcs12-other-certs-crash.yml
+++ b/changelogs/fragments/487-openssl_pkcs12-other-certs-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_pkcs12 - when using the pyOpenSSL backend, do not crash when trying to read non-existing other certificates (https://github.com/ansible-collections/community.crypto/issues/486, https://github.com/ansible-collections/community.crypto/pull/487)."

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -559,6 +559,8 @@ class PkcsPyOpenSSL(Pkcs):
         return crypto.dump_certificate(crypto.FILETYPE_PEM, cert) if cert else None
 
     def _dump_other_certificates(self, pkcs12):
+        if pkcs12.get_ca_certificates() is None:
+            return []
         return [
             crypto.dump_certificate(crypto.FILETYPE_PEM, other_cert)
             for other_cert in pkcs12.get_ca_certificates()


### PR DESCRIPTION
##### SUMMARY
Fixes #486.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
