### PR TITLE
[stable-1] openssl_pkcs12: fix crash when trying to get non-existing other certificates

### DIFF
--- a/changelogs/fragments/487-openssl_pkcs12-other-certs-crash.yml
+++ b/changelogs/fragments/487-openssl_pkcs12-other-certs-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_pkcs12 - when using the pyOpenSSL backend, do not crash when trying to read non-existing other certificates (https://github.com/ansible-collections/community.crypto/issues/486, https://github.com/ansible-collections/community.crypto/pull/487)."

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -542,6 +542,8 @@ class PkcsPyOpenSSL(Pkcs):
         return crypto.dump_certificate(crypto.FILETYPE_PEM, cert) if cert else None
 
     def _dump_other_certificates(self, pkcs12):
+        if pkcs12.get_ca_certificates() is None:
+            return []
         return [
             crypto.dump_certificate(crypto.FILETYPE_PEM, other_cert)
             for other_cert in pkcs12.get_ca_certificates()

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -45,6 +45,18 @@
       return_content: true
     register: p12_standard_idempotency
 
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file again, idempotency (empty other_certificates)"
+    openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
+      path: '{{ remote_tmp_dir }}/ansible.p12'
+      friendly_name: abracadabra
+      privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+      state: present
+      return_content: true
+      other_certificates: []
+    register: p12_standard_idempotency_no_certs
+
   - name: "({{ select_crypto_backend }}) Read ansible.p12"
     slurp:
       src: '{{ remote_tmp_dir }}/ansible.p12'

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -25,6 +25,7 @@
       - p12_dumped is changed
       - p12_standard_idempotency is not changed
       - p12_standard_idempotency_check is not changed
+      - p12_standard_idempotency_no_certs is not changed
       - p12_multiple_certs_idempotency is not changed
       - p12_dumped_idempotency is not changed
       - p12_dumped_check_mode is not changed


### PR DESCRIPTION
##### SUMMARY
Backport of #487 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
