### PR TITLE
Correctly mark plugins/module_utils/crypto/_obj2txt.py as being dually licensed

### DIFF
--- a/plugins/module_utils/crypto/_obj2txt.py
+++ b/plugins/module_utils/crypto/_obj2txt.py
@@ -10,8 +10,7 @@
 #
 # The Apache 2.0 license has been included as LICENSES/Apache-2.0.txt in this collection.
 # The BSD License license has been included as LICENSES/BSD-3-Clause.txt in this collection.
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 #
 # Adapted from cryptography's hazmat/backends/openssl/decode_asn1.py
 #

--- a/tests/sanity/extra/licenses.py
+++ b/tests/sanity/extra/licenses.py
@@ -30,7 +30,8 @@ def find_licenses(filename, relax=False):
                 print('%s: found copyright line with "Copyright:". Please remove the colon.' % (filename, ))
             idx = line.find('SPDX-License-Identifier: ')
             if idx >= 0:
-                spdx_license_identifiers.append(line[idx + len('SPDX-License-Identifier: '):])
+                lic_id = line[idx + len('SPDX-License-Identifier: '):]
+                spdx_license_identifiers.extend(lic_id.split(' OR '))
             if 'GNU General Public License' in line:
                 if 'v3.0+' in line:
                     other_license_identifiers.append('GPL-3.0-or-later')


### PR DESCRIPTION
##### SUMMARY
I think I marked that file wrong. (See https://reuse.software/spec/#comment-headers)

CC @gotmax23 @briantist

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins/module_utils/crypto/_obj2txt.py
