### PR TITLE
add production directory URL for ACME v2 for Sectigo

### DIFF
--- a/plugins/doc_fragments/acme.py
+++ b/plugins/doc_fragments/acme.py
@@ -105,6 +105,8 @@ options:
          U(https://api.buypass.com/acme/directory)."
       - "For B(ZeroSSL), the production directory URL for ACME v2 is
          U(https://acme.zerossl.com/v2/DV90)."
+      - "For B(Sectigo), the production directory URL for ACME v2 is
+         U(https://acme-qa.secure.trust-provider.com/v2/DV)."
       - The notes for this module contain a list of ACME services this module has
         been tested against.
     required: true


### PR DESCRIPTION
##### SUMMARY
According the to official Sectigo documentation [1] the directory URL for ACME v2 is: https://acme-qa.secure.trust-provider.com/v2/DV

[1] https://docs.sectigo.com/scm/acme-integration-docs/1/eab-clients-sectigo-acme-integration.html

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme

##### ADDITIONAL INFORMATION

none
