### PR TITLE
CI: Move Fedora 35 from devel to stable-2.13 CI runs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -131,8 +131,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 35
-              test: fedora35
             - name: Fedora 36
               test: fedora36
             - name: openSUSE 15
@@ -153,6 +151,8 @@ stages:
           targets:
             - name: openSUSE 15 py2
               test: opensuse15py2
+            - name: Fedora 35
+              test: fedora35
             - name: Fedora 34
               test: fedora34
             - name: Ubuntu 18.04


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/news-for-maintainers/issues/21.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
