### PR TITLE
[TEMP] Fix CI: create temp remote directory in ~

### DIFF
--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/default.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/default.yml
@@ -3,10 +3,16 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: create ~/tmp
+  file:
+    path: '~/tmp'
+    state: directory
+
 - name: create temporary directory
   tempfile:
     state: directory
     suffix: .test
+    path: '~/tmp'
   register: remote_tmp_dir
   notify:
     - delete temporary directory


### PR DESCRIPTION
##### SUMMARY
CI currently fails because of https://github.com/ansible-collections/community.crypto/issues/416#issuecomment-1224742778

Once that bug is fixed, this can be reverted.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
