### PR TITLE
acme modules: support 429 Too Many Requests

### DIFF
--- a/changelogs/fragments/508-acme-429.yml
+++ b/changelogs/fragments/508-acme-429.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "acme* modules - support the HTTP 429 Too Many Requests response status (https://github.com/ansible-collections/community.crypto/pull/508)."


### PR DESCRIPTION
##### SUMMARY
Let's Encrypt is now emitting 429 Too Many Requests (instead of not so helpful 500s) when their systems are overloaded: https://community.letsencrypt.org/t/new-service-busy-responses-beginning-during-high-load/184174/1

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme
