### PR TITLE
feat: add private_key_format choices for openssh_keypair

### DIFF
--- a/changelogs/fragments/511-openssh_keypair-private_key_format_options.yml
+++ b/changelogs/fragments/511-openssh_keypair-private_key_format_options.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "openssh_keypair - added ``pkcs1``, ``pkcs8``, and ``ssh`` to the available choices
+    for the ``private_key_format`` option.
+    (https://github.com/ansible-collections/community.crypto/pull/511)."

--- a/plugins/module_utils/openssh/backends/common.py
+++ b/plugins/module_utils/openssh/backends/common.py
@@ -219,10 +219,11 @@ class KeygenCommand(object):
 
 
 class PrivateKey(object):
-    def __init__(self, size, key_type, fingerprint):
+    def __init__(self, size, key_type, fingerprint, format=''):
         self._size = size
         self._type = key_type
         self._fingerprint = fingerprint
+        self._format = format
 
     @property
     def size(self):
@@ -235,6 +236,10 @@ class PrivateKey(object):
     @property
     def fingerprint(self):
         return self._fingerprint
+
+    @property
+    def format(self):
+        return self._format
 
     @classmethod
     def from_string(cls, string):
@@ -251,6 +256,7 @@ class PrivateKey(object):
             'size': self._size,
             'type': self._type,
             'fingerprint': self._fingerprint,
+            'format': self._format,
         }
 
 
@@ -324,3 +330,17 @@ class PublicKey(object):
             'comment': self._comment,
             'public_key': self._data,
         }
+
+
+def parse_private_key_format(path):
+    with open(path, 'r') as file:
+        header = file.readline().strip()
+
+    if header == '-----BEGIN OPENSSH PRIVATE KEY-----':
+        return 'SSH'
+    elif header == '-----BEGIN PRIVATE KEY-----':
+        return 'PKCS8'
+    elif header == '-----BEGIN RSA PRIVATE KEY-----':
+        return 'PKCS1'
+
+    return ''

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -66,14 +66,20 @@ options:
         version_added: 1.7.0
     private_key_format:
         description:
-            - Used when a I(backend=cryptography) to select a format for the private key at the provided I(path).
-            - The only valid option currently is C(auto) which will match the key format of the installed OpenSSH version.
+            - Used when I(backend=cryptography) to select a format for the private key at the provided I(path).
+            - When set to C(auto) this module will match the key format of the installed OpenSSH version.
             - For OpenSSH < 7.8 private keys will be in PKCS1 format except ed25519 keys which will be in OpenSSH format.
             - For OpenSSH >= 7.8 all private key types will be in the OpenSSH format.
+            - Using this option when I(regenerate=partial_idempotence) or I(regenerate=full_idempotence) will cause
+              a new keypair to be generated if the private key's format does not match the value of I(private_key_format).
+              This module will not however convert existing private keys between formats.
         type: str
         default: auto
         choices:
             - auto
+            - pkcs1
+            - pkcs8
+            - ssh
         version_added: 1.7.0
     backend:
         description:
@@ -210,7 +216,11 @@ def main():
                 choices=['never', 'fail', 'partial_idempotence', 'full_idempotence', 'always']
             ),
             passphrase=dict(type='str', no_log=True),
-            private_key_format=dict(type='str', default='auto', no_log=False, choices=['auto']),
+            private_key_format=dict(
+                type='str',
+                default='auto',
+                no_log=False,
+                choices=['auto', 'pkcs1', 'pkcs8', 'ssh']),
             backend=dict(type='str', default='auto', choices=['auto', 'cryptography', 'opensshbin'])
         ),
         supports_check_mode=True,

--- a/tests/integration/targets/openssh_keypair/tests/cryptography_backend.yml
+++ b/tests/integration/targets/openssh_keypair/tests/cryptography_backend.yml
@@ -94,3 +94,75 @@
     path: '{{ remote_tmp_dir }}/pem_encoded'
     backend: cryptography
     state: absent
+
+- name: Generate a private key with specified format
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: pkcs1
+    backend: cryptography
+
+- name: Generate a private key with specified format (Idempotent)
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: pkcs1
+    backend: cryptography
+  register: private_key_format_idempotent
+
+- name: Check that private key with specified format is idempotent
+  assert:
+    that:
+      - private_key_format_idempotent is not changed
+
+- name: Change to PKCS8 format
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: pkcs8
+    backend: cryptography
+  register: private_key_format_pkcs8
+
+- name: Check that format change causes regeneration
+  assert:
+    that:
+      - private_key_format_pkcs8 is changed
+
+- name: Change to PKCS8 format (Idempotent)
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: pkcs8
+    backend: cryptography
+  register: private_key_format_pkcs8_idempotent
+
+- name: Check that private key with PKCS8 format is idempotent
+  assert:
+    that:
+      - private_key_format_pkcs8_idempotent is not changed
+
+- name: Change to SSH format
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: ssh
+    backend: cryptography
+  register: private_key_format_ssh
+
+- name: Check that format change causes regeneration
+  assert:
+    that:
+      - private_key_format_ssh is changed
+
+- name: Change to SSH format (Idempotent)
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    private_key_format: ssh
+    backend: cryptography
+  register: private_key_format_ssh_idempotent
+
+- name: Check that private key with SSH format is idempotent
+  assert:
+    that:
+      - private_key_format_ssh_idempotent is not changed
+
+- name: Remove private key with specified format
+  openssh_keypair:
+    path: '{{ remote_tmp_dir }}/private_key_format'
+    backend: cryptography
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds the `pkcs1`, `pkcs8`, and `ssh` options to the `openssh_keypair` `private_key_format` option.

Fixes #510

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/openssh_keypair

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
