### PR TITLE
openssh_keypair: Fail when 'private_key_format' specified with backend='opensshbin'

### DIFF
--- a/plugins/module_utils/openssh/backends/keypair_backend.py
+++ b/plugins/module_utils/openssh/backends/keypair_backend.py
@@ -312,6 +312,12 @@ class KeypairBackendOpensshBin(KeypairBackend):
     def __init__(self, module):
         super(KeypairBackendOpensshBin, self).__init__(module)
 
+        if self.module.params['private_key_format'] != 'auto':
+            self.module.fail_json(
+                msg="'auto' is the only valid option for " +
+                    "'private_key_format' when 'backend' is not 'cryptography'"
+            )
+
         self.ssh_keygen = KeygenCommand(self.module)
 
     def _generate_keypair(self, private_key_path):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Alerts user when attempting to specify `private_key_format` with backends other than `cryptography`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/openssh_keypair

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
