### PR TITLE
acme modules: also support 503 for retries

### DIFF
--- a/changelogs/fragments/513-acme-503.yml
+++ b/changelogs/fragments/513-acme-503.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "acme* modules - also support the HTTP 503 Service Unavailable response status (https://github.com/ansible-collections/community.crypto/pull/513)."

--- a/changelogs/fragments/513-acme-503.yml
+++ b/changelogs/fragments/513-acme-503.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "acme* modules - also support the HTTP 503 Service Unavailable response status (https://github.com/ansible-collections/community.crypto/pull/513)."
+  - "acme* modules - also support the HTTP 503 Service Unavailable and 408 Request Timeout response status for automatic retries (https://github.com/ansible-collections/community.crypto/pull/513)."

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -52,7 +52,7 @@ else:
     IPADDRESS_IMPORT_ERROR = None
 
 
-RETRY_STATUS_CODES = (429, 503)
+RETRY_STATUS_CODES = (408, 429, 503)
 
 
 def _decode_retry(module, response, info, retry_count):
@@ -62,6 +62,7 @@ def _decode_retry(module, response, info, retry_count):
     if retry_count >= 5:
         raise ACMEProtocolException(module, msg='Giving up after 5 retries', info=info, response=response)
 
+    # 429 and 503 should have a Retry-After header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
     try:
         retry_after = min(max(1, int(info.get('retry-after'))), 60)
     except (TypeError, ValueError) as dummy:

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -52,8 +52,11 @@ else:
     IPADDRESS_IMPORT_ERROR = None
 
 
+RETRY_STATUS_CODES = (429, 503)
+
+
 def _decode_retry(module, response, info, retry_count):
-    if info['status'] != 429:
+    if info['status'] not in RETRY_STATUS_CODES:
         return False
 
     if retry_count >= 5:

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -63,7 +63,7 @@ def _decode_retry(module, response, info, retry_count):
         retry_after = min(max(1, int(info.get('retry-after'))), 60)
     except (TypeError, ValueError) as dummy:
         retry_after = 10
-    module.log('Retrieved a 429 Too Many Requests on %s, retrying in %s seconds' % (info['url'], retry_after))
+    module.log('Retrieved a %d HTTP status on %s, retrying in %s seconds' % (info['status'], info['url'], retry_after))
 
     time.sleep(retry_after)
     return True


### PR DESCRIPTION
##### SUMMARY
A couple of hours after releasing a new version of the collection with support for HTTP status code 529 for Let's Encrypt, Let's Encrypt decided to switch to HTTP status code 503 (https://community.letsencrypt.org/t/new-service-busy-responses-beginning-during-high-load/184174/2) :roll_eyes:.

This also supports that status code...

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme module utils
