### PR TITLE
CI: drop remote CI targets for EoL Ansible/ansible-base versions; move docker CI targets for EoL Ansible/ansible-base versions to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -109,28 +109,6 @@ stages:
               test: '2.11/sanity/1'
             - name: Units
               test: '2.11/units/1'
-  - stage: Ansible_2_10
-    displayName: Sanity & Units 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.10/sanity/1'
-            - name: Units
-              test: '2.10/units/1'
-  - stage: Ansible_2_9
-    displayName: Sanity & Units 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.9/sanity/1'
-            - name: Units
-              test: '2.9/units/1'
 ### Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -206,28 +184,6 @@ stages:
               test: fedora32
             - name: Alpine 3
               test: alpine3
-  - stage: Docker_2_10
-    displayName: Docker 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.10/linux/{0}/1
-          targets:
-            - name: CentOS 6
-              test: centos6
-  - stage: Docker_2_9
-    displayName: Docker 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.9/linux/{0}/1
-          targets:
-            - name: Fedora 31
-              test: fedora31
-            - name: Ubuntu 18.04
-              test: ubuntu1804
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -312,28 +268,6 @@ stages:
               test: rhel/8.3
             - name: FreeBSD 12.2
               test: freebsd/12.2
-  - stage: Remote_2_10
-    displayName: Remote 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.10/{0}/1
-          targets:
-            - name: OS X 10.11
-              test: osx/10.11
-            # - name: macOS 10.15
-            #   test: macos/10.15
-  - stage: Remote_2_9
-    displayName: Remote 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.9/{0}/1
-          targets:
-            - name: 'RHEL 7.8'
-              test: 'rhel/7.8'
 ### Generic
   - stage: Generic_devel
     displayName: Generic devel
@@ -393,26 +327,6 @@ stages:
           testFormat: 2.11/generic/{0}/1
           targets:
             - test: 3.8
-  - stage: Generic_2_10
-    displayName: Generic 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.10/generic/{0}/1
-          targets:
-            - test: 3.6
-  - stage: Generic_2_9
-    displayName: Generic 2.9
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.9/generic/{0}/1
-          targets:
-            - test: 2.7
 
   ## Finally
 
@@ -424,29 +338,21 @@ stages:
       - Ansible_2_13
       - Ansible_2_12
       - Ansible_2_11
-      - Ansible_2_10
-      - Ansible_2_9
       - Remote_devel
       - Remote_2_14
       - Remote_2_13
       - Remote_2_12
       - Remote_2_11
-      - Remote_2_10
-      - Remote_2_9
       - Docker_devel
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12
       - Docker_2_11
-      - Docker_2_10
-      - Docker_2_9
       - Docker_community_devel
       - Generic_devel
       - Generic_2_14
       - Generic_2_13
       - Generic_2_12
       - Generic_2_11
-      - Generic_2_10
-      - Generic_2_9
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -56,7 +56,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }})
+    name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }}:${{ matrix.target }})
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +65,8 @@ jobs:
         docker:
           - ''
         python:
+          - ''
+        target:
           - ''
         exclude:
           - ansible: ''
@@ -104,6 +106,7 @@ jobs:
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
             ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
+          target: ${{ matrix.target }}
           target-python-version: ${{ matrix.python }}
           docker-image: ${{ matrix.docker }}
           testing-type: integration

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,0 +1,109 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# For the comprehensive list of the inputs supported by the ansible-community/ansible-test-gh-action GitHub Action, see
+# https://github.com/marketplace/actions/ansible-test
+
+name: EOL CI
+on:
+  # Run EOL CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run EOL CI once per day (at 09:00 UTC)
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  sanity:
+    name: EOL Sanity (Ⓐ${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible:
+          - '2.9'
+          - '2.10'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Perform sanity testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          testing-type: sanity
+
+  units:
+    runs-on: ubuntu-latest
+    name: EOL Units (Ⓐ${{ matrix.ansible }})
+    strategy:
+      # As soon as the first unit test fails, cancel the others to free up the CI queue
+      fail-fast: true
+      matrix:
+        ansible:
+          - '2.9'
+          - '2.10'
+
+    steps:
+      - name: >-
+          Perform unit testing against
+          Ansible version ${{ matrix.ansible }}
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          testing-type: units
+
+  integration:
+    runs-on: ubuntu-latest
+    name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }})
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible:
+          - ''
+        docker:
+          - ''
+        python:
+          - ''
+        exclude:
+          - ansible: ''
+        include:
+          # 2.9
+          - ansible: '2.9'
+            docker: fedora31
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.9'
+            docker: ubuntu1804
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.9'
+            docker: default
+            python: '2.7'
+            target: azp/generic/1/
+          # 2.10
+          - ansible: '2.10'
+            docker: centos6
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.10'
+            docker: default
+            python: '3.6'
+            target: azp/generic/1/
+
+    steps:
+      - name: >-
+          Perform integration testing against
+          Ansible version ${{ matrix.ansible }}
+          under Python ${{ matrix.python }}
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-version: stable-${{ matrix.ansible }}
+          pre-test-cmd: >-
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
+          target-python-version: ${{ matrix.python }}
+          docker-image: ${{ matrix.docker }}
+          testing-type: integration

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -29,9 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: felixfontein/ansible-test-gh-action@change-detection
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
+          pull-request-change-detection: 'true'
           testing-type: sanity
 
   units:
@@ -49,9 +50,10 @@ jobs:
       - name: >-
           Perform unit testing against
           Ansible version ${{ matrix.ansible }}
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: felixfontein/ansible-test-gh-action@change-detection
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
+          pull-request-change-detection: 'true'
           testing-type: units
 
   integration:
@@ -99,14 +101,15 @@ jobs:
           Perform integration testing against
           Ansible version ${{ matrix.ansible }}
           under Python ${{ matrix.python }}
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: felixfontein/ansible-test-gh-action@change-detection
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
+          docker-image: ${{ matrix.docker }}
           pre-test-cmd: >-
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
             ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
+          pull-request-change-detection: 'true'
           target: ${{ matrix.target }}
           target-python-version: ${{ matrix.python }}
-          docker-image: ${{ matrix.docker }}
           testing-type: integration


### PR DESCRIPTION
##### SUMMARY
Drop remote CI targets for EoL Ansible/ansible-base versions.
Move docker CI targets for EoL Ansible/ansible-base versions to GHA.

This should remove the size of the Docker image collection on AZP.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
