### PR TITLE
openssl_pkcs12: allow to configure encryption level

### DIFF
--- a/changelogs/fragments/523-pkcs12-compat.yml
+++ b/changelogs/fragments/523-pkcs12-compat.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "openssl_pkcs12 - add option ``encryption_level`` which allows to chose ``compatibility2022`` when cryptography >= 38.0.0 is used
+     to enable a more backwards compatible encryption algorithm. If cryptography uses OpenSSL 3.0.0 or newer, the default algorithm
+     is not compatible with older software (https://github.com/ansible-collections/community.crypto/pull/523)."

--- a/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/impl.yml
@@ -330,6 +330,25 @@
       path: '{{ remote_tmp_dir }}/ansible_empty.pem'
       action: parse
 
+  - name: "({{ select_crypto_backend }}) Generate PKCS#12 file passphrase and compatibility encryption"
+    openssl_pkcs12:
+      select_crypto_backend: '{{ select_crypto_backend }}'
+      path: '{{ remote_tmp_dir }}/ansible_compatibility2022.p12'
+      friendly_name: compat_fn
+      encryption_level: compatibility2022
+      iter_size: 3210
+      passphrase: magicpassword
+      privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+      certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+      other_certificates:
+      - '{{ remote_tmp_dir }}/ansible2.crt'
+      - '{{ remote_tmp_dir }}/ansible3.crt'
+      state: present
+    register: p12_compatibility2022
+    when:
+      - select_crypto_backend == 'cryptography'
+      - cryptography_version.stdout is version('38.0.0', '>=')
+
   - import_tasks: ../tests/validate.yml
 
   always:
@@ -345,3 +364,4 @@
     - ansible_pw2
     - ansible_pw3
     - ansible_empty
+    - ansible_compatibility2022

--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -90,3 +90,23 @@
       - p12_empty_idem is not changed
       - p12_empty_concat_idem is not changed
       - (empty_contents == empty_expected_cryptography) or (empty_contents == empty_expected_pyopenssl and select_crypto_backend == 'pyopenssl')
+
+- name: '({{ select_crypto_backend }}) PKCS#12 with compatibility2022 settings'
+  when:
+    - select_crypto_backend == 'cryptography'
+    - cryptography_version.stdout is version('38.0.0', '>=')
+  block:
+    - name: '({{ select_crypto_backend }}) Validate PKCS#12 with compatibility2022 settings'
+      shell: "{{ openssl_binary }} pkcs12 -info -in {{ remote_tmp_dir }}/ansible_compatibility2022.p12 -nodes -passin pass:'magicpassword'"
+      register: p12_validate_compatibility2022
+
+    - name: '({{ select_crypto_backend }}) Check PKCS#12 with compatibility2022 settings'
+      assert:
+        that:
+          - p12_compatibility2022 is changed
+          - >-
+            'PKCS7 Encrypted data: pbeWithSHA1And3-KeyTripleDES-CBC, Iteration 3210' in p12_validate_compatibility2022.stderr_lines
+          - >-
+            'Shrouded Keybag: pbeWithSHA1And3-KeyTripleDES-CBC, Iteration 3210' in p12_validate_compatibility2022.stderr_lines
+          - >-
+            'friendlyName: compat_fn' in p12_validate_compatibility2022.stdout


### PR DESCRIPTION
##### SUMMARY
At least when cryptography >= 38.0.0 is used. Utilizes https://github.com/pyca/cryptography/pull/7560.

Fixes #521.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_pkcs12
