### PR TITLE
acme module utils: include symbolic HTTP status codes in error and log messages when available

### DIFF
--- a/changelogs/fragments/524-acme-http-errors.yml
+++ b/changelogs/fragments/524-acme-http-errors.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "acme_* modules - include symbolic HTTP status codes in error and log messages when available (https://github.com/ansible-collections/community.crypto/pull/524)."

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -38,6 +38,7 @@ from ansible_collections.community.crypto.plugins.module_utils.acme.errors impor
     NetworkException,
     ModuleFailException,
     KeyParsingError,
+    format_http_status,
 )
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.utils import (
@@ -69,7 +70,7 @@ def _decode_retry(module, response, info, retry_count):
         retry_after = min(max(1, int(info.get('retry-after'))), 60)
     except (TypeError, ValueError) as dummy:
         retry_after = 10
-    module.log('Retrieved a %d HTTP status on %s, retrying in %s seconds' % (info['status'], info['url'], retry_after))
+    module.log('Retrieved a %s HTTP status on %s, retrying in %s seconds' % (format_http_status(info['status']), info['url'], retry_after))
 
     time.sleep(retry_after)
     return True
@@ -138,7 +139,7 @@ class ACMEDirectory(object):
                 retry_count += 1
                 continue
             if info['status'] not in (200, 204):
-                raise NetworkException("Failed to get replay-nonce, got status {0}".format(info['status']))
+                raise NetworkException("Failed to get replay-nonce, got status {0}".format(format_http_status(info['status'])))
             return info['replay-nonce']
 
 

--- a/tests/unit/plugins/module_utils/acme/test_errors.py
+++ b/tests/unit/plugins/module_utils/acme/test_errors.py
@@ -166,7 +166,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             },
         },
         None,
-        'ACME request failed for https://ca.example.com/foo with HTTP status 201.',
+        'ACME request failed for https://ca.example.com/foo with HTTP status 201 Created.',
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -181,7 +181,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'response': create_regular_response('xxx'),
         },
         None,
-        'ACME request failed for https://ca.example.com/foo with HTTP status 201. The raw error result: xxx',
+        'ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The raw error result: xxx',
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -196,7 +196,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'response': create_regular_response('xxx'),
         },
         create_decode_error('yyy'),
-        'ACME request failed for https://ca.example.com/foo with HTTP status 201. The raw error result: xxx',
+        'ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The raw error result: xxx',
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -211,7 +211,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'response': create_regular_response('xxx'),
         },
         lambda content: dict(foo='bar'),
-        "ACME request failed for https://ca.example.com/foo with HTTP status 201. The JSON error result: {'foo': 'bar'}",
+        "ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The JSON error result: {'foo': 'bar'}",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -226,7 +226,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'response': create_error_response(),
         },
         None,
-        'ACME request failed for https://ca.example.com/foo with HTTP status 201.',
+        'ACME request failed for https://ca.example.com/foo with HTTP status 201 Created.',
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -242,7 +242,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'response': create_error_response(),
         },
         lambda content: dict(foo='bar'),
-        "ACME request failed for https://ca.example.com/foo with HTTP status 201. The JSON error result: {'foo': 'bar'}",
+        "ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The JSON error result: {'foo': 'bar'}",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -257,7 +257,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             'content': 'xxx',
         },
         None,
-        "ACME request failed for https://ca.example.com/foo with HTTP status 201. The raw error result: xxx",
+        "ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The raw error result: xxx",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -277,7 +277,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             }
         },
         None,
-        "ACME request failed for https://ca.example.com/foo with HTTP status 400. The JSON error result: {'foo': 'bar'}",
+        "ACME request failed for https://ca.example.com/foo with HTTP status 400 Bad Request. The JSON error result: {'foo': 'bar'}",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 400,
@@ -295,7 +295,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             },
         },
         None,
-        "ACME request failed for https://ca.example.com/foo with HTTP status 201. The JSON error result: {'type': 'foo'}",
+        "ACME request failed for https://ca.example.com/foo with HTTP status 201 Created. The JSON error result: {'type': 'foo'}",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 201,
@@ -312,7 +312,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             },
         },
         None,
-        "ACME request failed for https://ca.example.com/foo with status 400. Error foo.",
+        "ACME request failed for https://ca.example.com/foo with status 400 Bad Request. Error foo.",
         {
             'http_url': 'https://ca.example.com/foo',
             'http_status': 400,
@@ -341,7 +341,7 @@ TEST_ACME_PROTOCOL_EXCEPTION = [
             },
         },
         None,
-        "ACME request failed for https://ca.example.com/foo with status 400. Error \"Foo Error\" (foo). Subproblems:\n"
+        "ACME request failed for https://ca.example.com/foo with status 400 Bad Request. Error \"Foo Error\" (foo). Subproblems:\n"
         "(0) Error bar: \"This is a bar error\".",
         {
             'http_url': 'https://ca.example.com/foo',


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/community.crypto/pull/513#discussion_r994904737.

CC @webknjaz

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme module utils
