### PR TITLE
openssl_privatekey: fix example for cipher

### DIFF
--- a/plugins/modules/openssl_privatekey.py
+++ b/plugins/modules/openssl_privatekey.py
@@ -85,7 +85,7 @@ EXAMPLES = r'''
   community.crypto.openssl_privatekey:
     path: /etc/ssl/private/ansible.com.pem
     passphrase: ansible
-    cipher: aes256
+    cipher: auto
 
 - name: Generate an OpenSSL private key with a different size (2048 bits)
   community.crypto.openssl_privatekey:


### PR DESCRIPTION
##### SUMMARY
If you try to use the task previously described in the example for a encrypted private key you get a error message.

the cipher parameter required for encrypted private keys only accepts the value "auto"  as described in /plugins/doc_fragments/module_privatekey.py.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
openssl_privatekey

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The previously documented value of "aes256" is invalid here and if you tried using the previous example in a playbook you get an error message that the only valid value for this parameter is 'auto'

<!--- Paste verbatim command output below, e.g. before and after your change -->
example task before:
```yaml
    - name: Create private key for the root CA
      openssl_privatekey:
        passphrase: "{{ ca_key_password }}"
        path: "{{ ca_file_location }}/ca.key"
        cipher: aes256
        size: 4096
```

error message:
```
TASK [Create private key for the root CA] ***********************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: Cryptography backend can only use "auto" for cipher option.

```

example task after:
```yaml
    - name: Create private key for the root CA
      openssl_privatekey:
        passphrase: "{{ ca_key_password }}"
        path: "{{ ca_file_location }}/ca.key"
        cipher: auto
        size: 4096
```