### PR TITLE
fix #529 issuer_uri in x509_certificate_info

### DIFF
--- a/changelogs/fragments/aia_issuer.yaml
+++ b/changelogs/fragments/aia_issuer.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - x509_certificate_info - adds ``issuer_uri`` field in return value based on Authority Information Access data (https://github.com/ansible-collections/community.crypto/pull/530).

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -378,6 +378,12 @@ ocsp_uri:
                  C(none) if no OCSP responder URI is included.
     returned: success
     type: str
+issuer_uri:
+    description: The Issuer URI, if included in the certificate. Will be
+                 C(none) if no issuer URI is included.
+    returned: success
+    type: str
+    version_added: 2.9.0
 '''
 
 

--- a/tests/integration/targets/x509_certificate_info/tasks/impl.yml
+++ b/tests/integration/targets/x509_certificate_info/tasks/impl.yml
@@ -180,6 +180,8 @@
     that:
       - "'ocsp_uri' in result"
       - "result.ocsp_uri == 'http://ocsp.int-x3.letsencrypt.org'"
+      - "'issuer_uri' in result"
+      - "result.issuer_uri == 'http://cert.int-x3.letsencrypt.org/'"
       - result.extensions_by_oid | length == 9
       # Precert Signed Certificate Timestamps
       - result.extensions_by_oid['1.3.6.1.4.1.11129.2.4.2'].critical == false


### PR DESCRIPTION
The `issuer_uri` is retrieved from the Authority Information Access field the same way as the OCSP responder URI is. Handling is exactly the same since they reside in the same OID space and have the same data type. Tests have also been added based on the integration test certificates.

Signed-off-by: benaryorg <binary@benary.org>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #529 

Note: this code was semi-hastily put together after I saw that the OCSP responder handling was already there (and it is pretty much the same), so if I missed any additional test cases that should be added or anything else, please say something.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`x509_certificate_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Get certificate information
  community.crypto.x509_certificate_info:
    path: /some/certificate.pem
  register: certinfo

- name: Get upstream certificate
  ansible.builtin.debug:
    # this will print the URI at which the issuer certificate can be retrieved, useful for rebuilding certificate chains.
    msg: |-
      {{ certinfo.issuer_uri }}
```

Before this change no `issuer_uri` will be present, with the change it will be present (for further information consult the added test case).
