### PR TITLE
CI: ansible-core 2.11 is EOL; move CI runs to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -98,17 +98,6 @@ stages:
               test: '2.12/sanity/1'
             - name: Units
               test: '2.12/units/1'
-  - stage: Ansible_2_11
-    displayName: Sanity & Units 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.11/sanity/1'
-            - name: Units
-              test: '2.11/units/1'
 ### Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -170,20 +159,6 @@ stages:
               test: centos6
             - name: Fedora 33
               test: fedora33
-  - stage: Docker_2_11
-    displayName: Docker 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.11/linux/{0}/1
-          targets:
-            - name: CentOS 7
-              test: centos7
-            - name: Fedora 32
-              test: fedora32
-            - name: Alpine 3
-              test: alpine3
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -256,16 +231,6 @@ stages:
             #   test: macos/11.1
             - name: RHEL 8.4
               test: rhel/8.4
-  - stage: Remote_2_11
-    displayName: Remote 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.11/{0}/1
-          targets:
-            - name: RHEL 8.3
-              test: rhel/8.3
             - name: FreeBSD 12.2
               test: freebsd/12.2
 ### Generic
@@ -317,16 +282,6 @@ stages:
           targets:
             - test: 2.6
             - test: 3.9
-  - stage: Generic_2_11
-    displayName: Generic 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.11/generic/{0}/1
-          targets:
-            - test: 3.8
 
   ## Finally
 
@@ -337,22 +292,18 @@ stages:
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
-      - Ansible_2_11
       - Remote_devel
       - Remote_2_14
       - Remote_2_13
       - Remote_2_12
-      - Remote_2_11
       - Docker_devel
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12
-      - Docker_2_11
       - Docker_community_devel
       - Generic_devel
       - Generic_2_14
       - Generic_2_13
       - Generic_2_12
-      - Generic_2_11
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,6 +26,7 @@ jobs:
         ansible:
           - '2.9'
           - '2.10'
+          - '2.11'
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
@@ -45,6 +46,7 @@ jobs:
         ansible:
           - '2.9'
           - '2.10'
+          - '2.11'
 
     steps:
       - name: >-
@@ -94,6 +96,19 @@ jobs:
           - ansible: '2.10'
             docker: default
             python: '3.6'
+            target: azp/generic/1/
+          # 2.11
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.11'
+            docker: default
+            python: '3.8'
             target: azp/generic/1/
 
     steps:


### PR DESCRIPTION
##### SUMMARY
See https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-changelogs

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
