### PR TITLE
Switch CI from ubuntu-latest to ubuntu-20.04 to avoid problems with ansible-test from ansible-core 2.12, 2.13, 2.14

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,7 +27,7 @@ jobs:
           - '2.9'
           - '2.10'
           - '2.11'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@integration-error-behavior
@@ -38,7 +38,7 @@ jobs:
           testing-type: sanity
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: EOL Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
@@ -61,7 +61,7 @@ jobs:
           testing-type: units
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }}:${{ matrix.target }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
##### SUMMARY
This is necessary until https://github.com/ansible/ansible/pull/78550 has been backported to stable-2.12, stable-2.13, and stable-2.14.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
GHA CI
