### PR TITLE
CI: extend matrix to run more tests with VMs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -109,16 +109,17 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 36
-              test: fedora36
             - name: openSUSE 15
               test: opensuse15
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-            - name: Ubuntu 22.04
-              test: ubuntu2204
-            - name: Alpine 3
-              test: alpine3
+            # The following are already tested as VMs with devel:
+            # - name: Fedora 36
+            #   test: fedora36
+            # - name: Ubuntu 20.04
+            #   test: ubuntu2004
+            # - name: Ubuntu 22.04
+            #   test: ubuntu2204
+            # - name: Alpine 3
+            #   test: alpine3
   - stage: Docker_2_14
     displayName: Docker 2.14
     dependsOn: []

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -173,6 +173,8 @@ stages:
               test: debian-bullseye/3.9
             - name: ArchLinux
               test: archlinux/3.10
+            - name: CentOS Stream 8 with Python 3.6
+              test: centos-stream8/3.6
             - name: CentOS Stream 8 with Python 3.9
               test: centos-stream8/3.9
 
@@ -195,6 +197,14 @@ stages:
               test: freebsd/12.3
             - name: FreeBSD 13.1
               test: freebsd/13.1
+            - name: Alpine 3.16
+              test: alpine/3.16
+            - name: Fedora 36
+              test: fedora/36
+            - name: Ubuntu 20.04
+              test: ubuntu/20.04
+            - name: Ubuntu 22.04
+              test: ubuntu/22.04
   - stage: Remote_2_14
     displayName: Remote 2.14
     dependsOn: []

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,11 +111,11 @@ stages:
               test: centos7
             - name: openSUSE 15
               test: opensuse15
+            - name: Ubuntu 20.04
+              test: ubuntu2004
             # The following are already tested as VMs with devel:
             # - name: Fedora 36
             #   test: fedora36
-            # - name: Ubuntu 20.04
-            #   test: ubuntu2004
             # - name: Ubuntu 22.04
             #   test: ubuntu2204
             # - name: Alpine 3
@@ -202,8 +202,9 @@ stages:
               test: alpine/3.16
             - name: Fedora 36
               test: fedora/36
-            - name: Ubuntu 20.04
-              test: ubuntu/20.04
+            # Does not work yet: https://github.com/ansible/ansible/issues/79575
+            # - name: Ubuntu 20.04
+            #   test: ubuntu/20.04
             - name: Ubuntu 22.04
               test: ubuntu/22.04
   - stage: Remote_2_14

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -38,7 +38,7 @@ jobs:
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
       - name: Perform sanity testing
-        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        uses: felixfontein/ansible-test-gh-action@main
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
@@ -69,7 +69,7 @@ jobs:
       - name: >-
           Perform unit testing against
           Ansible version ${{ matrix.ansible }}
-        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        uses: felixfontein/ansible-test-gh-action@main
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
@@ -142,12 +142,14 @@ jobs:
           Perform integration testing against
           Ansible version ${{ matrix.ansible }}
           under Python ${{ matrix.python }}
-        uses: felixfontein/ansible-test-gh-action@integration-error-behavior
+        uses: felixfontein/ansible-test-gh-action@main
         with:
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           docker-image: ${{ matrix.docker }}
           integration-continue-on-error: 'false'
+          integration-diff: 'false'
+          integration-retry-on-error: 'true'
           pre-test-cmd: >-
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
             ;


### PR DESCRIPTION
##### SUMMARY
Switches some Docker containers to VMs (Ubuntu 20.04, 22.04; Fedora 36; Alpine 1.16), and adds CentOS Stream 8 with Python 3.6 (system Python interpreter).

CC @mattclay (as I don't know whether these VMs are supposed to be used by collections as well)

CC @Spredzy @Andersson007 as this extends the CI matrix (even though just minimally) and RH is paying for that :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
