### PR TITLE
CI: improve CI matrix, split into two groups

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -115,8 +115,8 @@ stages:
               test: opensuse15
             - name: Ubuntu 20.04
               test: ubuntu2004
-            - name: Ubuntu 22.04
-              test: ubuntu2204
+            # - name: Ubuntu 22.04
+            #   test: ubuntu2204
             - name: Alpine 3
               test: alpine3
           groups:
@@ -183,6 +183,8 @@ stages:
               test: archlinux/3.10
             - name: CentOS Stream 8 with Python 3.9
               test: centos-stream8/3.9
+            - name: CentOS Stream 8 with Python 3.6
+              test: centos-stream8/3.6
           groups:
             - 1
 
@@ -199,8 +201,8 @@ stages:
               test: macos/12.0
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 9.0
-              test: rhel/9.0
+            # - name: RHEL 9.0
+            #   test: rhel/9.0
             - name: FreeBSD 12.3
               test: freebsd/12.3
             - name: FreeBSD 13.1
@@ -227,8 +229,8 @@ stages:
         parameters:
           testFormat: 2.13/{0}
           targets:
-            - name: macOS 12.0
-              test: macos/12.0
+            # - name: macOS 12.0
+            #   test: macos/12.0
             - name: RHEL 8.5
               test: rhel/8.5
             - name: FreeBSD 13.0
@@ -243,6 +245,7 @@ stages:
         parameters:
           testFormat: 2.12/{0}
           targets:
+            # Not working anymore:
             # - name: macOS 11.1
             #   test: macos/11.1
             - name: RHEL 8.4
@@ -265,8 +268,8 @@ stages:
             - test: 3.5
             - test: 3.6
             - test: 3.7
-            - test: 3.8
-            - test: 3.9
+            # - test: 3.8
+            # - test: 3.9
             - test: "3.10"
             - test: "3.11"
           groups:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -105,7 +105,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}/1
+          testFormat: devel/linux/{0}
           targets:
             - name: CentOS 7
               test: centos7
@@ -119,23 +119,27 @@ stages:
               test: ubuntu2204
             - name: Alpine 3
               test: alpine3
+          groups:
+            - 1
   - stage: Docker_2_14
     displayName: Docker 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.14/linux/{0}/1
+          testFormat: 2.14/linux/{0}
           targets:
             - name: Ubuntu 22.04
               test: ubuntu2204
+          groups:
+            - 1
   - stage: Docker_2_13
     displayName: Docker 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.13/linux/{0}/1
+          testFormat: 2.13/linux/{0}
           targets:
             - name: openSUSE 15 py2
               test: opensuse15py2
@@ -147,18 +151,22 @@ stages:
               test: ubuntu1804
             - name: Alpine 3
               test: alpine3
+          groups:
+            - 1
   - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.12/linux/{0}/1
+          testFormat: 2.12/linux/{0}
           targets:
             - name: CentOS 6
               test: centos6
             - name: Fedora 33
               test: fedora33
+          groups:
+            - 1
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -167,7 +175,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}/1
+          testFormat: devel/linux-community/{0}
           targets:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
@@ -175,6 +183,8 @@ stages:
               test: archlinux/3.10
             - name: CentOS Stream 8 with Python 3.9
               test: centos-stream8/3.9
+          groups:
+            - 1
 
 ### Remote
   - stage: Remote_devel
@@ -183,7 +193,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}/1
+          testFormat: devel/{0}
           targets:
             - name: macOS 12.0
               test: macos/12.0
@@ -195,23 +205,27 @@ stages:
               test: freebsd/12.3
             - name: FreeBSD 13.1
               test: freebsd/13.1
+          groups:
+            - 1
   - stage: Remote_2_14
     displayName: Remote 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.14/{0}/1
+          testFormat: 2.14/{0}
           targets:
             - name: RHEL 9.0
               test: rhel/9.0
+          groups:
+            - 1
   - stage: Remote_2_13
     displayName: Remote 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.13/{0}/1
+          testFormat: 2.13/{0}
           targets:
             - name: macOS 12.0
               test: macos/12.0
@@ -219,13 +233,15 @@ stages:
               test: rhel/8.5
             - name: FreeBSD 13.0
               test: freebsd/13.0
+          groups:
+            - 1
   - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: 2.12/{0}/1
+          testFormat: 2.12/{0}
           targets:
             # - name: macOS 11.1
             #   test: macos/11.1
@@ -233,6 +249,8 @@ stages:
               test: rhel/8.4
             - name: FreeBSD 12.2
               test: freebsd/12.2
+          groups:
+            - 1
 ### Generic
   - stage: Generic_devel
     displayName: Generic devel
@@ -241,7 +259,7 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/generic/{0}/1
+          testFormat: devel/generic/{0}
           targets:
             - test: 2.7
             - test: 3.5
@@ -251,6 +269,8 @@ stages:
             - test: 3.9
             - test: "3.10"
             - test: "3.11"
+          groups:
+            - 1
   - stage: Generic_2_14
     displayName: Generic 2.14
     dependsOn: []
@@ -258,9 +278,11 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.14/generic/{0}/1
+          testFormat: 2.14/generic/{0}
           targets:
             - test: 3.9
+          groups:
+            - 1
   - stage: Generic_2_13
     displayName: Generic 2.13
     dependsOn: []
@@ -268,9 +290,11 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.13/generic/{0}/1
+          testFormat: 2.13/generic/{0}
           targets:
             - test: 3.8
+          groups:
+            - 1
   - stage: Generic_2_12
     displayName: Generic 2.12
     dependsOn: []
@@ -278,10 +302,12 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.12/generic/{0}/1
+          testFormat: 2.12/generic/{0}
           targets:
             - test: 2.6
             - test: 3.9
+          groups:
+            - 1
 
   ## Finally
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -121,6 +121,7 @@ stages:
               test: alpine3
           groups:
             - 1
+            - 2
   - stage: Docker_2_14
     displayName: Docker 2.14
     dependsOn: []
@@ -133,6 +134,7 @@ stages:
               test: ubuntu2204
           groups:
             - 1
+            - 2
   - stage: Docker_2_13
     displayName: Docker 2.13
     dependsOn: []
@@ -153,6 +155,7 @@ stages:
               test: alpine3
           groups:
             - 1
+            - 2
   - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
@@ -167,6 +170,7 @@ stages:
               test: fedora33
           groups:
             - 1
+            - 2
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -187,6 +191,7 @@ stages:
               test: centos-stream8/3.6
           groups:
             - 1
+            - 2
 
 ### Remote
   - stage: Remote_devel
@@ -209,6 +214,7 @@ stages:
               test: freebsd/13.1
           groups:
             - 1
+            - 2
   - stage: Remote_2_14
     displayName: Remote 2.14
     dependsOn: []
@@ -221,6 +227,7 @@ stages:
               test: rhel/9.0
           groups:
             - 1
+            - 2
   - stage: Remote_2_13
     displayName: Remote 2.13
     dependsOn: []
@@ -237,6 +244,7 @@ stages:
               test: freebsd/13.0
           groups:
             - 1
+            - 2
   - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
@@ -254,6 +262,7 @@ stages:
               test: freebsd/12.2
           groups:
             - 1
+            - 2
 ### Generic
   - stage: Generic_devel
     displayName: Generic devel
@@ -274,6 +283,7 @@ stages:
             - test: "3.11"
           groups:
             - 1
+            - 2
   - stage: Generic_2_14
     displayName: Generic 2.14
     dependsOn: []
@@ -286,6 +296,7 @@ stages:
             - test: 3.9
           groups:
             - 1
+            - 2
   - stage: Generic_2_13
     displayName: Generic 2.13
     dependsOn: []
@@ -298,6 +309,7 @@ stages:
             - test: 3.8
           groups:
             - 1
+            - 2
   - stage: Generic_2_12
     displayName: Generic 2.12
     dependsOn: []
@@ -311,6 +323,7 @@ stages:
             - test: 3.9
           groups:
             - 1
+            - 2
 
   ## Finally
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -107,35 +107,67 @@ jobs:
             python: ''
             target: azp/posix/1/
           - ansible: '2.9'
+            docker: fedora31
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.9'
             docker: ubuntu1804
             python: ''
             target: azp/posix/1/
           - ansible: '2.9'
+            docker: ubuntu1804
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.9'
             docker: default
             python: '2.7'
             target: azp/generic/1/
+          - ansible: '2.9'
+            docker: default
+            python: '2.7'
+            target: azp/generic/2/
           # 2.10
           - ansible: '2.10'
             docker: centos6
             python: ''
             target: azp/posix/1/
           - ansible: '2.10'
+            docker: centos6
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.10'
             docker: default
             python: '3.6'
             target: azp/generic/1/
+          - ansible: '2.10'
+            docker: default
+            python: '3.6'
+            target: azp/generic/2/
           # 2.11
           - ansible: '2.11'
             docker: fedora32
             python: ''
             target: azp/posix/1/
           - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.11'
             docker: alpine3
             python: ''
             target: azp/posix/1/
           - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.11'
             docker: default
             python: '3.8'
             target: azp/generic/1/
+          - ansible: '2.11'
+            docker: default
+            python: '3.8'
+            target: azp/generic/2/
 
     steps:
       - name: >-

--- a/tests/integration/targets/openssl_csr_info/aliases
+++ b/tests/integration/targets/openssl_csr_info/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_csr_pipe/aliases
+++ b/tests/integration/targets/openssl_csr_pipe/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_dhparam/aliases
+++ b/tests/integration/targets/openssl_dhparam/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_pkcs12/aliases
+++ b/tests/integration/targets/openssl_pkcs12/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_privatekey/aliases
+++ b/tests/integration/targets/openssl_privatekey/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_privatekey_convert/aliases
+++ b/tests/integration/targets/openssl_privatekey_convert/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_privatekey_info/aliases
+++ b/tests/integration/targets/openssl_privatekey_info/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_privatekey_pipe/aliases
+++ b/tests/integration/targets/openssl_privatekey_pipe/aliases
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 context/controller
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_publickey/aliases
+++ b/tests/integration/targets/openssl_publickey/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_publickey_info/aliases
+++ b/tests/integration/targets/openssl_publickey_info/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/openssl_signature/aliases
+++ b/tests/integration/targets/openssl_signature/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 openssl_signature_info
 destructive

--- a/tests/integration/targets/x509_certificate/aliases
+++ b/tests/integration/targets/x509_certificate/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/x509_certificate_info/aliases
+++ b/tests/integration/targets/x509_certificate_info/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/x509_certificate_pipe/aliases
+++ b/tests/integration/targets/x509_certificate_pipe/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 destructive

--- a/tests/integration/targets/x509_crl/aliases
+++ b/tests/integration/targets/x509_crl/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-azp/generic/1
-azp/posix/1
+azp/generic/2
+azp/posix/2
 x509_crl_info
 destructive


### PR DESCRIPTION
##### SUMMARY
Remove some duplicate targets, and instead add CentOS Stream 8 with Python 3.6.

Also splits CI up into two groups, so that a full run can go through faster. Right now (all tests in a row) can run up to 30 minutes, which is quite long.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
