### PR TITLE
CI: add extra VM group

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -202,10 +202,10 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: Alpine 3.16
-              test: alpine/3.16
-            - name: Fedora 36
-              test: fedora/36
+            - name: Alpine 3.17
+              test: alpine/3.17
+            - name: Fedora 37
+              test: fedora/37
             - name: Ubuntu 20.04
               test: ubuntu/20.04
             - name: Ubuntu 22.04

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -194,6 +194,24 @@ stages:
             - 2
 
 ### Remote
+  - stage: Remote_devel_extra_vms
+    displayName: Remote devel extra VMs
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}
+          targets:
+            - name: Alpine 3.16
+              test: alpine/3.16
+            - name: Fedora 36
+              test: fedora/36
+            - name: Ubuntu 20.04
+              test: ubuntu/20.04
+            - name: Ubuntu 22.04
+              test: ubuntu/22.04
+          groups:
+            - vm
   - stage: Remote_devel
     displayName: Remote devel
     dependsOn: []
@@ -336,6 +354,7 @@ stages:
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
+      - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_14
       - Remote_2_13

--- a/tests/integration/targets/luks_device/aliases
+++ b/tests/integration/targets/luks_device/aliases
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+azp/posix/vm
 skip/osx
 skip/macos
 skip/freebsd


### PR DESCRIPTION
##### SUMMARY
Add extra VM group to CI for tests that really require a VM. Right now that is only the luks_device test.

Closes #541.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
