### PR TITLE
openssl_publickey_info: fix crash when public key cannot be parsed

### DIFF
--- a/changelogs/fragments/551-publickey-info.yml
+++ b/changelogs/fragments/551-publickey-info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_publickey_info - do not crash with internal error when public key cannot be parsed (https://github.com/ansible-collections/community.crypto/pull/551)."

--- a/plugins/module_utils/crypto/module_backends/publickey_info.py
+++ b/plugins/module_utils/crypto/module_backends/publickey_info.py
@@ -112,7 +112,7 @@ class PublicKeyInfoRetrieval(object):
             try:
                 self.key = load_publickey(content=self.content, backend=self.backend)
             except OpenSSLObjectError as e:
-                raise PublicKeyParseError(to_native(e))
+                raise PublicKeyParseError(to_native(e), {})
 
         pk = self._get_public_key(binary=True)
         result['fingerprints'] = get_fingerprint_of_bytes(


### PR DESCRIPTION
##### SUMMARY
Found while working on #550.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_publickey_info
