### PR TITLE
Support Custom Cipher Selection

### DIFF
--- a/changelogs/fragments/571_get_certificate_ciphers.yaml
+++ b/changelogs/fragments/571_get_certificate_ciphers.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- get_certificate - adds ``ciphers`` option for custom cipher selection (https://github.com/ansible-collections/community.crypto/pull/571).

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -87,7 +87,7 @@ options:
         - 'When a list is provided, all ciphers are joined in order with C(:).'
         - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
           for more details.
-        - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions
+        - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.
       type: list
       elements: str
 

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -306,7 +306,7 @@ def main():
         if proxy_host:
             module.fail_json(msg='To use proxy_host, you must run the get_certificate module with Python 2.7 or newer.',
                              exception=CREATE_DEFAULT_CONTEXT_IMP_ERR)
-        if ciphers:
+        if ciphers is not None:
             module.fail_json(msg='To use ciphers, you must run the get_certificate module with Python 2.7 or newer.',
                              exception=CREATE_DEFAULT_CONTEXT_IMP_ERR)
         try:

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -84,7 +84,7 @@ options:
     ciphers:
       description:
         - SSL/TLS Ciphers to use for the request.
-        - 'When a list is provided, all ciphers are joined in order with C(:)'
+        - 'When a list is provided, all ciphers are joined in order with C(:).'
         - See the L(OpenSSL Cipher List Format,https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT)
           for more details.
         - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -306,6 +306,9 @@ def main():
         if proxy_host:
             module.fail_json(msg='To use proxy_host, you must run the get_certificate module with Python 2.7 or newer.',
                              exception=CREATE_DEFAULT_CONTEXT_IMP_ERR)
+        if ciphers:
+            module.fail_json(msg='To use ciphers, you must run the get_certificate module with Python 2.7 or newer.',
+                             exception=CREATE_DEFAULT_CONTEXT_IMP_ERR)
         try:
             # Note: get_server_certificate does not support SNI!
             cert = get_server_certificate((host, port), ca_certs=ca_cert)

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -90,6 +90,7 @@ options:
         - The available ciphers is dependent on the Python and OpenSSL/LibreSSL versions.
       type: list
       elements: str
+      version_added: 2.11.0
 
 notes:
     - When using ca_cert on OS X it has been reported that in some conditions the validate will always succeed.


### PR DESCRIPTION
##### SUMMARY
Adds an option for ciphers to the community.crypto.get_certificate module and aligns with the ciphers option of the ansible.builtin.uri module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.crypto.get_certificate

##### ADDITIONAL INFORMATION
I use Ansible to manage various device types (e.g. PDU's, BMC's, etc) that only support legacy ciphers and/or do not support >2048 bit certificates. For some of these devices, depending on the Ansible controller, the get_certificate module was experiencing a handshake failure, though I could still interact them with CLI or GUI web browsers (curl, Chrome, Firefox).

Without manually setting ciphers (example endpoint uses 2048 bit cert, TLSv1.2 / AES256-GCM-SHA384, cannot be changed):
```paste below
TASK [Get Certificate] ***************************************************************************************************************
fatal: [REDACTED]: FAILED! => {"changed": false, "msg": "Failed to get cert from w.x.y.z:443, error: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:997)"}
```

After manually setting ciphers to "HIGH":
```
TASK [Get Certificate] ***************************************************************************************************************
ok: [REDACTED]
```

Relevant task
```
    - name: "Get Certificate"
      community.crypto.get_certificate:
        host: "{{ ipv4_address }}"
        port: "443"
        ciphers:
          - "ALL"
        ca_cert: "{{ pki_ca_cert }}"
      register: certificate
```