### PR TITLE
action plugin helper: fix deprecation handling

### DIFF
--- a/changelogs/fragments/572-action-module.yml
+++ b/changelogs/fragments/572-action-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "action plugin helper - fix handling of deprecations for ansible-core 2.14.2 (https://github.com/ansible-collections/community.crypto/pull/572)."

--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -145,9 +145,14 @@ class AnsibleActionModule(object):
             # warnings and deprecations that do not work in plugins. This is a copy of that code adjusted
             # for our use-case:
             for d in self._validation_result._deprecations:
-                self.deprecate(
-                    "Alias '{name}' is deprecated. See the module docs for more information".format(name=d['name']),
-                    version=d.get('version'), date=d.get('date'), collection_name=d.get('collection_name'))
+                # Before ansible-core 2.14.2, deprecations were always for aliases:
+                if 'name' in d:
+                    self.deprecate(
+                        "Alias '{name}' is deprecated. See the module docs for more information".format(name=d['name']),
+                        version=d.get('version'), date=d.get('date'), collection_name=d.get('collection_name'))
+                # Since ansible-core 2.14.2, a message is present that can be directly printed:
+                if 'msg' in d:
+                    self.deprecate(d['msg'], version=d.get('version'), date=d.get('date'), collection_name=d.get('collection_name'))
 
             for w in self._validation_result._warnings:
                 self.warn('Both option {option} and its alias {alias} are set.'.format(option=w['option'], alias=w['alias']))


### PR DESCRIPTION
##### SUMMARY
This is a consequence of https://github.com/ansible/ansible/pull/79681 and https://github.com/ansible/ansible/pull/79740, which were backported to stable-2.14 and released in ansible-core 2.14.2. Without these, there will be a crash when deprecations appear with ansible-core 2.14.2+ in action plugins using this helper.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/plugin_utils/action_module.py
