### PR TITLE
fix: privatekey_content docs were the same as privatekey_path

### DIFF
--- a/plugins/doc_fragments/module_certificate.py
+++ b/plugins/doc_fragments/module_certificate.py
@@ -43,7 +43,7 @@ options:
         type: path
     privatekey_content:
         description:
-            - Path to the private key to use when signing the certificate.
+            - Content of the private key to use when signing the certificate.
             - This is mutually exclusive with I(privatekey_path).
         type: str
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/module_certificate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The docs for `privatekey_content` seem to have been mistakenly duplicated from `privatekey_path`. This PR clarifies that the former refers to the actual content of the private key, rather than a path to a private key file, exactly how the name describes.


