### PR TITLE
x509_certificate ACME tests: use curl instead of get_url on Python 2.6

### DIFF
--- a/tests/integration/targets/x509_certificate-acme/tasks/main.yml
+++ b/tests/integration/targets/x509_certificate-acme/tasks/main.yml
@@ -71,6 +71,13 @@
   get_url:
     url: https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py
     dest: "{{ remote_tmp_dir }}/acme-tiny"
+  when: ansible_python_version is version('2.7', '>=')
+
+- name: Get hold of acme-tiny executable (Python 2.6)
+  command:
+    cmd: >-
+      curl https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py --output "{{ remote_tmp_dir }}/acme-tiny"
+  when: ansible_python_version is version('2.7', '<')
 
 - name: Make sure acme-tiny is executable
   file:


### PR DESCRIPTION
##### SUMMARY
The new TLS cert of github.com is no longer accepted by Python 2.6, which makes the `x509_certificate-acme` integration tests fail.

Try to work around that.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
x509_certificate
