### PR TITLE
get_certificate: add asn1_base64 option

### DIFF
--- a/changelogs/fragments/592-get_certificate-base64.yml
+++ b/changelogs/fragments/592-get_certificate-base64.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "get_certificate - add ``asn1_base64`` option to control whether the ASN.1 included in the ``extensions`` return value is binary data or Base64 encoded (https://github.com/ansible-collections/community.crypto/pull/592)."

--- a/tests/integration/targets/get_certificate/tests/validate.yml
+++ b/tests/integration/targets/get_certificate/tests/validate.yml
@@ -8,6 +8,7 @@
     host: "{{ httpbin_host }}"
     port: 443
     server_name: "{{ sni_host }}"
+    asn1_base64: true
   register: result
 
 - debug: var=result
@@ -25,6 +26,7 @@
     host: "{{ sni_host }}"
     port: 443
     server_name: "{{ httpbin_host }}"
+    asn1_base64: true
   register: result
 
 - debug: var=result
@@ -42,6 +44,7 @@
     host: "{{ httpbin_host }}"
     port: 443
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
 
 - debug: var=result
@@ -59,6 +62,7 @@
     host: "{{ httpbin_host }}"
     port: 80
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
   ignore_errors: true
 
@@ -75,6 +79,7 @@
     port: 1234
     timeout: 1
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
   ignore_errors: true
 
@@ -91,6 +96,7 @@
     port: 443
     ca_cert: dn.e
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
   ignore_errors: true
 
@@ -112,6 +118,7 @@
     host: "{{ httpbin_host }}"
     port: 443
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
 
 - assert:
@@ -150,6 +157,7 @@
     host: "{{ httpbin_host }}"
     port: 443
     select_crypto_backend: "{{ select_crypto_backend }}"
+    asn1_base64: true
   register: result
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
This allows to work around the crash in the default callback; see #591.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
get_certificate
