### PR TITLE
x509_crl: prepare releasing the mode option for AnsibleModule's use

### DIFF
--- a/changelogs/fragments/596-x509_crl-mode.yml
+++ b/changelogs/fragments/596-x509_crl-mode.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - "x509_crl - remove problem with ansible-core 2.16 due to ``AnsibleModule`` is now validating the ``mode`` parameter's values (https://github.com/ansible-collections/community.crypto/issues/596)."
+minor_changes:
+  - "x509_crl - the ``crl_mode`` option has been added to replace the existing ``mode`` option (https://github.com/ansible-collections/community.crypto/issues/596)."
+deprecated_features:
+  - "x509_crl - the ``mode`` option is deprecated; use ``crl_mode`` instead. The ``mode`` option will change its meaning in community.crypto 3.0.0, and will refer to the CRL file's mode instead (https://github.com/ansible-collections/community.crypto/issues/596)."

--- a/plugins/modules/x509_crl.py
+++ b/plugins/modules/x509_crl.py
@@ -52,13 +52,16 @@ options:
               already exists, all entries from the existing CRL will also be included in the new CRL.
               When using C(update), you might be interested in setting I(ignore_timestamps) to C(true).
             - The default value is C(generate).
+            - This parameter was called I(mode) before community.crypto 2.13.0. It has been renamed to avoid
+              a collision with the common I(mode) parameter for setting the CRL file's access mode.
         type: str
         # default: generate
         choices: [ generate, update ]
         version_added: 2.13.0
     mode:
         description:
-            - This parameter is deprecated and will be removed in community.crypto 3.0.0. Use I(crl_mode) instead.
+            - This parameter has been renamed to I(crl_mode). The old name I(mode) is now deprecated and will
+              be removed in community.crypto 3.0.0. Replace usage of this parameter with I(crl_mode).
             - Note that from community.crypto 3.0.0 on, I(mode) will be used for the CRL file's mode.
         type: str
         # default: generate

--- a/tests/integration/targets/filter_x509_crl_info/tasks/impl.yml
+++ b/tests/integration/targets/filter_x509_crl_info/tasks/impl.yml
@@ -130,7 +130,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: false
-    mode: update
+    crl_mode: update
     return_content: true
   register: crl_2_change
 
@@ -156,7 +156,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
     return_content: true
   register: crl_2_change_order
 

--- a/tests/integration/targets/x509_crl/tasks/impl.yml
+++ b/tests/integration/targets/x509_crl/tasks/impl.yml
@@ -360,7 +360,7 @@
     revoked_certificates:
       - serial_number: 1235
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
   check_mode: true
   register: crl_2_idem_update_change_check
 
@@ -378,7 +378,7 @@
     revoked_certificates:
       - serial_number: 1235
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
   register: crl_2_idem_update_change
 
 - name: Create CRL 2 (idempotent update, check mode)
@@ -398,7 +398,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
   check_mode: true
   register: crl_2_idem_update_check
 
@@ -419,7 +419,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
   register: crl_2_idem_update
 
 - name: Create CRL 2 (changed timestamps, check mode)
@@ -439,7 +439,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: false
-    mode: update
+    crl_mode: update
   check_mode: true
   register: crl_2_change_check
 
@@ -460,7 +460,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: false
-    mode: update
+    crl_mode: update
     return_content: true
   register: crl_2_change
 
@@ -493,7 +493,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
     return_content: true
   register: crl_2_change_order_ignore
 
@@ -514,7 +514,7 @@
         reason_critical: true
         invalidity_date: 20191012000000Z
     ignore_timestamps: true
-    mode: update
+    crl_mode: update
     return_content: true
   register: crl_2_change_order
 


### PR DESCRIPTION
##### SUMMARY
Since https://github.com/ansible/ansible/pull/80449 got merged the module no longer works with ansible-core devel, since the `mode` values `generate` and `update` are not allowed by ansible-core's validation.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
x509_crl
