### PR TITLE
Always generate a new key pair if the private key doesn't exist

### DIFF
--- a/changelogs/fragments/598-openssh_keypair-generate-new-key.yml
+++ b/changelogs/fragments/598-openssh_keypair-generate-new-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssh_keypair - always generate a new key pair if the private key does not exist. Previously, the module would fail when ``regenerate=fail`` without an existing key, contradicting the documentation (https://github.com/ansible-collections/community.crypto/pull/598)."

--- a/plugins/module_utils/openssh/backends/keypair_backend.py
+++ b/plugins/module_utils/openssh/backends/keypair_backend.py
@@ -161,8 +161,10 @@ class KeypairBackend(OpensshModule):
         pass
 
     def _should_generate(self):
-        if self.regenerate == 'never':
-            return self.original_private_key is None
+        if self.original_private_key is None:
+            return True
+        elif self.regenerate == 'never':
+            return False
         elif self.regenerate == 'fail':
             if not self._private_key_valid():
                 self.module.fail_json(
@@ -170,7 +172,7 @@ class KeypairBackend(OpensshModule):
                         "To force regeneration, call the module with `generate` set to " +
                         "`partial_idempotence`, `full_idempotence` or `always`, or with `force=true`."
                 )
-            return self.original_private_key is None
+            return False
         elif self.regenerate in ('partial_idempotence', 'full_idempotence'):
             return not self._private_key_valid()
         else:

--- a/tests/integration/targets/openssh_keypair/tests/regenerate.yml
+++ b/tests/integration/targets/openssh_keypair/tests/regenerate.yml
@@ -28,6 +28,7 @@
     type: rsa
     size: 1024
     backend: "{{ backend }}"
+    regenerate: "{{ item }}"
   loop: "{{ regenerate_values }}"
 - name: "({{ backend }}) Regenerate - setup password protected keys"
   command: 'ssh-keygen -f {{ remote_tmp_dir }}/regenerate-b-{{ item }} -N {{ passphrase }}'


### PR DESCRIPTION
##### SUMMARY

This PR updates `KeypairBackend._should_generate()` to first check if the original private key named by the `path` argument exists, and return `True` if it does not. This brings the code in line with the documentation, which says that a new key will always be generated if the key file doesn't already exist. It also modifies the existing tests to check for this bug.
    
Fixes #597 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_keypair

##### ADDITIONAL INFORMATION

Before this fix, using the sample playbook from #597:

```console
$ ansible-playbook keypair.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'

PLAY [localhost] ******************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************
ok: [localhost]

TASK [Ensure key directory exists] ************************************************************************************
ok: [localhost]

TASK [Ensure id_ed25519 key does not exist] ***************************************************************************
ok: [localhost] => (item=id_ed25519)
ok: [localhost] => (item=id_ed25519.pub)

TASK [Generate keypair] ***********************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Key has wrong type and/or size. Will not proceed. To force regeneration, call the module with `generate` set to `partial_idempotence`, `full_idempotence` or `always`, or with `force=true`."}

PLAY RECAP ************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

After the fix:

```console
$ ansible-playbook keypair.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'

PLAY [localhost] ******************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************
ok: [localhost]

TASK [Ensure key directory exists] ************************************************************************************
ok: [localhost]

TASK [Ensure id_ed25519 key does not exist] ***************************************************************************
ok: [localhost] => (item=id_ed25519)
ok: [localhost] => (item=id_ed25519.pub)

TASK [Generate keypair] ***********************************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************
localhost                  : ok=4    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

As an alternative to the approach implemented here, I also considered only modifying the condition in the `fail` branch of the if statement - this was @felixfontein's suggestion [in a comment](https://github.com/ansible-collections/community.crypto/issues/597#issuecomment-1528850402), and it was also my first thought about how to fix this - but I thought doing it the way I did would make it easier to check that the code is doing the right thing just by looking at it. That can certainly be changed if necessary.

I also considered doing something to make the logic more similar to `PrivateKeyBackend.needs_regeneration()` (the openssl version of this functionality), because [the two are supposed to be acting the same way](https://github.com/ansible-collections/community.crypto/issues/597#issuecomment-1528856059), but I thought that'd be going beyond the scope of just fixing this bug. If it'd be useful to make both methods work the same way, someone can refactor the code in a future commit.