### PR TITLE
Move ansible-core 2.12 to EOL CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -98,17 +98,6 @@ stages:
               test: '2.13/sanity/1'
             - name: Units
               test: '2.13/units/1'
-  - stage: Ansible_2_12
-    displayName: Sanity & Units 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.12/sanity/1'
-            - name: Units
-              test: '2.12/units/1'
 ### Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -175,21 +164,6 @@ stages:
               test: ubuntu1804
             - name: Alpine 3
               test: alpine3
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_12
-    displayName: Docker 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/linux/{0}
-          targets:
-            - name: CentOS 6
-              test: centos6
-            - name: Fedora 33
-              test: fedora33
           groups:
             - 1
             - 2
@@ -300,25 +274,6 @@ stages:
           groups:
             - 1
             - 2
-  - stage: Remote_2_12
-    displayName: Remote 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}
-          targets:
-            # Not working anymore:
-            # - name: macOS 11.1
-            #   test: macos/11.1
-            - name: RHEL 8.4
-              test: rhel/8.4
-            # Not working anymore:
-            # - name: FreeBSD 12.2
-            #   test: freebsd/12.2
-          groups:
-            - 1
-            - 2
 ### Generic
   - stage: Generic_devel
     displayName: Generic devel
@@ -379,20 +334,6 @@ stages:
           groups:
             - 1
             - 2
-  - stage: Generic_2_12
-    displayName: Generic 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.12/generic/{0}
-          targets:
-            - test: 2.6
-            - test: 3.9
-          groups:
-            - 1
-            - 2
 
   ## Finally
 
@@ -403,23 +344,19 @@ stages:
       - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
-      - Ansible_2_12
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_15
       - Remote_2_14
       - Remote_2_13
-      - Remote_2_12
       - Docker_devel
       - Docker_2_15
       - Docker_2_14
       - Docker_2_13
-      - Docker_2_12
       - Docker_community_devel
       - Generic_devel
       - Generic_2_15
       - Generic_2_14
       - Generic_2_13
-      - Generic_2_12
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,6 +32,7 @@ jobs:
           - '2.9'
           - '2.10'
           - '2.11'
+          - '2.12'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -70,6 +71,7 @@ jobs:
           - '2.9'
           - '2.10'
           - '2.11'
+          - '2.12'
 
     steps:
       - name: >-
@@ -174,6 +176,31 @@ jobs:
           - ansible: '2.11'
             docker: default
             python: '3.8'
+            target: azp/generic/2/
+          # 2.12
+          - ansible: '2.12'
+            docker: centos6
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.12'
+            docker: centos6
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.12'
+            docker: fedora33
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.12'
+            docker: fedora33
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.12'
+            docker: default
+            python: '2.6'
+            target: azp/generic/1/
+          - ansible: '2.12'
+            docker: default
+            python: '3.9'
             target: azp/generic/2/
 
     steps:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
         with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pull-request-change-detection: 'true'
@@ -76,6 +77,7 @@ jobs:
           Ansible version ${{ matrix.ansible }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pull-request-change-detection: 'true'
@@ -181,6 +183,7 @@ jobs:
           under Python ${{ matrix.python }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           docker-image: ${{ matrix.docker }}


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.12 is EOL since the release of ansible-core 2.15.0.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
