### PR TITLE
Added support for certificates in DER format for `x509_certificate_info` module

### DIFF
--- a/plugins/module_utils/crypto/support.py
+++ b/plugins/module_utils/crypto/support.py
@@ -203,7 +203,7 @@ def load_certificate(path, content=None, backend='cryptography'):
     if backend == 'pyopenssl':
         return crypto.load_certificate(crypto.FILETYPE_PEM, cert_content)
     elif backend == 'cryptography':
-        if any([x in cert_content for x in [b'-----BEGIN CERTIFICATE-----', b'-----END CERTIFICATE-----\n']]):
+        if any([x in cert_content for x in [b'-----BEGIN CERTIFICATE-----', b'-----END CERTIFICATE-----']]):
             try:
                 return x509.load_pem_x509_certificate(cert_content, cryptography_backend())
             except ValueError as exc:

--- a/plugins/module_utils/crypto/support.py
+++ b/plugins/module_utils/crypto/support.py
@@ -203,10 +203,16 @@ def load_certificate(path, content=None, backend='cryptography'):
     if backend == 'pyopenssl':
         return crypto.load_certificate(crypto.FILETYPE_PEM, cert_content)
     elif backend == 'cryptography':
-        try:
-            return x509.load_pem_x509_certificate(cert_content, cryptography_backend())
-        except ValueError as exc:
-            raise OpenSSLObjectError(exc)
+        if any([x in cert_content for x in [b'-----BEGIN CERTIFICATE-----', b'-----END CERTIFICATE-----\n']]):
+            try:
+                return x509.load_pem_x509_certificate(cert_content, cryptography_backend())
+            except ValueError as exc:
+                raise OpenSSLObjectError(exc)
+        else:
+            try:
+                return x509.load_der_x509_certificate(cert_content, cryptography_backend())
+            except ValueError as exc:
+                raise OpenSSLObjectError('Cannot parse DER certificate: {0}'.format(exc))
 
 
 def load_certificate_request(path, content=None, backend='cryptography'):

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -40,10 +40,11 @@ options:
         description:
             - Remote absolute path where the certificate file is loaded from.
             - Either I(path) or I(content) must be specified, but not both.
+            - PEM and DER formats are supported.
         type: path
     content:
         description:
-            - Content of the X.509 certificate in PEM or DER format.
+            - Content of the X.509 certificate in PEM format.
             - Either I(path) or I(content) must be specified, but not both.
         type: str
         version_added: '1.0.0'

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -43,7 +43,7 @@ options:
         type: path
     content:
         description:
-            - Content of the X.509 certificate in PEM format.
+            - Content of the X.509 certificate in PEM or DER format.
             - Either I(path) or I(content) must be specified, but not both.
         type: str
         version_added: '1.0.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #603 by adding support for DER-format certificates when loading a certificate via `path`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`community.crypto.x509_certificate_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have not found a solution to load the certificate via the `content` parameter. It fails due to module input encoding (`ansible_community.crypto.x509_certificate_info_payload.zip/ansible/module_utils/basic.py\", line 1392, in _log_invocation\nUnicodeEncodeError: 'utf-8' codec can't encode character '\\udc82' in position 1: surrogates not allowed`), but in my opinion it's still better than calling openssl command externally.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
