### PR TITLE
CI: Ubuntu 20.02 VM is being removed from ansible-core devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,8 +111,6 @@ stages:
               test: fedora37
             - name: openSUSE 15
               test: opensuse15
-            - name: Ubuntu 20.04
-              test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
             - name: Alpine 3


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible/ansible/pull/81070.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
