### PR TITLE
Add RHEL 8.7, 8.8, and 9.2 to CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -216,8 +216,10 @@ stages:
           targets:
             - name: macOS 13.2
               test: macos/13.2
-            - name: RHEL 9.1
-              test: rhel/9.1
+            - name: RHEL 9.2
+              test: rhel/9.2
+            - name: RHEL 8.8
+              test: rhel/8.8
             - name: FreeBSD 12.4
               test: freebsd/12.4
             - name: FreeBSD 13.2
@@ -233,6 +235,10 @@ stages:
         parameters:
           testFormat: 2.15/{0}
           targets:
+            - name: RHEL 9.1
+              test: rhel/9.1
+            - name: RHEL 8.7
+              test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
             - name: FreeBSD 13.1


### PR DESCRIPTION
##### SUMMARY
Move RHEL 9.1 from devel to stable-2.15; add RHEL 9.2 and 8.8 to devel, add RHEL 8.7 to stable-2.15.

Ref: https://github.com/ansible-collections/news-for-maintainers/issues/47

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
