### PR TITLE
CI: support for Ubuntu 20.04 VM was removed

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -200,8 +200,6 @@ stages:
               test: alpine/3.17
             - name: Fedora 37
               test: fedora/37
-            - name: Ubuntu 20.04
-              test: ubuntu/20.04
             - name: Ubuntu 22.04
               test: ubuntu/22.04
           groups:


### PR DESCRIPTION
##### SUMMARY
Remove this extra VM using ansible-core devel.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
