### PR TITLE
CI: remove no longer needed ignore

### DIFF
--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,3 +1,2 @@
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen
 tests/ee/roles/smoke/library/smoke_ipaddress.py shebang
 tests/ee/roles/smoke/library/smoke_pyyaml.py shebang


### PR DESCRIPTION
##### SUMMARY
Nightly CI fails because ansible-core devel's ansible-test no longer requires a `replace-urlopen` ignore for `.azure-pipelines/scripts/publish-codecov.py`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity test ignores
