### PR TITLE
CI: FreeBSD 13.0 and 12.3 are no longer availabe, bump versions and disable since these versions are already tested with stable-2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -260,8 +260,8 @@ stages:
               test: macos/12.0
             - name: RHEL 9.0
               test: rhel/9.0
-            - name: FreeBSD 12.3
-              test: freebsd/12.3
+            #- name: FreeBSD 12.4
+            #  test: freebsd/12.4
           groups:
             - 1
             - 2
@@ -275,8 +275,8 @@ stages:
           targets:
             - name: RHEL 8.5
               test: rhel/8.5
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
+            #- name: FreeBSD 13.1
+            #  test: freebsd/13.1
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible/ansible/pull/81498
Ref: https://github.com/ansible/ansible/pull/81497

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
