### PR TITLE
acme error reporting: allow type to be missing in problem documents

### DIFF
--- a/changelogs/fragments/652-problem-type.yml
+++ b/changelogs/fragments/652-problem-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acme_* modules - correctly handle error documents without ``type`` (https://github.com/ansible-collections/community.crypto/issues/651, https://github.com/ansible-collections/community.crypto/pull/652)."

--- a/plugins/module_utils/acme/errors.py
+++ b/plugins/module_utils/acme/errors.py
@@ -21,13 +21,14 @@ def format_http_status(status_code):
 
 
 def format_error_problem(problem, subproblem_prefix=''):
+    error_type = problem.get('type', 'about:blank')  # https://www.rfc-editor.org/rfc/rfc7807#section-3.1
     if 'title' in problem:
         msg = 'Error "{title}" ({type})'.format(
-            type=problem['type'],
+            type=error_type,
             title=problem['title'],
         )
     else:
-        msg = 'Error {type}'.format(type=problem['type'])
+        msg = 'Error {type}'.format(type=error_type)
     if 'detail' in problem:
         msg += ': "{detail}"'.format(detail=problem['detail'])
     subproblems = problem.get('subproblems')


### PR DESCRIPTION
##### SUMMARY
Fixes #651.

According to https://www.rfc-editor.org/rfc/rfc7807#section-3.1, `type` can be not present in problem documnts (https://www.rfc-editor.org/rfc/rfc8555#section-6.7). So don't assume it is always there. ZeroSSL apparently sometimes returns errors without it (#651).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme module utils
