### PR TITLE
openssh_keypair tests: explicitly tell ssh-keygen to use RSA

### DIFF
--- a/tests/integration/targets/openssh_keypair/tests/cryptography_backend.yml
+++ b/tests/integration/targets/openssh_keypair/tests/cryptography_backend.yml
@@ -75,7 +75,7 @@
     state: absent
 
 - name: Generate PEM encoded key with passphrase
-  command: 'ssh-keygen -b 1280 -f {{ remote_tmp_dir }}/pem_encoded -N {{ passphrase }} -m PEM'
+  command: 'ssh-keygen -t rsa -b 1280 -f {{ remote_tmp_dir }}/pem_encoded -N {{ passphrase }} -m PEM'
 
 - name: Try to verify a PEM encoded key
   openssh_keypair:


### PR DESCRIPTION
##### SUMMARY
Latest OpenSSH's ssh-keygen apparently defaults to ed25519 keys, no longer RSA. This causes the openssh_keypair tests to fail on Arch Linux.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
openssh_keygen
