### PR TITLE
CI: remove macOS 12.0 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -253,8 +253,8 @@ stages:
         parameters:
           testFormat: 2.14/{0}
           targets:
-            - name: macOS 12.0
-              test: macos/12.0
+            #- name: macOS 12.0
+            #  test: macos/12.0
             - name: RHEL 9.0
               test: rhel/9.0
             #- name: FreeBSD 12.4


### PR DESCRIPTION
##### SUMMARY
stable-2.14's macOS 12.0 seems to be dead, or at least very unreliable.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
