### PR TITLE
openssl_pkcs12: handle pyOpenSSL 23.3.0, which removed PKCS#12 support

### DIFF
--- a/changelogs/fragments/pkcs12.yml
+++ b/changelogs/fragments/pkcs12.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_pkcs12 - modify autodetect to not detect pyOpenSSL >= 23.3.0, which removed PKCS#12 support (https://github.com/ansible-collections/community.crypto/pull/666)."

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -69,7 +69,10 @@
       vars:
         select_crypto_backend: pyopenssl
 
-    when: (pyopenssl_version.stdout | default('0.0')) is version('0.15', '>=')
+    when: >-
+      (pyopenssl_version.stdout | default('0.0')) is version('0.15', '>=')
+      and
+      (pyopenssl_version.stdout | default('0.0')) is version('23.3.0', '<')
 
   - block:
     - name: Running tests with cryptography backend
@@ -79,4 +82,11 @@
 
     when: cryptography_version.stdout is version('3.0', '>=')
 
-  when: (pyopenssl_version.stdout | default('0.0')) is version('0.15', '>=') or cryptography_version.stdout is version('3.0', '>=')
+  when: >-
+    (
+      (pyopenssl_version.stdout | default('0.0')) is version('0.15', '>=')
+      and
+      (pyopenssl_version.stdout | default('0.0')) is version('23.3.0', '<')
+    )
+    or
+    cryptography_version.stdout is version('3.0', '>=')


### PR DESCRIPTION
##### SUMMARY
See https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst#2330-2023-10-25.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
