### PR TITLE
[stable-1] openssl_pkcs12: handle pyOpenSSL 23.3.0, which removed PKCS#12 support

### DIFF
--- a/changelogs/fragments/pkcs12.yml
+++ b/changelogs/fragments/pkcs12.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_pkcs12 - modify autodetect to not detect pyOpenSSL >= 23.3.0, which removed PKCS#12 support (https://github.com/ansible-collections/community.crypto/pull/666)."

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -23,7 +23,7 @@ description:
     # Please note that the C(pyopenssl) backend has been deprecated in community.crypto x.y.0,
     # and will be removed in community.crypto (x+1).0.0.
 requirements:
-    - PyOpenSSL >= 0.15 or cryptography >= 3.0
+    - PyOpenSSL >= 0.15, < 23.3.0 or cryptography >= 3.0
 options:
     action:
         description:
@@ -270,11 +270,13 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import
 
 MINIMAL_CRYPTOGRAPHY_VERSION = '3.0'
 MINIMAL_PYOPENSSL_VERSION = '0.15'
+MAXIMAL_PYOPENSSL_VERSION = '23.3.0'
 
 PYOPENSSL_IMP_ERR = None
 try:
     import OpenSSL
     from OpenSSL import crypto
+    from OpenSSL.crypto import load_pkcs12 as _load_pkcs12  # this got removed in pyOpenSSL 23.3.0
     PYOPENSSL_VERSION = LooseVersion(OpenSSL.__version__)
 except (ImportError, AttributeError):
     PYOPENSSL_IMP_ERR = traceback.format_exc()
@@ -637,7 +639,11 @@ def select_backend(module, backend):
     if backend == 'auto':
         # Detection what is possible
         can_use_cryptography = CRYPTOGRAPHY_FOUND and CRYPTOGRAPHY_VERSION >= LooseVersion(MINIMAL_CRYPTOGRAPHY_VERSION)
-        can_use_pyopenssl = PYOPENSSL_FOUND and PYOPENSSL_VERSION >= LooseVersion(MINIMAL_PYOPENSSL_VERSION)
+        can_use_pyopenssl = (
+            PYOPENSSL_FOUND and
+            PYOPENSSL_VERSION >= LooseVersion(MINIMAL_PYOPENSSL_VERSION) and
+            PYOPENSSL_VERSION < LooseVersion(MAXIMAL_PYOPENSSL_VERSION)
+        )
 
         # If no restrictions are provided, first try cryptography, then pyOpenSSL
         if module.params['iter_size'] is not None or module.params['maciter_size'] is not None:
@@ -651,14 +657,17 @@ def select_backend(module, backend):
         # Success?
         if backend == 'auto':
             module.fail_json(msg=("Can't detect any of the required Python libraries "
-                                  "cryptography (>= {0}) or PyOpenSSL (>= {1})").format(
+                                  "cryptography (>= {0}) or PyOpenSSL (>= {1}, < {2})").format(
                                       MINIMAL_CRYPTOGRAPHY_VERSION,
-                                      MINIMAL_PYOPENSSL_VERSION))
+                                      MINIMAL_PYOPENSSL_VERSION,
+                                      MAXIMAL_PYOPENSSL_VERSION))
 
     if backend == 'pyopenssl':
         if not PYOPENSSL_FOUND:
-            module.fail_json(msg=missing_required_lib('pyOpenSSL >= {0}'.format(MINIMAL_PYOPENSSL_VERSION)),
-                             exception=PYOPENSSL_IMP_ERR)
+            msg = missing_required_lib(
+                'pyOpenSSL >= {0}, < {1}'.format(MINIMAL_PYOPENSSL_VERSION, MAXIMAL_PYOPENSSL_VERSION)
+            )
+            module.fail_json(msg=msg, exception=PYOPENSSL_IMP_ERR)
         # module.deprecate('The module is using the PyOpenSSL backend. This backend has been deprecated',
         #                  version='x.0.0', collection_name='community.crypto')
         return backend, PkcsPyOpenSSL(module)

--- a/tests/integration/targets/openssl_pkcs12/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12/tasks/main.yml
@@ -65,7 +65,10 @@
       vars:
         select_crypto_backend: pyopenssl
 
-    when: pyopenssl_version.stdout is version('0.15', '>=')
+    when: >-
+      pyopenssl_version.stdout is version('0.15', '>=')
+      and
+      pyopenssl_version.stdout is version('23.3.0', '<')
 
   - block:
     - name: Running tests with cryptography backend
@@ -75,4 +78,11 @@
 
     when: cryptography_version.stdout is version('3.0', '>=')
 
-  when: pyopenssl_version.stdout is version('0.15', '>=') or cryptography_version.stdout is version('3.0', '>=')
+  when: >-
+    (
+      pyopenssl_version.stdout is version('0.15', '>=')
+      and
+      pyopenssl_version.stdout is version('23.3.0', '<')
+    )
+    or
+    cryptography_version.stdout is version('3.0', '>=')

--- a/tests/integration/targets/setup_python_info/vars/main.yml
+++ b/tests/integration/targets/setup_python_info/vars/main.yml
@@ -43,6 +43,8 @@ system_python_version_data:
       - '3.8'
     '13.0':
       - '3.7'
+    '13.1':
+      - '3.8'
   RedHat:
     '7':
       - '2.7'


### PR DESCRIPTION
##### SUMMARY
Manual backport of #666 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_pkcs12
