### PR TITLE
CI: devel supports Fedora 39, and no longer Fedora 38

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -107,8 +107,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}
           targets:
-            - name: Fedora 38
-              test: fedora38
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 22.04
               test: ubuntu2204
             - name: Alpine 3
@@ -124,6 +124,8 @@ stages:
         parameters:
           testFormat: 2.16/linux/{0}
           targets:
+            - name: Fedora 38
+              test: fedora38
             - name: openSUSE 15
               test: opensuse15
           groups:
@@ -188,8 +190,8 @@ stages:
           targets:
             - name: Alpine 3.18
               test: alpine/3.18
-            - name: Fedora 38
-              test: fedora/38
+            - name: Fedora 39
+              test: fedora/39
             - name: Ubuntu 22.04
               test: ubuntu/22.04
           groups:


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/63

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
