### PR TITLE
Remove Fedora 36 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -154,8 +154,8 @@ stages:
         parameters:
           testFormat: 2.14/linux/{0}
           targets:
-            - name: Fedora 36
-              test: fedora36
+            - name: Ubuntu 20.04
+              test: ubuntu2004
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Seems like Fedora 36 is failing in CI (https://dev.azure.com/ansible/community.crypto/_build/results?buildId=96627&view=results).

Remove it from the CI matrix and replace it with something else.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
