### PR TITLE
Deactivate FreeBSD 13.1 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -242,8 +242,8 @@ stages:
               test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            # - name: FreeBSD 13.1
+            #   test: freebsd/13.1
             - name: FreeBSD 12.4
               test: freebsd/12.4
           groups:


### PR DESCRIPTION
##### SUMMARY
For some reason FreeBSD 13.1 is failing in CI.

https://dev.azure.com/ansible/community.crypto/_build/results?buildId=97988&view=logs&j=489c5a82-e9cd-5bc3-857e-065b97d45876&t=11e2531d-7868-57c8-064b-fb71affce1d8&l=1513

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
