### PR TITLE
acme modules: improve error reporting

### DIFF
--- a/changelogs/fragments/684-info-code.yml
+++ b/changelogs/fragments/684-info-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acme_* modules - fix improved error reporting in case of socket errors, bad status lines, and unknown connection errors (https://github.com/ansible-collections/community.crypto/pull/684)."

--- a/plugins/module_utils/acme/errors.py
+++ b/plugins/module_utils/acme/errors.py
@@ -96,12 +96,12 @@ class ACMEProtocolException(ModuleFailException):
             extras['http_status'] = code
             if code is not None and code >= 400 and content_json is not None and 'type' in content_json:
                 if 'status' in content_json and content_json['status'] != code:
-                    code = 'status {problem_code} (HTTP status: {http_code})'.format(
+                    code_msg = 'status {problem_code} (HTTP status: {http_code})'.format(
                         http_code=format_http_status(code), problem_code=content_json['status'])
                 else:
-                    code = 'status {problem_code}'.format(problem_code=format_http_status(code))
+                    code_msg = 'status {problem_code}'.format(problem_code=format_http_status(code))
                     if code == -1 and info.get('msg'):
-                        code += ' ({msg})'.format(msg=info['msg'])
+                        code_msg = 'error: {msg}'.format(msg=info['msg'])
                 subproblems = content_json.pop('subproblems', None)
                 add_msg = ' {problem}.'.format(problem=format_error_problem(content_json))
                 extras['problem'] = content_json
@@ -115,14 +115,14 @@ class ACMEProtocolException(ModuleFailException):
                             problem=format_error_problem(problem, subproblem_prefix='{0}.'.format(index)),
                         )
             else:
-                code = 'HTTP status {code}'.format(code=format_http_status(code))
+                code_msg = 'HTTP status {code}'.format(code=format_http_status(code))
                 if code == -1 and info.get('msg'):
-                    code += ' ({msg})'.format(msg=info['msg'])
+                    code_msg = 'error: {msg}'.format(msg=info['msg'])
                 if content_json is not None:
                     add_msg = ' The JSON error result: {content}'.format(content=content_json)
                 elif content is not None:
                     add_msg = ' The raw error result: {content}'.format(content=to_text(content))
-            msg = '{msg} for {url} with {code}'.format(msg=msg, url=url, code=format_http_status(code))
+            msg = '{msg} for {url} with {code}'.format(msg=msg, url=url, code=code_msg)
         elif content_json is not None:
             add_msg = ' The JSON result: {content}'.format(content=content_json)
         elif content is not None:


### PR DESCRIPTION
##### SUMMARY
The improved error reporting in #680 is not working since `code` is used for two different things. This PR improves the code and instates the intended bevior from #680.

(Since ZeroSSL's ACME endpoint seems to constantly have these problems I was able to verify that this works...)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme module utils
