### PR TITLE
acme modules: increase retry count from 5 to 10

### DIFF
--- a/changelogs/fragments/685-acme-retry.yml
+++ b/changelogs/fragments/685-acme-retry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acme_* modules - increase number of retries from 5 to 10 to increase stability with unstable ACME endpoints (https://github.com/ansible-collections/community.crypto/pull/685)."

--- a/plugins/module_utils/acme/acme.py
+++ b/plugins/module_utils/acme/acme.py
@@ -58,13 +58,16 @@ else:
 # -1 usually means connection problems
 RETRY_STATUS_CODES = (-1, 408, 429, 503)
 
+RETRY_COUNT = 10
+
 
 def _decode_retry(module, response, info, retry_count):
     if info['status'] not in RETRY_STATUS_CODES:
         return False
 
-    if retry_count >= 5:
-        raise ACMEProtocolException(module, msg='Giving up after 5 retries', info=info, response=response)
+    if retry_count >= RETRY_COUNT:
+        raise ACMEProtocolException(
+            module, msg='Giving up after {retry} retries'.format(retry=RETRY_COUNT), info=info, response=response)
 
     # 429 and 503 should have a Retry-After header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
     try:


### PR DESCRIPTION
##### SUMMARY
Improves stability with ZeroSSL and other unstable ACME endpoints.

I'm a bit torn between calling this a bugfix or a feature. I decided for bugfix since I plan to do a release with this, and all other changes are bugfixes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme modules
