### PR TITLE
[stable-1] Remove FreeBSD 12.4 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,8 +99,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.5
               test: rhel/8.5
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
+            # - name: FreeBSD 12.4
+            #   test: freebsd/12.4
             # - name: FreeBSD 13.1
             #   test: freebsd/13.1
 ### cloud


### PR DESCRIPTION
##### SUMMARY
Looks like it was removed from FreeBSD's side.

Ref: #690.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
