### PR TITLE
add allow discard option for luks devices

### DIFF
--- a/changelogs/fragments/693-allow-discards.yaml
+++ b/changelogs/fragments/693-allow-discards.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - luks_device - add allow discards option.

--- a/changelogs/fragments/693-allow-discards.yaml
+++ b/changelogs/fragments/693-allow-discards.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - luks_device - add allow discards option.
+  - luks_device - add allow discards option (https://github.com/ansible-collections/community.crypto/pull/693).

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -293,8 +293,8 @@ options:
     persistent:
         description:
             - "Allows the user to store options into container's metadata persistently and automatically use them next time.
-              Only O(perf_same_cpu_crypt), O(perf_submit_from_crypt_cpus), O(perf_no_read_workqueue), and O(perf_no_write_workqueue)
-              can be stored persistently."
+              Only O(perf_same_cpu_crypt), O(perf_submit_from_crypt_cpus), O(perf_no_read_workqueue), O(perf_no_write_workqueue)
+              and O(allow_discards) can be stored persistently."
             - "Will only work with LUKS2 containers."
             - "Will only be used when opening containers."
         type: bool

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -303,7 +303,6 @@ options:
     allow_discards:
         description:
             - "Allow discards (also known as TRIM) requests for device."
-            - "Will only work with LUKS2 containers."
             - "Will only be used when opening containers."
         type: bool
         default: false

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -293,7 +293,7 @@ options:
     persistent:
         description:
             - "Allows the user to store options into container's metadata persistently and automatically use them next time.
-              Only O(perf_same_cpu_crypt), O(perf_submit_from_crypt_cpus), O(perf_no_read_workqueue), O(perf_no_write_workqueue)
+              Only O(perf_same_cpu_crypt), O(perf_submit_from_crypt_cpus), O(perf_no_read_workqueue), O(perf_no_write_workqueue),
               and O(allow_discards) can be stored persistently."
             - "Will only work with LUKS2 containers."
             - "Will only be used when opening containers."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -302,7 +302,7 @@ options:
         version_added: '2.3.0'
     allow_discards:
         description:
-            - "Allow discards (aka TRIM) requests for device."
+            - "Allow discards (also known as TRIM) requests for device."
             - "Will only work with LUKS2 containers."
             - "Will only be used when opening containers."
         type: bool

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -307,7 +307,7 @@ options:
             - "Will only be used when opening containers."
         type: bool
         default: false
-        version_added: '2.16.3'
+        version_added: '2.17.0'
 
 requirements:
     - "cryptsetup"

--- a/tests/integration/targets/luks_device/tasks/tests/performance.yml
+++ b/tests/integration/targets/luks_device/tasks/tests/performance.yml
@@ -15,6 +15,7 @@
         perf_no_read_workqueue: true
         perf_no_write_workqueue: true
         persistent: true
+        allow_discards: true
         pbkdf:
           iteration_time: 0.1
       check_mode: true
@@ -32,6 +33,7 @@
         perf_no_read_workqueue: true
         perf_no_write_workqueue: true
         persistent: true
+        allow_discards: true
       become: true
       register: create_open
     - name: Create and open (idempotent)
@@ -46,6 +48,7 @@
         perf_no_read_workqueue: true
         perf_no_write_workqueue: true
         persistent: true
+        allow_discards: true
       become: true
       register: create_open_idem
     - name: Create and open (idempotent, check)
@@ -60,6 +63,7 @@
         perf_no_read_workqueue: true
         perf_no_write_workqueue: true
         persistent: true
+        allow_discards: true
       check_mode: true
       become: true
       register: create_open_idem_check
@@ -80,6 +84,7 @@
           - "'no-write-workqueue' in luks_header.stdout"
           - "'same-cpu-crypt' in luks_header.stdout"
           - "'submit-from-crypt-cpus' in luks_header.stdout"
+          - "'allow-discards' in luks_header.stdout"
 
     - name: Dump device mapper table
       command: "dmsetup table {{ create_open.name }}"
@@ -91,6 +96,7 @@
           - "'no_write_workqueue' in dm_table.stdout"
           - "'same_cpu_crypt' in dm_table.stdout"
           - "'submit_from_crypt_cpus' in dm_table.stdout"
+          - "'allow_discards' in dm_table.stdout"
 
     - name: Closed and Removed
       luks_device:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add allow discard option for luks devices.
It's often used for disks encryption with VMs + fstrim enabled.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
luks_device

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
