### PR TITLE
Fix openssl_dhparam

### DIFF
--- a/changelogs/fragments/698-openssl_dhparam-cryptography.yml
+++ b/changelogs/fragments/698-openssl_dhparam-cryptography.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "openssl_dhparam - was using an internal function instead of the public API to load DH param files when using the ``cryptography`` backend.
+     The internal function was removed in cryptography 42.0.0. The module now uses the public API, which has been available since support for
+     DH params was added to cryptography (https://github.com/ansible-collections/community.crypto/pull/698)."

--- a/plugins/modules/openssl_dhparam.py
+++ b/plugins/modules/openssl_dhparam.py
@@ -341,7 +341,7 @@ class DHParameterCryptography(DHParameterBase):
         try:
             with open(self.path, 'rb') as f:
                 data = f.read()
-            params = self.crypto_backend.load_pem_parameters(data)
+            params = cryptography.hazmat.primitives.serialization.load_pem_parameters(data, backend=self.crypto_backend)
         except Exception as dummy:
             return False
         # Check parameters


### PR DESCRIPTION
##### SUMMARY
It doesn't work with cryptography 42.0.0+ because it used a private API that got removed, despite that same API being available publicly under another name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_dhparam
