### PR TITLE
[stable-1] openssl_privatekey_info: check whether _backend exists before calling internal function

### DIFF
--- a/changelogs/fragments/700-private_key_info-cryptography.yml
+++ b/changelogs/fragments/700-private_key_info-cryptography.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "openssl_privatekey_info - was using an internal function for determining whether a private key is consistent, that got removed in cryptography 42.0.0.
+     The code now checks whether that function exists before calling it (https://github.com/ansible-collections/community.crypto/pull/700)."

--- a/plugins/module_utils/crypto/module_backends/privatekey_info.py
+++ b/plugins/module_utils/crypto/module_backends/privatekey_info.py
@@ -119,7 +119,11 @@ def _check_dsa_consistency(key_public_data, key_private_data):
 
 def _is_cryptography_key_consistent(key, key_public_data, key_private_data):
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey):
-        return bool(key._backend._lib.RSA_check_key(key._rsa_cdata))
+        # key._backend was removed in cryptography 42.0.0
+        backend = getattr(key, '_backend', None)
+        if backend is None:
+            return None
+        return bool(backend._lib.RSA_check_key(key._rsa_cdata))
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey):
         result = _check_dsa_consistency(key_public_data, key_private_data)
         if result is not None:

--- a/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
@@ -71,7 +71,8 @@
   - name: Compare results
     assert:
       that:
-      - '  (pyopenssl_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | list | items2dict)
-        == (cryptography_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | list | items2dict)'
+      - >-
+        (pyopenssl_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | rejectattr("key", "equalto", "key_is_consistent") | list | items2dict)
+        == (cryptography_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | rejectattr("key", "equalto", "key_is_consistent") | list | items2dict)
     loop: "{{ pyopenssl_info_results.keys() | intersect(cryptography_info_results.keys()) | list }}"
   when: pyopenssl_version.stdout is version('0.15', '>=') and cryptography_version.stdout is version('1.2.3', '>=')


### PR DESCRIPTION
##### SUMMARY
`RSA._backend` was removed in cryptography 42.0.0.

(That code got removed in community.crypto 2.0.0.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey_info
