### PR TITLE
Disable consistency checking of RSA keys for cryptography 42.0.0 which no longer gives access to the required function

### DIFF
--- a/changelogs/fragments/701-private_key_info-consistency.yml
+++ b/changelogs/fragments/701-private_key_info-consistency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_privatekey_info - ``check_consistency=true`` no longer works for RSA keys with cryptography 42.0.0+ (https://github.com/ansible-collections/community.crypto/pull/701)."

--- a/plugins/module_utils/crypto/module_backends/privatekey_info.py
+++ b/plugins/module_utils/crypto/module_backends/privatekey_info.py
@@ -107,7 +107,10 @@ def _check_dsa_consistency(key_public_data, key_private_data):
 
 def _is_cryptography_key_consistent(key, key_public_data, key_private_data):
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey):
-        return bool(key._backend._lib.RSA_check_key(key._rsa_cdata))
+        # key._backend was removed in cryptography 42.0.0
+        backend = getattr(key, '_backend', None)
+        if backend is not None:
+            return bool(backend._lib.RSA_check_key(key._rsa_cdata))
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey):
         result = _check_dsa_consistency(key_public_data, key_private_data)
         if result is not None:

--- a/plugins/modules/openssl_privatekey_info.py
+++ b/plugins/modules/openssl_privatekey_info.py
@@ -60,6 +60,9 @@ options:
               avoid private key material to be transported around and computed with, and only do
               so when requested explicitly. This can potentially prevent
               L(side-channel attacks,https://en.wikipedia.org/wiki/Side-channel_attack).
+            - Note that consistency checks only work for certain key types, and might depend on the
+              version of the cryptography library. For example, with cryptography 42.0.0 and newer
+              consistency of RSA keys can no longer be checked.
         type: bool
         default: false
         version_added: 2.0.0


### PR DESCRIPTION
##### SUMMARY
Fixes #701.

Needs to be backported manually.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey_info
