### PR TITLE
[stable-1] Disable consistency checking of RSA keys for cryptography 42.0.0 which no longer gives access to the required function

### DIFF
--- a/changelogs/fragments/701-private_key_info-consistency.yml
+++ b/changelogs/fragments/701-private_key_info-consistency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_privatekey_info - ``check_consistency=true`` no longer works for RSA keys with cryptography 42.0.0+ (https://github.com/ansible-collections/community.crypto/pull/701)."

--- a/plugins/module_utils/crypto/module_backends/privatekey_info.py
+++ b/plugins/module_utils/crypto/module_backends/privatekey_info.py
@@ -119,7 +119,10 @@ def _check_dsa_consistency(key_public_data, key_private_data):
 
 def _is_cryptography_key_consistent(key, key_public_data, key_private_data):
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey):
-        return bool(key._backend._lib.RSA_check_key(key._rsa_cdata))
+        # key._backend was removed in cryptography 42.0.0
+        backend = getattr(key, '_backend', None)
+        if backend is not None:
+            return bool(backend._lib.RSA_check_key(key._rsa_cdata))
     if isinstance(key, cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey):
         result = _check_dsa_consistency(key_public_data, key_private_data)
         if result is not None:

--- a/plugins/modules/openssl_privatekey_info.py
+++ b/plugins/modules/openssl_privatekey_info.py
@@ -102,6 +102,9 @@ key_is_consistent:
         - Whether the key is consistent. Can also return C(none) next to C(yes) and
           C(no), to indicate that consistency could not be checked.
         - In case the check returns C(no), the module will fail.
+        - Note that consistency checks only work for certain key types, and might depend on the
+          version of the cryptography library. For example, with cryptography 42.0.0 and newer
+          consistency of RSA keys can no longer be checked.
     returned: always
     type: bool
 public_key:

--- a/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_privatekey_info/tasks/main.yml
@@ -71,7 +71,8 @@
   - name: Compare results
     assert:
       that:
-      - '  (pyopenssl_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | list | items2dict)
-        == (cryptography_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | list | items2dict)'
+      - >-
+        (pyopenssl_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | rejectattr("key", "equalto", "key_is_consistent") | list | items2dict)
+        == (cryptography_info_results[item] | dict2items | rejectattr("key", "equalto", "deprecations") | rejectattr("key", "equalto", "key_is_consistent") | list | items2dict)
     loop: "{{ pyopenssl_info_results.keys() | intersect(cryptography_info_results.keys()) | list }}"
   when: pyopenssl_version.stdout is version('0.15', '>=') and cryptography_version.stdout is version('1.2.3', '>=')


### PR DESCRIPTION
##### SUMMARY
Backport of #702 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey_info
