### PR TITLE
[stable-1] Add MarkDown changelog and use it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,848 @@
+# Community Crypto Release Notes
+
+**Topics**
+- <a href="#v1-9-24">v1\.9\.24</a>
+  - <a href="#release-summary">Release Summary</a>
+  - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v1-9-23">v1\.9\.23</a>
+  - <a href="#release-summary-1">Release Summary</a>
+  - <a href="#bugfixes-1">Bugfixes</a>
+- <a href="#v1-9-22">v1\.9\.22</a>
+  - <a href="#release-summary-2">Release Summary</a>
+  - <a href="#bugfixes-2">Bugfixes</a>
+- <a href="#v1-9-21">v1\.9\.21</a>
+  - <a href="#release-summary-3">Release Summary</a>
+  - <a href="#bugfixes-3">Bugfixes</a>
+- <a href="#v1-9-20">v1\.9\.20</a>
+  - <a href="#release-summary-4">Release Summary</a>
+  - <a href="#bugfixes-4">Bugfixes</a>
+- <a href="#v1-9-19">v1\.9\.19</a>
+  - <a href="#release-summary-5">Release Summary</a>
+  - <a href="#bugfixes-5">Bugfixes</a>
+- <a href="#v1-9-18">v1\.9\.18</a>
+  - <a href="#release-summary-6">Release Summary</a>
+  - <a href="#bugfixes-6">Bugfixes</a>
+- <a href="#v1-9-17">v1\.9\.17</a>
+  - <a href="#release-summary-7">Release Summary</a>
+  - <a href="#bugfixes-7">Bugfixes</a>
+- <a href="#v1-9-16">v1\.9\.16</a>
+  - <a href="#release-summary-8">Release Summary</a>
+  - <a href="#bugfixes-8">Bugfixes</a>
+- <a href="#v1-9-15">v1\.9\.15</a>
+  - <a href="#release-summary-9">Release Summary</a>
+  - <a href="#bugfixes-9">Bugfixes</a>
+- <a href="#v1-9-14">v1\.9\.14</a>
+  - <a href="#release-summary-10">Release Summary</a>
+  - <a href="#bugfixes-10">Bugfixes</a>
+- <a href="#v1-9-13">v1\.9\.13</a>
+  - <a href="#release-summary-11">Release Summary</a>
+  - <a href="#bugfixes-11">Bugfixes</a>
+- <a href="#v1-9-12">v1\.9\.12</a>
+  - <a href="#release-summary-12">Release Summary</a>
+  - <a href="#bugfixes-12">Bugfixes</a>
+  - <a href="#known-issues">Known Issues</a>
+- <a href="#v1-9-11">v1\.9\.11</a>
+  - <a href="#release-summary-13">Release Summary</a>
+  - <a href="#bugfixes-13">Bugfixes</a>
+- <a href="#v1-9-10">v1\.9\.10</a>
+  - <a href="#release-summary-14">Release Summary</a>
+  - <a href="#bugfixes-14">Bugfixes</a>
+- <a href="#v1-9-9">v1\.9\.9</a>
+  - <a href="#bugfixes-15">Bugfixes</a>
+- <a href="#v1-9-8">v1\.9\.8</a>
+  - <a href="#release-summary-15">Release Summary</a>
+- <a href="#v1-9-7">v1\.9\.7</a>
+  - <a href="#release-summary-16">Release Summary</a>
+  - <a href="#minor-changes">Minor Changes</a>
+  - <a href="#bugfixes-16">Bugfixes</a>
+- <a href="#v1-9-6">v1\.9\.6</a>
+  - <a href="#release-summary-17">Release Summary</a>
+  - <a href="#bugfixes-17">Bugfixes</a>
+- <a href="#v1-9-5">v1\.9\.5</a>
+  - <a href="#release-summary-18">Release Summary</a>
+  - <a href="#bugfixes-18">Bugfixes</a>
+- <a href="#v1-9-4">v1\.9\.4</a>
+  - <a href="#release-summary-19">Release Summary</a>
+  - <a href="#bugfixes-19">Bugfixes</a>
+- <a href="#v1-9-3">v1\.9\.3</a>
+  - <a href="#release-summary-20">Release Summary</a>
+  - <a href="#bugfixes-20">Bugfixes</a>
+- <a href="#v1-9-2">v1\.9\.2</a>
+  - <a href="#release-summary-21">Release Summary</a>
+- <a href="#v1-9-1">v1\.9\.1</a>
+  - <a href="#release-summary-22">Release Summary</a>
+- <a href="#v1-9-0">v1\.9\.0</a>
+  - <a href="#release-summary-23">Release Summary</a>
+  - <a href="#minor-changes-1">Minor Changes</a>
+  - <a href="#bugfixes-21">Bugfixes</a>
+- <a href="#v1-8-0">v1\.8\.0</a>
+  - <a href="#release-summary-24">Release Summary</a>
+  - <a href="#minor-changes-2">Minor Changes</a>
+  - <a href="#bugfixes-22">Bugfixes</a>
+- <a href="#v1-7-1">v1\.7\.1</a>
+  - <a href="#release-summary-25">Release Summary</a>
+  - <a href="#bugfixes-23">Bugfixes</a>
+- <a href="#v1-7-0">v1\.7\.0</a>
+  - <a href="#release-summary-26">Release Summary</a>
+  - <a href="#minor-changes-3">Minor Changes</a>
+  - <a href="#bugfixes-24">Bugfixes</a>
+  - <a href="#new-modules">New Modules</a>
+- <a href="#v1-6-2">v1\.6\.2</a>
+  - <a href="#release-summary-27">Release Summary</a>
+  - <a href="#bugfixes-25">Bugfixes</a>
+- <a href="#v1-6-1">v1\.6\.1</a>
+  - <a href="#release-summary-28">Release Summary</a>
+  - <a href="#bugfixes-26">Bugfixes</a>
+- <a href="#v1-6-0">v1\.6\.0</a>
+  - <a href="#release-summary-29">Release Summary</a>
+  - <a href="#minor-changes-4">Minor Changes</a>
+  - <a href="#deprecated-features">Deprecated Features</a>
+  - <a href="#bugfixes-27">Bugfixes</a>
+- <a href="#v1-5-0">v1\.5\.0</a>
+  - <a href="#release-summary-30">Release Summary</a>
+  - <a href="#minor-changes-5">Minor Changes</a>
+  - <a href="#deprecated-features-1">Deprecated Features</a>
+  - <a href="#bugfixes-28">Bugfixes</a>
+- <a href="#v1-4-0">v1\.4\.0</a>
+  - <a href="#release-summary-31">Release Summary</a>
+  - <a href="#minor-changes-6">Minor Changes</a>
+  - <a href="#bugfixes-29">Bugfixes</a>
+- <a href="#v1-3-0">v1\.3\.0</a>
+  - <a href="#release-summary-32">Release Summary</a>
+  - <a href="#minor-changes-7">Minor Changes</a>
+  - <a href="#bugfixes-30">Bugfixes</a>
+  - <a href="#new-modules-1">New Modules</a>
+- <a href="#v1-2-0">v1\.2\.0</a>
+  - <a href="#release-summary-33">Release Summary</a>
+  - <a href="#minor-changes-8">Minor Changes</a>
+  - <a href="#security-fixes">Security Fixes</a>
+  - <a href="#bugfixes-31">Bugfixes</a>
+- <a href="#v1-1-1">v1\.1\.1</a>
+  - <a href="#release-summary-34">Release Summary</a>
+  - <a href="#bugfixes-32">Bugfixes</a>
+- <a href="#v1-1-0">v1\.1\.0</a>
+  - <a href="#release-summary-35">Release Summary</a>
+  - <a href="#minor-changes-9">Minor Changes</a>
+  - <a href="#bugfixes-33">Bugfixes</a>
+  - <a href="#new-modules-2">New Modules</a>
+- <a href="#v1-0-0">v1\.0\.0</a>
+  - <a href="#release-summary-36">Release Summary</a>
+  - <a href="#minor-changes-10">Minor Changes</a>
+  - <a href="#deprecated-features-2">Deprecated Features</a>
+  - <a href="#removed-features-previously-deprecated">Removed Features \(previously deprecated\)</a>
+  - <a href="#bugfixes-34">Bugfixes</a>
+  - <a href="#new-modules-3">New Modules</a>
+
+<a id="v1-9-24"></a>
+## v1\.9\.24
+
+<a id="release-summary"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes"></a>
+### Bugfixes
+
+* openssl\_dhparam \- was using an internal function instead of the public API to load DH param files when using the <code>cryptography</code> backend\. The internal function was removed in cryptography 42\.0\.0\. The module now uses the public API\, which has been available since support for DH params was added to cryptography \([https\://github\.com/ansible\-collections/community\.crypto/pull/698](https\://github\.com/ansible\-collections/community\.crypto/pull/698)\)\.
+* openssl\_privatekey\_info \- <code>check\_consistency\=true</code> no longer works for RSA keys with cryptography 42\.0\.0\+ \([https\://github\.com/ansible\-collections/community\.crypto/pull/701](https\://github\.com/ansible\-collections/community\.crypto/pull/701)\)\.
+* x509\_certificate \- when using the PyOpenSSL backend with <code>provider\=assertonly</code>\, better handle unexpected errors when validating private keys \([https\://github\.com/ansible\-collections/community\.crypto/pull/704](https\://github\.com/ansible\-collections/community\.crypto/pull/704)\)\.
+
+<a id="v1-9-23"></a>
+## v1\.9\.23
+
+<a id="release-summary-1"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-1"></a>
+### Bugfixes
+
+* openssl\_pkcs12 \- modify autodetect to not detect pyOpenSSL \>\= 23\.3\.0\, which removed PKCS\#12 support \([https\://github\.com/ansible\-collections/community\.crypto/pull/666](https\://github\.com/ansible\-collections/community\.crypto/pull/666)\)\.
+
+<a id="v1-9-22"></a>
+## v1\.9\.22
+
+<a id="release-summary-2"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-2"></a>
+### Bugfixes
+
+* openssh\_keypair \- always generate a new key pair if the private key does not exist\. Previously\, the module would fail when <code>regenerate\=fail</code> without an existing key\, contradicting the documentation \([https\://github\.com/ansible\-collections/community\.crypto/pull/598](https\://github\.com/ansible\-collections/community\.crypto/pull/598)\)\.
+
+<a id="v1-9-21"></a>
+## v1\.9\.21
+
+<a id="release-summary-3"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-3"></a>
+### Bugfixes
+
+* action plugin helper \- fix handling of deprecations for ansible\-core 2\.14\.2 \([https\://github\.com/ansible\-collections/community\.crypto/pull/572](https\://github\.com/ansible\-collections/community\.crypto/pull/572)\)\.
+* openssl\_csr\, openssl\_csr\_pipe \- prevent invalid values for <code>crl\_distribution\_points</code> that do not have one of <code>full\_name</code>\, <code>relative\_name</code>\, and <code>crl\_issuer</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/560](https\://github\.com/ansible\-collections/community\.crypto/pull/560)\)\.
+
+<a id="v1-9-20"></a>
+## v1\.9\.20
+
+<a id="release-summary-4"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-4"></a>
+### Bugfixes
+
+* openssl\_publickey\_info \- do not crash with internal error when public key cannot be parsed \([https\://github\.com/ansible\-collections/community\.crypto/pull/551](https\://github\.com/ansible\-collections/community\.crypto/pull/551)\)\.
+
+<a id="v1-9-19"></a>
+## v1\.9\.19
+
+<a id="release-summary-5"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-5"></a>
+### Bugfixes
+
+* openssl\_privatekey\_pipe \- ensure compatibility with newer versions of ansible\-core \([https\://github\.com/ansible\-collections/community\.crypto/pull/515](https\://github\.com/ansible\-collections/community\.crypto/pull/515)\)\.
+
+<a id="v1-9-18"></a>
+## v1\.9\.18
+
+<a id="release-summary-6"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-6"></a>
+### Bugfixes
+
+* openssl\_pkcs12 \- when using the pyOpenSSL backend\, do not crash when trying to read non\-existing other certificates \([https\://github\.com/ansible\-collections/community\.crypto/issues/486](https\://github\.com/ansible\-collections/community\.crypto/issues/486)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/487](https\://github\.com/ansible\-collections/community\.crypto/pull/487)\)\.
+
+<a id="v1-9-17"></a>
+## v1\.9\.17
+
+<a id="release-summary-7"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-7"></a>
+### Bugfixes
+
+* Include <code>Apache\-2\.0\.txt</code> file for <code>plugins/module\_utils/crypto/\_obj2txt\.py</code> and <code>plugins/module\_utils/crypto/\_objects\_data\.py</code>\.
+* openssl\_csr \- the module no longer crashes with \'permitted\_subtrees/excluded\_subtrees must be a non\-empty list or None\' if only one of <code>name\_constraints\_permitted</code> and <code>name\_constraints\_excluded</code> is provided \([https\://github\.com/ansible\-collections/community\.crypto/issues/481](https\://github\.com/ansible\-collections/community\.crypto/issues/481)\)\.
+* x509\_crl \- do not crash when signing CRL with Ed25519 or Ed448 keys \([https\://github\.com/ansible\-collections/community\.crypto/issues/473](https\://github\.com/ansible\-collections/community\.crypto/issues/473)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/474](https\://github\.com/ansible\-collections/community\.crypto/pull/474)\)\.
+
+<a id="v1-9-16"></a>
+## v1\.9\.16
+
+<a id="release-summary-8"></a>
+### Release Summary
+
+Maintenance and bugfix release\.
+
+<a id="bugfixes-8"></a>
+### Bugfixes
+
+* Include <code>simplified\_bsd\.txt</code> license file for the ECS module utils\.
+* certificate\_complete\_chain \- do not stop execution if an unsupported signature algorithm is encountered\; warn instead \([https\://github\.com/ansible\-collections/community\.crypto/pull/457](https\://github\.com/ansible\-collections/community\.crypto/pull/457)\)\.
+
+<a id="v1-9-15"></a>
+## v1\.9\.15
+
+<a id="release-summary-9"></a>
+### Release Summary
+
+Maintenance release\.
+
+<a id="bugfixes-9"></a>
+### Bugfixes
+
+* Include <code>PSF\-license\.txt</code> file for <code>plugins/module\_utils/\_version\.py</code>\.
+
+<a id="v1-9-14"></a>
+## v1\.9\.14
+
+<a id="release-summary-10"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-10"></a>
+### Bugfixes
+
+* Make collection more robust when PyOpenSSL is used with an incompatible cryptography version \([https\://github\.com/ansible\-collections/community\.crypto/pull/446](https\://github\.com/ansible\-collections/community\.crypto/pull/446)\)\.
+* openssh\_\* modules \- fix exception handling to report traceback to users for enhanced traceability \([https\://github\.com/ansible\-collections/community\.crypto/pull/417](https\://github\.com/ansible\-collections/community\.crypto/pull/417)\)\.
+* x509\_crl \- fix crash when <code>issuer</code> for a revoked certificate is specified \([https\://github\.com/ansible\-collections/community\.crypto/pull/441](https\://github\.com/ansible\-collections/community\.crypto/pull/441)\)\.
+
+<a id="v1-9-13"></a>
+## v1\.9\.13
+
+<a id="release-summary-11"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-11"></a>
+### Bugfixes
+
+* luks\_device \- fix parsing of <code>lsblk</code> output when device name ends with <code>crypt</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/409](https\://github\.com/ansible\-collections/community\.crypto/issues/409)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/410](https\://github\.com/ansible\-collections/community\.crypto/pull/410)\)\.
+
+<a id="v1-9-12"></a>
+## v1\.9\.12
+
+<a id="release-summary-12"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-12"></a>
+### Bugfixes
+
+* certificate\_complete\_chain \- allow multiple potential intermediate certificates to have the same subject \([https\://github\.com/ansible\-collections/community\.crypto/issues/399](https\://github\.com/ansible\-collections/community\.crypto/issues/399)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/403](https\://github\.com/ansible\-collections/community\.crypto/pull/403)\)\.
+* x509\_certificate \- for the <code>ownca</code> provider\, check whether the CA private key actually belongs to the CA certificate\. This fix only covers the <code>cryptography</code> backend\, not the <code>pyopenssl</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+* x509\_certificate \- regenerate certificate when the CA\'s public key changes for <code>provider\=ownca</code>\. This fix only covers the <code>cryptography</code> backend\, not the <code>pyopenssl</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+* x509\_certificate \- regenerate certificate when the CA\'s subject changes for <code>provider\=ownca</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/400](https\://github\.com/ansible\-collections/community\.crypto/issues/400)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/402](https\://github\.com/ansible\-collections/community\.crypto/pull/402)\)\.
+* x509\_certificate \- regenerate certificate when the private key changes for <code>provider\=selfsigned</code>\. This fix only covers the <code>cryptography</code> backend\, not the <code>pyopenssl</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+
+<a id="known-issues"></a>
+### Known Issues
+
+* x509\_certificate \- when using the <code>ownca</code> provider with the <code>pyopenssl</code> backend\, changing the CA\'s public key does not cause regeneration of the certificate \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+* x509\_certificate \- when using the <code>ownca</code> provider with the <code>pyopenssl</code> backend\, it is possible to specify a CA private key which is not related to the CA certificate \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+* x509\_certificate \- when using the <code>selfsigned</code> provider with the <code>pyopenssl</code> backend\, changing the private key does not cause regeneration of the certificate \([https\://github\.com/ansible\-collections/community\.crypto/pull/407](https\://github\.com/ansible\-collections/community\.crypto/pull/407)\)\.
+
+<a id="v1-9-11"></a>
+## v1\.9\.11
+
+<a id="release-summary-13"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-13"></a>
+### Bugfixes
+
+* openssh\_cert \- fixed false <code>changed</code> status for <code>host</code> certificates when using <code>full\_idempotence</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/395](https\://github\.com/ansible\-collections/community\.crypto/issues/395)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/396](https\://github\.com/ansible\-collections/community\.crypto/pull/396)\)\.
+
+<a id="v1-9-10"></a>
+## v1\.9\.10
+
+<a id="release-summary-14"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-14"></a>
+### Bugfixes
+
+* luks\_devices \- set <code>LANG</code> and similar environment variables to avoid translated output\, which can break some of the module\'s functionality like key management \([https\://github\.com/ansible\-collections/community\.crypto/pull/388](https\://github\.com/ansible\-collections/community\.crypto/pull/388)\, [https\://github\.com/ansible\-collections/community\.crypto/issues/385](https\://github\.com/ansible\-collections/community\.crypto/issues/385)\)\.
+
+<a id="v1-9-9"></a>
+## v1\.9\.9
+
+<a id="bugfixes-15"></a>
+### Bugfixes
+
+* Various modules and plugins \- use vendored version of <code>distutils\.version</code> instead of the deprecated Python standard library <code>distutils</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/353](https\://github\.com/ansible\-collections/community\.crypto/pull/353)\)\.
+* certificate\_complete\_chain \- do not append root twice if the chain already ends with a root certificate \([https\://github\.com/ansible\-collections/community\.crypto/pull/360](https\://github\.com/ansible\-collections/community\.crypto/pull/360)\)\.
+* certificate\_complete\_chain \- do not hang when infinite loop is found \([https\://github\.com/ansible\-collections/community\.crypto/issues/355](https\://github\.com/ansible\-collections/community\.crypto/issues/355)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/360](https\://github\.com/ansible\-collections/community\.crypto/pull/360)\)\.
+
+<a id="v1-9-8"></a>
+## v1\.9\.8
+
+<a id="release-summary-15"></a>
+### Release Summary
+
+Documentation fix release\. No actual code changes\.
+
+<a id="v1-9-7"></a>
+## v1\.9\.7
+
+<a id="release-summary-16"></a>
+### Release Summary
+
+Bugfix release with extra forward compatibility for newer versions of cryptography\.
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* acme\_\* modules \- fix usage of <code>fetch\_url</code> with changes in latest ansible\-core <code>devel</code> branch \([https\://github\.com/ansible\-collections/community\.crypto/pull/339](https\://github\.com/ansible\-collections/community\.crypto/pull/339)\)\.
+
+<a id="bugfixes-16"></a>
+### Bugfixes
+
+* acme\_certificate \- avoid passing multiple certificates to <code>cryptography</code>\'s X\.509 certificate loader when <code>fullchain\_dest</code> is used \([https\://github\.com/ansible\-collections/community\.crypto/pull/324](https\://github\.com/ansible\-collections/community\.crypto/pull/324)\)\.
+* get\_certificate\, openssl\_csr\_info\, x509\_certificate\_info \- add fallback code for extension parsing that works with cryptography 36\.0\.0 and newer\. This code re\-serializes de\-serialized extensions and thus can return slightly different values if the extension in the original CSR resp\. certificate was not canonicalized correctly\. This code is currently used as a fallback if the existing code stops working\, but we will switch it to be the main code in a future release \([https\://github\.com/ansible\-collections/community\.crypto/pull/331](https\://github\.com/ansible\-collections/community\.crypto/pull/331)\)\.
+* luks\_device \- now also runs a built\-in LUKS signature cleaner on <code>state\=absent</code> to make sure that also the secondary LUKS2 header is wiped when older versions of wipefs are used \([https\://github\.com/ansible\-collections/community\.crypto/issues/326](https\://github\.com/ansible\-collections/community\.crypto/issues/326)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/327](https\://github\.com/ansible\-collections/community\.crypto/pull/327)\)\.
+* openssl\_pkcs12 \- use new PKCS\#12 deserialization infrastructure from cryptography 36\.0\.0 if available \([https\://github\.com/ansible\-collections/community\.crypto/pull/302](https\://github\.com/ansible\-collections/community\.crypto/pull/302)\)\.
+
+<a id="v1-9-6"></a>
+## v1\.9\.6
+
+<a id="release-summary-17"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-17"></a>
+### Bugfixes
+
+* cryptography backend \- improve Unicode handling for Python 2 \([https\://github\.com/ansible\-collections/community\.crypto/pull/313](https\://github\.com/ansible\-collections/community\.crypto/pull/313)\)\.
+
+<a id="v1-9-5"></a>
+## v1\.9\.5
+
+<a id="release-summary-18"></a>
+### Release Summary
+
+Bugfix release to fully support cryptography 35\.0\.0\.
+
+<a id="bugfixes-18"></a>
+### Bugfixes
+
+* get\_certificate \- fix compatibility with the cryptography 35\.0\.0 release \([https\://github\.com/ansible\-collections/community\.crypto/pull/294](https\://github\.com/ansible\-collections/community\.crypto/pull/294)\)\.
+* openssl\_csr\_info \- fix compatibility with the cryptography 35\.0\.0 release \([https\://github\.com/ansible\-collections/community\.crypto/pull/294](https\://github\.com/ansible\-collections/community\.crypto/pull/294)\)\.
+* openssl\_csr\_info \- fix compatibility with the cryptography 35\.0\.0 release in PyOpenSSL backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/300](https\://github\.com/ansible\-collections/community\.crypto/pull/300)\)\.
+* openssl\_pkcs12 \- fix compatibility with the cryptography 35\.0\.0 release \([https\://github\.com/ansible\-collections/community\.crypto/pull/296](https\://github\.com/ansible\-collections/community\.crypto/pull/296)\)\.
+* x509\_certificate\_info \- fix compatibility with the cryptography 35\.0\.0 release \([https\://github\.com/ansible\-collections/community\.crypto/pull/294](https\://github\.com/ansible\-collections/community\.crypto/pull/294)\)\.
+* x509\_certificate\_info \- fix compatibility with the cryptography 35\.0\.0 release in PyOpenSSL backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/300](https\://github\.com/ansible\-collections/community\.crypto/pull/300)\)\.
+
+<a id="v1-9-4"></a>
+## v1\.9\.4
+
+<a id="release-summary-19"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-19"></a>
+### Bugfixes
+
+* acme\_\* modules \- fix commands composed for OpenSSL backend to retrieve information on CSRs and certificates from stdin to use <code>/dev/stdin</code> instead of <code>\-</code>\. This is needed for OpenSSL 1\.0\.1 and 1\.0\.2\, apparently \([https\://github\.com/ansible\-collections/community\.crypto/pull/279](https\://github\.com/ansible\-collections/community\.crypto/pull/279)\)\.
+* acme\_challenge\_cert\_helper \- only return exception when cryptography is not installed\, not when a too old version of it is installed\. This prevents Ansible\'s callback to crash \([https\://github\.com/ansible\-collections/community\.crypto/pull/281](https\://github\.com/ansible\-collections/community\.crypto/pull/281)\)\.
+
+<a id="v1-9-3"></a>
+## v1\.9\.3
+
+<a id="release-summary-20"></a>
+### Release Summary
+
+Regular bugfix release\.
+
+<a id="bugfixes-20"></a>
+### Bugfixes
+
+* openssl\_csr and openssl\_csr\_pipe \- make sure that Unicode strings are used to compare strings with the cryptography backend\. This fixes idempotency problems with non\-ASCII letters on Python 2 \([https\://github\.com/ansible\-collections/community\.crypto/issues/270](https\://github\.com/ansible\-collections/community\.crypto/issues/270)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/271](https\://github\.com/ansible\-collections/community\.crypto/pull/271)\)\.
+
+<a id="v1-9-2"></a>
+## v1\.9\.2
+
+<a id="release-summary-21"></a>
+### Release Summary
+
+Bugfix release to fix the changelog\. No other change compared to 1\.9\.0\.
+
+<a id="v1-9-1"></a>
+## v1\.9\.1
+
+<a id="release-summary-22"></a>
+### Release Summary
+
+Accidental 1\.9\.1 release\. Identical to 1\.9\.0\.
+
+<a id="v1-9-0"></a>
+## v1\.9\.0
+
+<a id="release-summary-23"></a>
+### Release Summary
+
+Regular feature release\.
+
+<a id="minor-changes-1"></a>
+### Minor Changes
+
+* get\_certificate \- added <code>starttls</code> option to retrieve certificates from servers which require clients to request an encrypted connection \([https\://github\.com/ansible\-collections/community\.crypto/pull/264](https\://github\.com/ansible\-collections/community\.crypto/pull/264)\)\.
+* openssh\_keypair \- added <code>diff</code> support \([https\://github\.com/ansible\-collections/community\.crypto/pull/260](https\://github\.com/ansible\-collections/community\.crypto/pull/260)\)\.
+
+<a id="bugfixes-21"></a>
+### Bugfixes
+
+* keypair\_backend module utils \- simplify code to pass sanity tests \([https\://github\.com/ansible\-collections/community\.crypto/pull/263](https\://github\.com/ansible\-collections/community\.crypto/pull/263)\)\.
+* openssh\_keypair \- fixed <code>cryptography</code> backend to preserve original file permissions when regenerating a keypair requires existing files to be overwritten \([https\://github\.com/ansible\-collections/community\.crypto/pull/260](https\://github\.com/ansible\-collections/community\.crypto/pull/260)\)\.
+* openssh\_keypair \- fixed error handling to restore original keypair if regeneration fails \([https\://github\.com/ansible\-collections/community\.crypto/pull/260](https\://github\.com/ansible\-collections/community\.crypto/pull/260)\)\.
+* x509\_crl \- restore inherited function signature to pass sanity tests \([https\://github\.com/ansible\-collections/community\.crypto/pull/263](https\://github\.com/ansible\-collections/community\.crypto/pull/263)\)\.
+
+<a id="v1-8-0"></a>
+## v1\.8\.0
+
+<a id="release-summary-24"></a>
+### Release Summary
+
+Regular bugfix and feature release\.
+
+<a id="minor-changes-2"></a>
+### Minor Changes
+
+* Avoid internal ansible\-core module\_utils in favor of equivalent public API available since at least Ansible 2\.9 \([https\://github\.com/ansible\-collections/community\.crypto/pull/253](https\://github\.com/ansible\-collections/community\.crypto/pull/253)\)\.
+* openssh certificate module utils \- new module\_utils for parsing OpenSSH certificates \([https\://github\.com/ansible\-collections/community\.crypto/pull/246](https\://github\.com/ansible\-collections/community\.crypto/pull/246)\)\.
+* openssh\_cert \- added <code>regenerate</code> option to validate additional certificate parameters which trigger regeneration of an existing certificate \([https\://github\.com/ansible\-collections/community\.crypto/pull/256](https\://github\.com/ansible\-collections/community\.crypto/pull/256)\)\.
+* openssh\_cert \- adding <code>diff</code> support \([https\://github\.com/ansible\-collections/community\.crypto/pull/255](https\://github\.com/ansible\-collections/community\.crypto/pull/255)\)\.
+
+<a id="bugfixes-22"></a>
+### Bugfixes
+
+* openssh\_cert \- fixed certificate generation to restore original certificate if an error is encountered \([https\://github\.com/ansible\-collections/community\.crypto/pull/255](https\://github\.com/ansible\-collections/community\.crypto/pull/255)\)\.
+* openssh\_keypair \- fixed a bug that prevented custom file attributes being applied to public keys \([https\://github\.com/ansible\-collections/community\.crypto/pull/257](https\://github\.com/ansible\-collections/community\.crypto/pull/257)\)\.
+
+<a id="v1-7-1"></a>
+## v1\.7\.1
+
+<a id="release-summary-25"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-23"></a>
+### Bugfixes
+
+* openssl\_pkcs12 \- fix crash when loading passphrase\-protected PKCS\#12 files with <code>cryptography</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/issues/247](https\://github\.com/ansible\-collections/community\.crypto/issues/247)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/248](https\://github\.com/ansible\-collections/community\.crypto/pull/248)\)\.
+
+<a id="v1-7-0"></a>
+## v1\.7\.0
+
+<a id="release-summary-26"></a>
+### Release Summary
+
+Regular feature and bugfix release\.
+
+<a id="minor-changes-3"></a>
+### Minor Changes
+
+* cryptography\_openssh module utils \- new module\_utils for managing asymmetric keypairs and OpenSSH formatted/encoded asymmetric keypairs \([https\://github\.com/ansible\-collections/community\.crypto/pull/213](https\://github\.com/ansible\-collections/community\.crypto/pull/213)\)\.
+* openssh\_keypair \- added <code>backend</code> parameter for selecting between the cryptography library or the OpenSSH binary for the execution of actions performed by <code>openssh\_keypair</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/236](https\://github\.com/ansible\-collections/community\.crypto/pull/236)\)\.
+* openssh\_keypair \- added <code>passphrase</code> parameter for encrypting/decrypting OpenSSH private keys \([https\://github\.com/ansible\-collections/community\.crypto/pull/225](https\://github\.com/ansible\-collections/community\.crypto/pull/225)\)\.
+* openssl\_csr \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* openssl\_csr\_info \- now returns <code>public\_key\_type</code> and <code>public\_key\_data</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/233](https\://github\.com/ansible\-collections/community\.crypto/pull/233)\)\.
+* openssl\_csr\_info \- refactor module to allow code re\-use for diff mode \([https\://github\.com/ansible\-collections/community\.crypto/pull/204](https\://github\.com/ansible\-collections/community\.crypto/pull/204)\)\.
+* openssl\_csr\_pipe \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* openssl\_pkcs12 \- added option <code>select\_crypto\_backend</code> and a <code>cryptography</code> backend\. This requires cryptography 3\.0 or newer\, and does not support the <code>iter\_size</code> and <code>maciter\_size</code> options \([https\://github\.com/ansible\-collections/community\.crypto/pull/234](https\://github\.com/ansible\-collections/community\.crypto/pull/234)\)\.
+* openssl\_privatekey \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* openssl\_privatekey\_info \- refactor module to allow code re\-use for diff mode \([https\://github\.com/ansible\-collections/community\.crypto/pull/205](https\://github\.com/ansible\-collections/community\.crypto/pull/205)\)\.
+* openssl\_privatekey\_pipe \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* openssl\_publickey \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* x509\_certificate \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* x509\_certificate\_info \- now returns <code>public\_key\_type</code> and <code>public\_key\_data</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/233](https\://github\.com/ansible\-collections/community\.crypto/pull/233)\)\.
+* x509\_certificate\_info \- refactor module to allow code re\-use for diff mode \([https\://github\.com/ansible\-collections/community\.crypto/pull/206](https\://github\.com/ansible\-collections/community\.crypto/pull/206)\)\.
+* x509\_certificate\_pipe \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* x509\_crl \- add diff mode \([https\://github\.com/ansible\-collections/community\.crypto/issues/38](https\://github\.com/ansible\-collections/community\.crypto/issues/38)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/150](https\://github\.com/ansible\-collections/community\.crypto/pull/150)\)\.
+* x509\_crl\_info \- add <code>list\_revoked\_certificates</code> option to avoid enumerating all revoked certificates \([https\://github\.com/ansible\-collections/community\.crypto/pull/232](https\://github\.com/ansible\-collections/community\.crypto/pull/232)\)\.
+* x509\_crl\_info \- refactor module to allow code re\-use for diff mode \([https\://github\.com/ansible\-collections/community\.crypto/pull/203](https\://github\.com/ansible\-collections/community\.crypto/pull/203)\)\.
+
+<a id="bugfixes-24"></a>
+### Bugfixes
+
+* openssh\_keypair \- fix <code>check\_mode</code> to populate return values for existing keypairs \([https\://github\.com/ansible\-collections/community\.crypto/issues/113](https\://github\.com/ansible\-collections/community\.crypto/issues/113)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/230](https\://github\.com/ansible\-collections/community\.crypto/pull/230)\)\.
+* various modules \- prevent crashes when modules try to set attributes on not yet existing files in check mode\. This will be fixed in ansible\-core 2\.12\, but it is not backported to every Ansible version we support \([https\://github\.com/ansible\-collections/community\.crypto/issue/242](https\://github\.com/ansible\-collections/community\.crypto/issue/242)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/243](https\://github\.com/ansible\-collections/community\.crypto/pull/243)\)\.
+* x509\_certificate \- fix crash when <code>assertonly</code> provider is used and some error conditions should be reported \([https\://github\.com/ansible\-collections/community\.crypto/issues/240](https\://github\.com/ansible\-collections/community\.crypto/issues/240)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/241](https\://github\.com/ansible\-collections/community\.crypto/pull/241)\)\.
+
+<a id="new-modules"></a>
+### New Modules
+
+* openssl\_publickey\_info \- Provide information for OpenSSL public keys
+
+<a id="v1-6-2"></a>
+## v1\.6\.2
+
+<a id="release-summary-27"></a>
+### Release Summary
+
+Bugfix release\. Fixes compatibility issue of ACME modules with step\-ca\.
+
+<a id="bugfixes-25"></a>
+### Bugfixes
+
+* acme\_\* modules \- avoid crashing for ACME servers where the <code>meta</code> directory key is not present \([https\://github\.com/ansible\-collections/community\.crypto/issues/220](https\://github\.com/ansible\-collections/community\.crypto/issues/220)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/221](https\://github\.com/ansible\-collections/community\.crypto/pull/221)\)\.
+
+<a id="v1-6-1"></a>
+## v1\.6\.1
+
+<a id="release-summary-28"></a>
+### Release Summary
+
+Bugfix release\.
+
+<a id="bugfixes-26"></a>
+### Bugfixes
+
+* acme\_\* modules \- fix wrong usages of <code>ACMEProtocolException</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/216](https\://github\.com/ansible\-collections/community\.crypto/pull/216)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/217](https\://github\.com/ansible\-collections/community\.crypto/pull/217)\)\.
+
+<a id="v1-6-0"></a>
+## v1\.6\.0
+
+<a id="release-summary-29"></a>
+### Release Summary
+
+Fixes compatibility issues with the latest ansible\-core 2\.11 beta\, and contains a lot of internal refactoring for the ACME modules and support for private key passphrases for them\.
+
+<a id="minor-changes-4"></a>
+### Minor Changes
+
+* acme module\_utils \- the <code>acme</code> module\_utils has been split up into several Python modules \([https\://github\.com/ansible\-collections/community\.crypto/pull/184](https\://github\.com/ansible\-collections/community\.crypto/pull/184)\)\.
+* acme\_\* modules \- codebase refactor which should not be visible to end\-users \([https\://github\.com/ansible\-collections/community\.crypto/pull/184](https\://github\.com/ansible\-collections/community\.crypto/pull/184)\)\.
+* acme\_\* modules \- support account key passphrases for <code>cryptography</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/issues/197](https\://github\.com/ansible\-collections/community\.crypto/issues/197)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/207](https\://github\.com/ansible\-collections/community\.crypto/pull/207)\)\.
+* acme\_certificate\_revoke \- support revoking by private keys that are passphrase protected for <code>cryptography</code> backend \([https\://github\.com/ansible\-collections/community\.crypto/pull/207](https\://github\.com/ansible\-collections/community\.crypto/pull/207)\)\.
+* acme\_challenge\_cert\_helper \- add <code>private\_key\_passphrase</code> parameter \([https\://github\.com/ansible\-collections/community\.crypto/pull/207](https\://github\.com/ansible\-collections/community\.crypto/pull/207)\)\.
+
+<a id="deprecated-features"></a>
+### Deprecated Features
+
+* acme module\_utils \- the <code>acme</code> module\_utils \(<code>ansible\_collections\.community\.crypto\.plugins\.module\_utils\.acme</code>\) is deprecated and will be removed in community\.crypto 2\.0\.0\. Use the new Python modules in the <code>acme</code> package instead \(<code>ansible\_collections\.community\.crypto\.plugins\.module\_utils\.acme\.xxx</code>\) \([https\://github\.com/ansible\-collections/community\.crypto/pull/184](https\://github\.com/ansible\-collections/community\.crypto/pull/184)\)\.
+
+<a id="bugfixes-27"></a>
+### Bugfixes
+
+* action\_module plugin helper \- make compatible with latest changes in ansible\-core 2\.11\.0b3 \([https\://github\.com/ansible\-collections/community\.crypto/pull/202](https\://github\.com/ansible\-collections/community\.crypto/pull/202)\)\.
+* openssl\_privatekey\_pipe \- make compatible with latest changes in ansible\-core 2\.11\.0b3 \([https\://github\.com/ansible\-collections/community\.crypto/pull/202](https\://github\.com/ansible\-collections/community\.crypto/pull/202)\)\.
+
+<a id="v1-5-0"></a>
+## v1\.5\.0
+
+<a id="release-summary-30"></a>
+### Release Summary
+
+Regular feature and bugfix release\. Deprecates a return value\.
+
+<a id="minor-changes-5"></a>
+### Minor Changes
+
+* acme\_account\_info \- when <code>retrieve\_orders</code> is not <code>ignore</code> and the ACME server allows to query orders\, the new return value <code>order\_uris</code> is always populated with a list of URIs \([https\://github\.com/ansible\-collections/community\.crypto/pull/178](https\://github\.com/ansible\-collections/community\.crypto/pull/178)\)\.
+* luks\_device \- allow to specify sector size for LUKS2 containers with new <code>sector\_size</code> parameter \([https\://github\.com/ansible\-collections/community\.crypto/pull/193](https\://github\.com/ansible\-collections/community\.crypto/pull/193)\)\.
+
+<a id="deprecated-features-1"></a>
+### Deprecated Features
+
+* acme\_account\_info \- when <code>retrieve\_orders\=url\_list</code>\, <code>orders</code> will no longer be returned in community\.crypto 2\.0\.0\. Use <code>order\_uris</code> instead \([https\://github\.com/ansible\-collections/community\.crypto/pull/178](https\://github\.com/ansible\-collections/community\.crypto/pull/178)\)\.
+
+<a id="bugfixes-28"></a>
+### Bugfixes
+
+* openssl\_csr \- no longer fails when comparing CSR without basic constraint when <code>basic\_constraints</code> is specified \([https\://github\.com/ansible\-collections/community\.crypto/issues/179](https\://github\.com/ansible\-collections/community\.crypto/issues/179)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/180](https\://github\.com/ansible\-collections/community\.crypto/pull/180)\)\.
+
+<a id="v1-4-0"></a>
+## v1\.4\.0
+
+<a id="release-summary-31"></a>
+### Release Summary
+
+Release with several new features and bugfixes\.
+
+<a id="minor-changes-6"></a>
+### Minor Changes
+
+* The ACME module\_utils has been relicensed back from the Simplified BSD License \([https\://opensource\.org/licenses/BSD\-2\-Clause](https\://opensource\.org/licenses/BSD\-2\-Clause)\) to the GPLv3\+ \(same license used by most other code in this collection\)\. This undoes a licensing change when the original GPLv3\+ licensed code was moved to module\_utils in [https\://github\.com/ansible/ansible/pull/40697](https\://github\.com/ansible/ansible/pull/40697) \([https\://github\.com/ansible\-collections/community\.crypto/pull/165](https\://github\.com/ansible\-collections/community\.crypto/pull/165)\)\.
+* The <code>crypto/identify\.py</code> module\_utils has been renamed to <code>crypto/pem\.py</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/166](https\://github\.com/ansible\-collections/community\.crypto/pull/166)\)\.
+* luks\_device \- <code>new\_keyfile</code>\, <code>new\_passphrase</code>\, <code>remove\_keyfile</code> and <code>remove\_passphrase</code> are now idempotent \([https\://github\.com/ansible\-collections/community\.crypto/issues/19](https\://github\.com/ansible\-collections/community\.crypto/issues/19)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/168](https\://github\.com/ansible\-collections/community\.crypto/pull/168)\)\.
+* luks\_device \- allow to configure PBKDF \([https\://github\.com/ansible\-collections/community\.crypto/pull/163](https\://github\.com/ansible\-collections/community\.crypto/pull/163)\)\.
+* openssl\_csr\, openssl\_csr\_pipe \- allow to specify CRL distribution endpoints with <code>crl\_distribution\_points</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/147](https\://github\.com/ansible\-collections/community\.crypto/issues/147)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/167](https\://github\.com/ansible\-collections/community\.crypto/pull/167)\)\.
+* openssl\_pkcs12 \- allow to specify certificate bundles in <code>other\_certificates</code> by using new option <code>other\_certificates\_parse\_all</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/149](https\://github\.com/ansible\-collections/community\.crypto/issues/149)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/166](https\://github\.com/ansible\-collections/community\.crypto/pull/166)\)\.
+
+<a id="bugfixes-29"></a>
+### Bugfixes
+
+* acme\_certificate \- error when requested challenge type is not found for non\-valid challenges\, instead of hanging on step 2 \([https\://github\.com/ansible\-collections/community\.crypto/issues/171](https\://github\.com/ansible\-collections/community\.crypto/issues/171)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/173](https\://github\.com/ansible\-collections/community\.crypto/pull/173)\)\.
+
+<a id="v1-3-0"></a>
+## v1\.3\.0
+
+<a id="release-summary-32"></a>
+### Release Summary
+
+Contains new modules <code>openssl\_privatekey\_pipe</code>\, <code>openssl\_csr\_pipe</code> and <code>x509\_certificate\_pipe</code> which allow to create or update private keys\, CSRs and X\.509 certificates without having to write them to disk\.
+
+<a id="minor-changes-7"></a>
+### Minor Changes
+
+* openssh\_cert \- add module parameter <code>use\_agent</code> to enable using signing keys stored in ssh\-agent \([https\://github\.com/ansible\-collections/community\.crypto/issues/116](https\://github\.com/ansible\-collections/community\.crypto/issues/116)\)\.
+* openssl\_csr \- refactor module to allow code re\-use by openssl\_csr\_pipe \([https\://github\.com/ansible\-collections/community\.crypto/pull/123](https\://github\.com/ansible\-collections/community\.crypto/pull/123)\)\.
+* openssl\_privatekey \- refactor module to allow code re\-use by openssl\_privatekey\_pipe \([https\://github\.com/ansible\-collections/community\.crypto/pull/119](https\://github\.com/ansible\-collections/community\.crypto/pull/119)\)\.
+* openssl\_privatekey \- the elliptic curve <code>secp192r1</code> now triggers a security warning\. Elliptic curves of at least 224 bits should be used for new keys\; see [here](https\://cryptography\.io/en/latest/hazmat/primitives/asymmetric/ec\.html\#elliptic\-curves) \([https\://github\.com/ansible\-collections/community\.crypto/pull/132](https\://github\.com/ansible\-collections/community\.crypto/pull/132)\)\.
+* x509\_certificate \- for the <code>selfsigned</code> provider\, a CSR is not required anymore\. If no CSR is provided\, the module behaves as if a minimal CSR which only contains the public key has been provided \([https\://github\.com/ansible\-collections/community\.crypto/issues/32](https\://github\.com/ansible\-collections/community\.crypto/issues/32)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/129](https\://github\.com/ansible\-collections/community\.crypto/pull/129)\)\.
+* x509\_certificate \- refactor module to allow code re\-use by x509\_certificate\_pipe \([https\://github\.com/ansible\-collections/community\.crypto/pull/135](https\://github\.com/ansible\-collections/community\.crypto/pull/135)\)\.
+
+<a id="bugfixes-30"></a>
+### Bugfixes
+
+* openssl\_pkcs12 \- report the correct state when <code>action</code> is <code>parse</code> \([https\://github\.com/ansible\-collections/community\.crypto/issues/143](https\://github\.com/ansible\-collections/community\.crypto/issues/143)\)\.
+* support code \- improve handling of certificate and certificate signing request \(CSR\) loading with the <code>cryptography</code> backend when errors occur \([https\://github\.com/ansible\-collections/community\.crypto/issues/138](https\://github\.com/ansible\-collections/community\.crypto/issues/138)\, [https\://github\.com/ansible\-collections/community\.crypto/pull/139](https\://github\.com/ansible\-collections/community\.crypto/pull/139)\)\.
+* x509\_certificate \- fix <code>entrust</code> provider\, which was broken since community\.crypto 0\.1\.0 due to a feature added before the collection move \([https\://github\.com/ansible\-collections/community\.crypto/pull/135](https\://github\.com/ansible\-collections/community\.crypto/pull/135)\)\.
+
+<a id="new-modules-1"></a>
+### New Modules
+
+* openssl\_csr\_pipe \- Generate OpenSSL Certificate Signing Request \(CSR\)
+* openssl\_privatekey\_pipe \- Generate OpenSSL private keys without disk access
+* x509\_certificate\_pipe \- Generate and/or check OpenSSL certificates
+
+<a id="v1-2-0"></a>
+## v1\.2\.0
+
+<a id="release-summary-33"></a>
+### Release Summary
+
+Please note that this release fixes a security issue \(CVE\-2020\-25646\)\.
+
+<a id="minor-changes-8"></a>
+### Minor Changes
+
+* acme\_certificate \- allow to pass CSR file as content with new option <code>csr\_content</code> \([https\://github\.com/ansible\-collections/community\.crypto/pull/115](https\://github\.com/ansible\-collections/community\.crypto/pull/115)\)\.
+* x509\_certificate\_info \- add <code>fingerprints</code> return value which returns certificate fingerprints \([https\://github\.com/ansible\-collections/community\.crypto/pull/121](https\://github\.com/ansible\-collections/community\.crypto/pull/121)\)\.
+
+<a id="security-fixes"></a>
+### Security Fixes
+
+* openssl\_csr \- the option <code>privatekey\_content</code> was not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+* openssl\_privatekey\_info \- the option <code>content</code> was not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+* openssl\_publickey \- the option <code>privatekey\_content</code> was not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+* openssl\_signature \- the option <code>privatekey\_content</code> was not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+* x509\_certificate \- the options <code>privatekey\_content</code> and <code>ownca\_privatekey\_content</code> were not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+* x509\_crl \- the option <code>privatekey\_content</code> was not marked as <code>no\_log</code>\, resulting in it being dumped into the system log by default\, and returned in the registered results in the <code>invocation</code> field \(CVE\-2020\-25646\, [https\://github\.com/ansible\-collections/community\.crypto/pull/125](https\://github\.com/ansible\-collections/community\.crypto/pull/125)\)\.
+
+<a id="bugfixes-31"></a>
+### Bugfixes
+
+* openssl\_pkcs12 \- do not crash when reading PKCS\#12 file which has no private key and/or no main certificate \([https\://github\.com/ansible\-collections/community\.crypto/issues/103](https\://github\.com/ansible\-collections/community\.crypto/issues/103)\)\.
+
+<a id="v1-1-1"></a>
+## v1\.1\.1
+
+<a id="release-summary-34"></a>
+### Release Summary
+
+Bugfixes for Ansible 2\.10\.0\.
+
+<a id="bugfixes-32"></a>
+### Bugfixes
+
+* meta/runtime\.yml \- convert Ansible version numbers for old names of modules to collection version numbers \([https\://github\.com/ansible\-collections/community\.crypto/pull/108](https\://github\.com/ansible\-collections/community\.crypto/pull/108)\)\.
+* openssl\_csr \- improve handling of IDNA errors \([https\://github\.com/ansible\-collections/community\.crypto/issues/105](https\://github\.com/ansible\-collections/community\.crypto/issues/105)\)\.
+
+<a id="v1-1-0"></a>
+## v1\.1\.0
+
+<a id="release-summary-35"></a>
+### Release Summary
+
+Release for Ansible 2\.10\.0\.
+
+<a id="minor-changes-9"></a>
+### Minor Changes
+
+* acme\_account \- add <code>external\_account\_binding</code> option to allow creation of ACME accounts with External Account Binding \([https\://github\.com/ansible\-collections/community\.crypto/issues/89](https\://github\.com/ansible\-collections/community\.crypto/issues/89)\)\.
+* acme\_certificate \- allow new selector <code>test\_certificates\: first</code> for <code>select\_chain</code> parameter \([https\://github\.com/ansible\-collections/community\.crypto/pull/102](https\://github\.com/ansible\-collections/community\.crypto/pull/102)\)\.
+* cryptography backends \- support arbitrary dotted OIDs \([https\://github\.com/ansible\-collections/community\.crypto/issues/39](https\://github\.com/ansible\-collections/community\.crypto/issues/39)\)\.
+* get\_certificate \- add support for SNI \([https\://github\.com/ansible\-collections/community\.crypto/issues/69](https\://github\.com/ansible\-collections/community\.crypto/issues/69)\)\.
+* luks\_device \- add support for encryption options on container creation \([https\://github\.com/ansible\-collections/community\.crypto/pull/97](https\://github\.com/ansible\-collections/community\.crypto/pull/97)\)\.
+* openssh\_cert \- add support for PKCS\#11 tokens \([https\://github\.com/ansible\-collections/community\.crypto/pull/95](https\://github\.com/ansible\-collections/community\.crypto/pull/95)\)\.
+* openssl\_certificate \- the PyOpenSSL backend now uses 160 bits of randomness for serial numbers\, instead of a random number between 1000 and 99999\. Please note that this is not a high quality random number \([https\://github\.com/ansible\-collections/community\.crypto/issues/76](https\://github\.com/ansible\-collections/community\.crypto/issues/76)\)\.
+* openssl\_csr \- add support for name constraints extension \([https\://github\.com/ansible\-collections/community\.crypto/issues/46](https\://github\.com/ansible\-collections/community\.crypto/issues/46)\)\.
+* openssl\_csr\_info \- add support for name constraints extension \([https\://github\.com/ansible\-collections/community\.crypto/issues/46](https\://github\.com/ansible\-collections/community\.crypto/issues/46)\)\.
+
+<a id="bugfixes-33"></a>
+### Bugfixes
+
+* acme\_inspect \- fix problem with Python 3\.5 that JSON was not decoded \([https\://github\.com/ansible\-collections/community\.crypto/issues/86](https\://github\.com/ansible\-collections/community\.crypto/issues/86)\)\.
+* get\_certificate \- fix <code>ca\_cert</code> option handling when <code>proxy\_host</code> is used \([https\://github\.com/ansible\-collections/community\.crypto/pull/84](https\://github\.com/ansible\-collections/community\.crypto/pull/84)\)\.
+* openssl\_\*\, x509\_\* modules \- fix handling of general names which refer to IP networks and not IP addresses \([https\://github\.com/ansible\-collections/community\.crypto/pull/92](https\://github\.com/ansible\-collections/community\.crypto/pull/92)\)\.
+
+<a id="new-modules-2"></a>
+### New Modules
+
+* openssl\_signature \- Sign data with openssl
+* openssl\_signature\_info \- Verify signatures with openssl
+
+<a id="v1-0-0"></a>
+## v1\.0\.0
+
+<a id="release-summary-36"></a>
+### Release Summary
+
+This is the first proper release of the <code>community\.crypto</code> collection\. This changelog contains all changes to the modules in this collection that were added after the release of Ansible 2\.9\.0\.
+
+<a id="minor-changes-10"></a>
+### Minor Changes
+
+* luks\_device \- accept <code>passphrase</code>\, <code>new\_passphrase</code> and <code>remove\_passphrase</code>\.
+* luks\_device \- add <code>keysize</code> parameter to set key size at LUKS container creation
+* luks\_device \- added support to use UUIDs\, and labels with LUKS2 containers
+* luks\_device \- added the <code>type</code> option that allows user explicit define the LUKS container format version
+* openssh\_keypair \- instead of regenerating some broken or password protected keys\, fail the module\. Keys can still be regenerated by calling the module with <code>force\=yes</code>\.
+* openssh\_keypair \- the <code>regenerate</code> option allows to configure the module\'s behavior when it should or needs to regenerate private keys\.
+* openssl\_\* modules \- the cryptography backend now properly supports <code>dirName</code>\, <code>otherName</code> and <code>RID</code> \(Registered ID\) names\.
+* openssl\_certificate \- Add option for changing which ACME directory to use with acme\-tiny\. Set the default ACME directory to Let\'s Encrypt instead of using acme\-tiny\'s default\. \(acme\-tiny also uses Let\'s Encrypt at the time being\, so no action should be neccessary\.\)
+* openssl\_certificate \- Change the required version of acme\-tiny to \>\= 4\.0\.0
+* openssl\_certificate \- allow to provide content of some input files via the <code>csr\_content</code>\, <code>privatekey\_content</code>\, <code>ownca\_privatekey\_content</code> and <code>ownca\_content</code> options\.
+* openssl\_certificate \- allow to return the existing/generated certificate directly as <code>certificate</code> by setting <code>return\_content</code> to <code>yes</code>\.
+* openssl\_certificate\_info \- allow to provide certificate content via <code>content</code> option \([https\://github\.com/ansible/ansible/issues/64776](https\://github\.com/ansible/ansible/issues/64776)\)\.
+* openssl\_csr \- Add support for specifying the SAN <code>otherName</code> value in the OpenSSL ASN\.1 UTF8 string format\, <code>otherName\:\<OID\>\;UTF8\:string value</code>\.
+* openssl\_csr \- allow to provide private key content via <code>private\_key\_content</code> option\.
+* openssl\_csr \- allow to return the existing/generated CSR directly as <code>csr</code> by setting <code>return\_content</code> to <code>yes</code>\.
+* openssl\_csr\_info \- allow to provide CSR content via <code>content</code> option\.
+* openssl\_dhparam \- allow to return the existing/generated DH params directly as <code>dhparams</code> by setting <code>return\_content</code> to <code>yes</code>\.
+* openssl\_dhparam \- now supports a <code>cryptography</code>\-based backend\. Auto\-detection can be overwritten with the <code>select\_crypto\_backend</code> option\.
+* openssl\_pkcs12 \- allow to return the existing/generated PKCS\#12 directly as <code>pkcs12</code> by setting <code>return\_content</code> to <code>yes</code>\.
+* openssl\_privatekey \- add <code>format</code> and <code>format\_mismatch</code> options\.
+* openssl\_privatekey \- allow to return the existing/generated private key directly as <code>privatekey</code> by setting <code>return\_content</code> to <code>yes</code>\.
+* openssl\_privatekey \- the <code>regenerate</code> option allows to configure the module\'s behavior when it should or needs to regenerate private keys\.
+* openssl\_privatekey\_info \- allow to provide private key content via <code>content</code> option\.
+* openssl\_publickey \- allow to provide private key content via <code>private\_key\_content</code> option\.
+* openssl\_publickey \- allow to return the existing/generated public key directly as <code>publickey</code> by setting <code>return\_content</code> to <code>yes</code>\.
+
+<a id="deprecated-features-2"></a>
+### Deprecated Features
+
+* openssl\_csr \- all values for the <code>version</code> option except <code>1</code> are deprecated\. The value 1 denotes the current only standardized CSR version\.
+
+<a id="removed-features-previously-deprecated"></a>
+### Removed Features \(previously deprecated\)
+
+* The <code>letsencrypt</code> module has been removed\. Use <code>acme\_certificate</code> instead\.
+
+<a id="bugfixes-34"></a>
+### Bugfixes
+
+* ACME modules\: fix bug in ACME v1 account update code
+* ACME modules\: make sure some connection errors are handled properly
+* ACME modules\: support Buypass\' ACME v1 endpoint
+* acme\_certificate \- fix crash when module is used with Python 2\.x\.
+* acme\_certificate \- fix misbehavior when ACME v1 is used with <code>modify\_account</code> set to <code>false</code>\.
+* ecs\_certificate \- Always specify header <code>connection\: keep\-alive</code> for ECS API connections\.
+* ecs\_certificate \- Fix formatting of contents of <code>full\_chain\_path</code>\.
+* get\_certificate \- Fix cryptography backend when pyopenssl is unavailable \([https\://github\.com/ansible/ansible/issues/67900](https\://github\.com/ansible/ansible/issues/67900)\)
+* openssh\_keypair \- add logic to avoid breaking password protected keys\.
+* openssh\_keypair \- fixes idempotence issue with public key \([https\://github\.com/ansible/ansible/issues/64969](https\://github\.com/ansible/ansible/issues/64969)\)\.
+* openssh\_keypair \- public key\'s file attributes \(permissions\, owner\, group\, etc\.\) are now set to the same values as the private key\.
+* openssl\_\* modules \- prevent crash on fingerprint determination in FIPS mode \([https\://github\.com/ansible/ansible/issues/67213](https\://github\.com/ansible/ansible/issues/67213)\)\.
+* openssl\_certificate \- When provider is <code>entrust</code>\, use a <code>connection\: keep\-alive</code> header for ECS API connections\.
+* openssl\_certificate \- <code>provider</code> option was documented as required\, but it was not checked whether it was provided\. It is now only required when <code>state</code> is <code>present</code>\.
+* openssl\_certificate \- fix <code>assertonly</code> provider certificate verification\, causing \'private key mismatch\' and \'subject mismatch\' errors\.
+* openssl\_certificate and openssl\_csr \- fix Ed25519 and Ed448 private key support for <code>cryptography</code> backend\. This probably needs at least cryptography 2\.8\, since older versions have problems with signing certificates or CSRs with such keys\. \([https\://github\.com/ansible/ansible/issues/59039](https\://github\.com/ansible/ansible/issues/59039)\, PR [https\://github\.com/ansible/ansible/pull/63984](https\://github\.com/ansible/ansible/pull/63984)\)
+* openssl\_csr \- a warning is issued if an unsupported value for <code>version</code> is used for the <code>cryptography</code> backend\.
+* openssl\_csr \- the module will now enforce that <code>privatekey\_path</code> is specified when <code>state\=present</code>\.
+* openssl\_publickey \- fix a module crash caused when pyOpenSSL is not installed \([https\://github\.com/ansible/ansible/issues/67035](https\://github\.com/ansible/ansible/issues/67035)\)\.
+
+<a id="new-modules-3"></a>
+### New Modules
+
+* ecs\_domain \- Request validation of a domain with the Entrust Certificate Services \(ECS\) API
+* x509\_crl \- Generate Certificate Revocation Lists \(CRLs\)
+* x509\_crl\_info \- Retrieve information on Certificate Revocation Lists \(CRLs\)

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,6 @@ Community Crypto Release Notes
 
 .. contents:: Topics
 
-
 v1.9.24
 =======
 
@@ -541,7 +540,6 @@ Release Summary
 
 Contains new modules ``openssl_privatekey_pipe``, ``openssl_csr_pipe`` and ``x509_certificate_pipe`` which allow to create or update private keys, CSRs and X.509 certificates without having to write them to disk.
 
-
 Minor Changes
 -------------
 
@@ -617,7 +615,6 @@ Release Summary
 
 Release for Ansible 2.10.0.
 
-
 Minor Changes
 -------------
 
@@ -651,7 +648,6 @@ Release Summary
 ---------------
 
 This is the first proper release of the ``community.crypto`` collection. This changelog contains all changes to the modules in this collection that were added after the release of Ansible 2.9.0.
-
 
 Minor Changes
 -------------

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [Ansible's dev guide](https://docs.ansible.com/ansible/devel/dev_guide/devel
 
 ## Release notes
 
-See the [changelog](https://github.com/ansible-collections/community.crypto/blob/main/CHANGELOG.rst).
+See the [changelog](https://github.com/ansible-collections/community.crypto/blob/stable-1/CHANGELOG.md).
 
 ## Roadmap
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -6,6 +6,9 @@ keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments
+output_formats:
+  - md
+  - rst
 prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sections:


### PR DESCRIPTION
##### SUMMARY
Uses https://github.com/ansible-community/antsibull-changelog/pull/139 to render the changelog both as RST and MarkDown. References the MarkDown version from README since GitHub stopped rendering the RST version.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
changelog
