### PR TITLE
luks_device: fix remove_keyslot not working when set to 0 and duplicate keys

### DIFF
--- a/changelogs/fragments/710-luks_device-keyslot-fixes.yml
+++ b/changelogs/fragments/710-luks_device-keyslot-fixes.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - "luks_device - Fixed module a bug that prevented using `remove_keyslot` with the value `0` (https://github.com/ansible-collections/community.crypto/pull/710)."
-  - "luks_device - Fixed module falsely outputting 'ok' when trying to add a new slot with a key that is already present in another slot. The module now rejects adding keys that are already present in another slot (https://github.com/ansible-collections/community.crypto/pull/710)."
-  - "luks_device - Fixed testing of LUKS passphrases in when specifying a keyslot for cryptsetup version 2.0.3. The output of this cryptsetup version slightly differs from later versions (https://github.com/ansible-collections/community.crypto/pull/710)."
+  - "luks_device - fixed module a bug that prevented using ``remove_keyslot`` with the value ``0`` (https://github.com/ansible-collections/community.crypto/pull/710)."
+  - "luks_device - fixed module falsely outputting ``changed=false`` when trying to add a new slot with a key that is already present in another slot. The module now rejects adding keys that are already present in another slot (https://github.com/ansible-collections/community.crypto/pull/710)."
+  - "luks_device - fixed testing of LUKS passphrases in when specifying a keyslot for cryptsetup version 2.0.3. The output of this cryptsetup version slightly differs from later versions (https://github.com/ansible-collections/community.crypto/pull/710)."

--- a/changelogs/fragments/710-luks_device-keyslot-fixes.yml
+++ b/changelogs/fragments/710-luks_device-keyslot-fixes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "luks_device - Fixed module a bug that prevented using `remove_keyslot` with the value `0` (https://github.com/ansible-collections/community.crypto/pull/710)."
+  - "luks_device - Fixed module falsely outputting 'ok' when trying to add a new slot with a key that is already present in another slot. The module now rejects adding keys that are already present in another slot (https://github.com/ansible-collections/community.crypto/pull/710)."
+  - "luks_device - Fixed testing of LUKS passphrases in when specifying a keyslot for cryptsetup version 2.0.3. The output of this cryptsetup version slightly differs from later versions (https://github.com/ansible-collections/community.crypto/pull/710)."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -923,7 +923,7 @@ class ConditionsHandler(Handler):
             self._module.fail_json(msg="Contradiction in setup: Asking to "
                                    "remove a key from absent LUKS.")
 
-        if self._module.params['remove_keyslot']:
+        if self._module.params['remove_keyslot'] is not None:
             if not self._crypthandler.is_luks_slot_set(self.device, self._module.params['remove_keyslot']):
                 return False
             result = self._crypthandler.luks_test_key(self.device, self._module.params['keyfile'], self._module.params['passphrase'])

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -912,7 +912,7 @@ class ConditionsHandler(Handler):
         key_present = self._crypthandler.luks_test_key(self.device, self._module.params['new_keyfile'], self._module.params['new_passphrase'])
         if self._module.params['new_keyslot'] is not None:
             key_present_slot = self._crypthandler.luks_test_key(self.device, self._module.params['new_keyfile'], self._module.params['new_passphrase'],
-                                                                keyslot=self._module.params['new_keyslot'])
+                                                                self._module.params['new_keyslot'])
             if key_present and not key_present_slot:
                 self._module.fail_json(msg="Trying to add key that is already present in another slot")
 

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -799,6 +799,11 @@ class CryptHandler(Handler):
             if 'No usable keyslot is available.' in result[output]:
                 return False
 
+        # This check is necessary due to cryptsetup in version 2.0.3 not printing 'No usable keyslot is available'
+        # when using the --key-slot parameter in combination with --test-passphrase
+        if result[RETURN_CODE] == 1 and keyslot is not None and result[STDOUT] == '' and result[STDERR] == '':
+            return True
+
         raise ValueError('Error while testing whether keyslot exists on %s: %s'
                          % (device, result[STDERR]))
 

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -909,7 +909,14 @@ class ConditionsHandler(Handler):
             self._module.fail_json(msg="Contradiction in setup: Asking to "
                                    "add a key to absent LUKS.")
 
-        return not self._crypthandler.luks_test_key(self.device, self._module.params['new_keyfile'], self._module.params['new_passphrase'])
+        key_present = self._crypthandler.luks_test_key(self.device, self._module.params['new_keyfile'], self._module.params['new_passphrase'])
+        if self._module.params['new_keyslot'] is not None:
+            key_present_slot = self._crypthandler.luks_test_key(self.device, self._module.params['new_keyfile'], self._module.params['new_passphrase'],
+                                                                keyslot=self._module.params['new_keyslot'])
+            if key_present and not key_present_slot:
+                self._module.fail_json(msg="Trying to add key that is already present in another slot")
+
+        return not key_present
 
     def luks_remove_key(self):
         if (self.device is None or

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -802,7 +802,7 @@ class CryptHandler(Handler):
         # This check is necessary due to cryptsetup in version 2.0.3 not printing 'No usable keyslot is available'
         # when using the --key-slot parameter in combination with --test-passphrase
         if result[RETURN_CODE] == 1 and keyslot is not None and result[STDOUT] == '' and result[STDERR] == '':
-            return True
+            return False
 
         raise ValueError('Error while testing whether keyslot exists on %s: %s'
                          % (device, result[STDERR]))

--- a/tests/integration/targets/luks_device/tasks/tests/keyslot-create-destroy.yml
+++ b/tests/integration/targets/luks_device/tasks/tests/keyslot-create-destroy.yml
@@ -176,3 +176,31 @@
     - kill_luks_slot4_idem is not changed
     - kill_luks_slot4_idem_check is not changed
     - "'Key Slot 4: DISABLED' in luks_header_slot4_removed.stdout or not '4: luks' in luks_header_slot4_removed.stdout"
+
+- name: Add key in slot 0
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: present
+    keyfile: "{{ remote_tmp_dir }}/keyfile2"
+    new_keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    new_keyslot: 0
+    pbkdf:
+      iteration_time: 0.1
+  become: true
+  register: add_luks_slot0
+- name: Remove key in slot 0
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    keyfile: "{{ remote_tmp_dir }}/keyfile2"
+    remove_keyslot: 0
+  become: true
+  register: kill_luks_slot0
+- name: Dump luks header
+  command: "cryptsetup luksDump {{ cryptfile_device }}"
+  become: true
+  register: luks_header_slot0_removed
+- assert:
+    that:
+    - add_luks_slot0 is changed
+    - kill_luks_slot0 is changed
+    - "'Key Slot 0: DISABLED' in luks_header_slot0_removed.stdout or not '0: luks' in luks_header_slot0_removed.stdout"

--- a/tests/integration/targets/luks_device/tasks/tests/keyslot-duplicate.yml
+++ b/tests/integration/targets/luks_device/tasks/tests/keyslot-duplicate.yml
@@ -1,0 +1,44 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create new luks
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: present
+    keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    pbkdf:
+      iteration_time: 0.1
+  become: true
+- name: Add new keyslot with same keyfile
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: present
+    new_keyslot: 1
+    keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    new_keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    pbkdf:
+      iteration_time: 0.1
+  become: true
+  ignore_errors: true
+  check_mode: true
+  register: keyslot_duplicate_check
+- name: Add new keyslot with same keyfile
+  luks_device:
+    device: "{{ cryptfile_device }}"
+    state: present
+    new_keyslot: 1
+    keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    new_keyfile: "{{ remote_tmp_dir }}/keyfile1"
+    pbkdf:
+      iteration_time: 0.1
+  become: true
+  ignore_errors: true
+  register: keyslot_duplicate
+- assert:
+    that:
+    - keyslot_duplicate_check is failed
+    - "'Trying to add key that is already present in another slot' in keyslot_duplicate_check.msg"
+    - keyslot_duplicate is failed
+    - "'Trying to add key that is already present in another slot' in keyslot_duplicate.msg"

--- a/tests/integration/targets/luks_device/tasks/tests/keyslot-duplicate.yml
+++ b/tests/integration/targets/luks_device/tasks/tests/keyslot-duplicate.yml
@@ -11,15 +11,13 @@
     pbkdf:
       iteration_time: 0.1
   become: true
-- name: Add new keyslot with same keyfile
+- name: Add new keyslot with same keyfile (check)
   luks_device:
     device: "{{ cryptfile_device }}"
     state: present
     new_keyslot: 1
     keyfile: "{{ remote_tmp_dir }}/keyfile1"
     new_keyfile: "{{ remote_tmp_dir }}/keyfile1"
-    pbkdf:
-      iteration_time: 0.1
   become: true
   ignore_errors: true
   check_mode: true
@@ -31,8 +29,6 @@
     new_keyslot: 1
     keyfile: "{{ remote_tmp_dir }}/keyfile1"
     new_keyfile: "{{ remote_tmp_dir }}/keyfile1"
-    pbkdf:
-      iteration_time: 0.1
   become: true
   ignore_errors: true
   register: keyslot_duplicate

--- a/tests/unit/plugins/modules/test_luks_device.py
+++ b/tests/unit/plugins/modules/test_luks_device.py
@@ -275,6 +275,7 @@ def test_luks_add_key(device, keyfile, passphrase, new_keyfile, new_passphrase,
     module.params["passphrase"] = passphrase
     module.params["new_keyfile"] = new_keyfile
     module.params["new_passphrase"] = new_passphrase
+    module.params["new_keyslot"] = None
     module.params["state"] = state
     module.params["label"] = label
 


### PR DESCRIPTION
##### SUMMARY
- Fixed task failure when specifying `remove_keyslot: 0`.
- Fixed module falsely outputting when trying to add a new slot with a key that is already present in another slot by rejecting duplicate keys
- Fixed testing LUKS passphrases when using keyslots in cryptsetup version 2.0.3

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
luks_device

##### ADDITIONAL INFORMATION
Tasks to reproduce the first issue:

```
- name: Add key in slot 0
  luks_device:
    device: "{{ device }}"
    state: present
    keyfile: "{{ keyfile1 }}"
    new_keyfile: "{{ keyfile2 }}"
    new_keyslot: 0
- name: Remove key in slot 0
  luks_device:
    device: "{{ device }}"
    keyfile: "{{ keyfile1 }}"
    remove_keyslot: 0
```

Tasks to reproduce the second issue, the second tasks outputs 'ok' but does not actually not add a new key to slot 1.

```
- name: Create new luks
  luks_device:
    device: "{{ device }}"
    state: present
    keyfile: "{{ keyfile 1}}"
- name: Add new keyslot with same keyfile
  luks_device:
    device: "{{ device }}"
    state: present
    new_keyslot: 1
    keyfile: "{{ keyfile1 }}"
    new_keyfile: "{{ keyfile1 }}"
```

The change in the luks_test_key method is necessary due to differing behavior cryptsetup 2.0.3 when using the parameters --test-passphrase and --key-slot at the same time.
Output with cryptsetup 2.0.3 (tested in a CentOS 7.9 container):
```bash
[root@21d89bdad3da /]# cryptsetup --version
cryptsetup 2.0.3
[root@21d89bdad3da /]# dd if=/dev/zero of=/tmp/test bs=1M count=1000
1000+0 records in
1000+0 records out
1048576000 bytes (1.0 GB) copied, 0.871568 s, 1.2 GB/s
[root@21d89bdad3da /]# dd if=/dev/urandom of=/tmp/keyfile bs=1M count=1
1+0 records in
1+0 records out
1048576 bytes (1.0 MB) copied, 0.00456403 s, 230 MB/s
[root@21d89bdad3da /]# cryptsetup luksFormat --key-file /tmp/keyfile /tmp/test

WARNING!
========
This will overwrite data on /tmp/test irrevocably.

Are you sure? (Type uppercase yes): YES
[root@21d89bdad3da /]# cryptsetup open --test-passphrase --key-file /tmp/keyfile /tmp/test
[root@21d89bdad3da /]# echo $?
0
[root@21d89bdad3da /]# cryptsetup open --test-passphrase --key-file /tmp/keyfile --key-slot 1 /tmp/test
[root@21d89bdad3da /]# echo $?
1
```

Output with cryptsetup 2.6.1 (tested on Manjaro):
```bash
[ansible-dev ~]# cryptsetup --version
cryptsetup 2.6.1 flags: UDEV BLKID KEYRING KERNEL_CAPI 
[ansible-dev ~]# dd if=/dev/zero of=/tmp/test bs=1M count=1000
1000+0 records in
1000+0 records out
1048576000 bytes (1,0 GB, 1000 MiB) copied, 0,202097 s, 5,2 GB/s
[ansible-dev ~]# dd if=/dev/urandom of=/tmp/keyfile bs=1M count=1
1+0 records in
1+0 records out
1048576 bytes (1,0 MB, 1,0 MiB) copied, 0,0112751 s, 93,0 MB/s
[ansible-dev ~]# cryptsetup luksFormat --key-file /tmp/keyfile /tmp/test

WARNING!
========
This will overwrite data on /tmp/test irrevocably.

Are you sure? (Type 'yes' in capital letters): YES
[ansible-dev ~]# cryptsetup open --test-passphrase --key-file /tmp/keyfile /tmp/test
[ansible-dev ~]# echo $?
0
[ansible-dev ~]# cryptsetup open --test-passphrase --key-file /tmp/keyfile --key-slot 1 /tmp/test
No usable keyslot is available.
[ansible-dev ~]# echo $?
1
```
