### PR TITLE
Deprecate check mode behavior of pipe modules

### DIFF
--- a/changelogs/fragments/714-pipe-check-mode-deprecation.yml
+++ b/changelogs/fragments/714-pipe-check-mode-deprecation.yml
@@ -1,0 +1,7 @@
+deprecated_features:
+  - "openssl_csr_pipe, openssl_privatekey_pipe, x509_certificate_pipe - the current behavior of check mode is deprecated and will change in community.crypto 3.0.0.
+    The current behavior is similar to the modules without ``_pipe``: if the object needs to be (re-)generated, only the ``changed`` status is set, but the object
+    is not updated. From community.crypto 3.0.0 on, the modules will ignore check mode and always act as if check mode is not active. This behavior can already
+    achieved now by adding ``check_mode: false`` to the task. If you think this breaks your use-case of this module, please
+    `create an issue in the community.crypto repository <https://github.com/ansible-collections/community.crypto/issues/new/choose>`__
+    (https://github.com/ansible-collections/community.crypto/issues/712, https://github.com/ansible-collections/community.crypto/pull/714)."

--- a/plugins/action/openssl_privatekey_pipe.py
+++ b/plugins/action/openssl_privatekey_pipe.py
@@ -51,6 +51,16 @@ class PrivateKeyModule(object):
                 self.module_backend.generate_private_key()
                 privatekey_data = self.module_backend.get_private_key_data()
                 self.privatekey_bytes = privatekey_data
+            else:
+                self.module.deprecate(
+                    'Check mode support for openssl_privatekey_pipe will change in community.crypto 3.0.0'
+                    ' to behave the same as without check mode. You can get that behavior right now'
+                    ' by adding `check_mode: false` to the openssl_privatekey_pipe task. If you think this'
+                    ' breaks your use-case of this module, please create an issue in the'
+                    ' community.crypto repository',
+                    version='3.0.0',
+                    collection_name='community.crypto',
+                )
             self.changed = True
         elif self.module_backend.needs_conversion():
             # Convert
@@ -58,6 +68,16 @@ class PrivateKeyModule(object):
                 self.module_backend.convert_private_key()
                 privatekey_data = self.module_backend.get_private_key_data()
                 self.privatekey_bytes = privatekey_data
+            else:
+                self.module.deprecate(
+                    'Check mode support for openssl_privatekey_pipe will change in community.crypto 3.0.0'
+                    ' to behave the same as without check mode. You can get that behavior right now'
+                    ' by adding `check_mode: false` to the openssl_privatekey_pipe task. If you think this'
+                    ' breaks your use-case of this module, please create an issue in the'
+                    ' community.crypto repository',
+                    version='3.0.0',
+                    collection_name='community.crypto',
+                )
             self.changed = True
 
     def dump(self):

--- a/plugins/modules/openssl_csr_pipe.py
+++ b/plugins/modules/openssl_csr_pipe.py
@@ -27,6 +27,12 @@ extends_documentation_fragment:
 attributes:
     check_mode:
         support: full
+        details:
+            - Currently in check mode, private keys will not be (re-)generated, only the changed status is
+              set. This will change in community.crypto 3.0.0.
+            - From community.crypto 3.0.0 on, the module will ignore check mode and always behave as if
+              check mode is not active. If you think this breaks your use-case of this module, please
+              create an issue in the community.crypto repository.
     diff_mode:
         support: full
 options:
@@ -146,6 +152,7 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.basic impo
 class CertificateSigningRequestModule(object):
     def __init__(self, module, module_backend):
         self.check_mode = module.check_mode
+        self.module = module
         self.module_backend = module_backend
         self.changed = False
         if module.params['content'] is not None:
@@ -156,6 +163,16 @@ class CertificateSigningRequestModule(object):
         if self.module_backend.needs_regeneration():
             if not self.check_mode:
                 self.module_backend.generate_csr()
+            else:
+                self.module.deprecate(
+                    'Check mode support for openssl_csr_pipe will change in community.crypto 3.0.0'
+                    ' to behave the same as without check mode. You can get that behavior right now'
+                    ' by adding `check_mode: false` to the openssl_csr_pipe task. If you think this'
+                    ' breaks your use-case of this module, please create an issue in the'
+                    ' community.crypto repository',
+                    version='3.0.0',
+                    collection_name='community.crypto',
+                )
             self.changed = True
 
     def dump(self):

--- a/plugins/modules/openssl_privatekey_pipe.py
+++ b/plugins/modules/openssl_privatekey_pipe.py
@@ -36,6 +36,12 @@ attributes:
             - This action runs completely on the controller.
     check_mode:
         support: full
+        details:
+            - Currently in check mode, private keys will not be (re-)generated, only the changed status is
+              set. This will change in community.crypto 3.0.0.
+            - From community.crypto 3.0.0 on, the module will ignore check mode and always behave as if
+              check mode is not active. If you think this breaks your use-case of this module, please
+              create an issue in the community.crypto repository.
     diff_mode:
         support: full
 options:

--- a/plugins/modules/x509_certificate_pipe.py
+++ b/plugins/modules/x509_certificate_pipe.py
@@ -32,6 +32,12 @@ extends_documentation_fragment:
 attributes:
     check_mode:
         support: full
+        details:
+            - Currently in check mode, private keys will not be (re-)generated, only the changed status is
+              set. This will change in community.crypto 3.0.0.
+            - From community.crypto 3.0.0 on, the module will ignore check mode and always behave as if
+              check mode is not active. If you think this breaks your use-case of this module, please
+              create an issue in the community.crypto repository.
     diff_mode:
         support: full
 options:
@@ -154,6 +160,7 @@ class GenericCertificate(object):
     """Retrieve a certificate using the given module backend."""
     def __init__(self, module, module_backend):
         self.check_mode = module.check_mode
+        self.module = module
         self.module_backend = module_backend
         self.changed = False
         if module.params['content'] is not None:
@@ -163,6 +170,16 @@ class GenericCertificate(object):
         if self.module_backend.needs_regeneration():
             if not self.check_mode:
                 self.module_backend.generate_certificate()
+            else:
+                self.module.deprecate(
+                    'Check mode support for x509_certificate_pipe will change in community.crypto 3.0.0'
+                    ' to behave the same as without check mode. You can get that behavior right now'
+                    ' by adding `check_mode: false` to the x509_certificate_pipe task. If you think this'
+                    ' breaks your use-case of this module, please create an issue in the'
+                    ' community.crypto repository',
+                    version='3.0.0',
+                    collection_name='community.crypto',
+                )
             self.changed = True
 
     def dump(self, check_mode=False):


### PR DESCRIPTION
##### SUMMARY
Prepare fixing #712 in community.crypto 3.0.0 by officially deprecating the current behavior, and informing about a workaround to already achieve the new behavior now. It also tells users to create an issue in this repository if they think the new behavior is problematic.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_csr_pipe
openssl_privatekey_pipe
x509_certificate_pipe
