### PR TITLE
CI: Add macOS 14.3 for devel, move 13.2 to stable-2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -204,8 +204,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: macOS 13.2
-              test: macos/13.2
+            - name: macOS 14.3
+              test: macos/14.3
             - name: RHEL 9.3
               test: rhel/9.3
             - name: FreeBSD 13.2
@@ -221,6 +221,8 @@ stages:
         parameters:
           testFormat: 2.16/{0}
           targets:
+            - name: macOS 13.2
+              test: macos/13.2
             - name: RHEL 9.2
               test: rhel/9.2
             - name: RHEL 8.8


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-macos-14-3-and-deprecated-macos-13-2/4330

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
