### PR TITLE
CI: Add FreeBSD 13.3 and 14.0 for devel, move FreeBSD 13.2 to stable-2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -208,8 +208,10 @@ stages:
               test: macos/14.3
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
+            - name: FreeBSD 14.0
+              test: freebsd/14.0
           groups:
             - 1
             - 2
@@ -227,6 +229,8 @@ stages:
               test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-freebsd-13-3-14-0-and-deprecated-13-2/4503

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
