### PR TITLE
CI: Add stable-2.17; copy ignore.txt files from 2.17 to 2.18; move stable-2.14 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -98,17 +98,6 @@ stages:
               test: '2.15/sanity/1'
             - name: Units
               test: '2.15/units/1'
-  - stage: Ansible_2_14
-    displayName: Sanity & Units 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.14/sanity/1'
-            - name: Units
-              test: '2.14/units/1'
 ### Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -169,19 +158,6 @@ stages:
               test: fedora37
             - name: CentOS 7
               test: centos7
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_14
-    displayName: Docker 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/linux/{0}
-          targets:
-            - name: Ubuntu 20.04
-              test: ubuntu2004
           groups:
             - 1
             - 2
@@ -292,23 +268,6 @@ stages:
           groups:
             - 1
             - 2
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            #- name: macOS 12.0
-            #  test: macos/12.0
-            - name: RHEL 9.0
-              test: rhel/9.0
-            #- name: FreeBSD 12.4
-            #  test: freebsd/12.4
-          groups:
-            - 1
-            - 2
 ### Generic
   - stage: Generic_devel
     displayName: Generic devel
@@ -371,19 +330,6 @@ stages:
           groups:
             - 1
             - 2
-  - stage: Generic_2_14
-    displayName: Generic 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.14/generic/{0}
-          targets:
-            - test: 3.9
-          groups:
-            - 1
-            - 2
 
   ## Finally
 
@@ -394,23 +340,19 @@ stages:
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
-      - Ansible_2_14
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15
-      - Remote_2_14
       - Docker_devel
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
-      - Docker_2_14
       - Docker_community_devel
       - Generic_devel
       - Generic_2_17
       - Generic_2_16
       - Generic_2_15
-      - Generic_2_14
     jobs:
       - template: templates/coverage.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -65,6 +65,17 @@ stages:
               test: 'devel/sanity/extra'
             - name: Units
               test: 'devel/units/1'
+  - stage: Ansible_2_17
+    displayName: Sanity & Units 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.17/sanity/1'
+            - name: Units
+              test: '2.17/units/1'
   - stage: Ansible_2_16
     displayName: Sanity & Units 2.16
     dependsOn: []
@@ -111,6 +122,19 @@ stages:
               test: fedora39
             - name: Ubuntu 22.04
               test: ubuntu2204
+            - name: Alpine 3.19
+              test: alpine319
+          groups:
+            - 1
+            - 2
+  - stage: Docker_2_17
+    displayName: Docker 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/linux/{0}
+          targets:
             - name: Alpine 3.19
               test: alpine319
           groups:
@@ -210,10 +234,21 @@ stages:
               test: macos/14.3
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.3
-              test: freebsd/13.3
             - name: FreeBSD 14.0
               test: freebsd/14.0
+          groups:
+            - 1
+            - 2
+  - stage: Remote_2_17
+    displayName: Remote 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/{0}
+          targets:
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
           groups:
             - 1
             - 2
@@ -293,6 +328,20 @@ stages:
           groups:
             - 1
             - 2
+  - stage: Generic_2_17
+    displayName: Generic 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.17/generic/{0}
+          targets:
+            - test: "3.7"
+            - test: "3.12"
+          groups:
+            - 1
+            - 2
   - stage: Generic_2_16
     displayName: Generic 2.16
     dependsOn: []
@@ -342,20 +391,24 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Remote_devel_extra_vms
       - Remote_devel
+      - Remote_2_17
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14
       - Docker_devel
+      - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
       - Docker_community_devel
       - Generic_devel
+      - Generic_2_17
       - Generic_2_16
       - Generic_2_15
       - Generic_2_14

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -34,6 +34,7 @@ jobs:
           - '2.11'
           - '2.12'
           - '2.13'
+          - '2.14'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -74,6 +75,7 @@ jobs:
           - '2.11'
           - '2.12'
           - '2.13'
+          - '2.14'
 
     steps:
       - name: >-
@@ -252,6 +254,23 @@ jobs:
           - ansible: '2.13'
             docker: default
             python: '3.8'
+            target: azp/generic/2/
+          # 2.14
+          - ansible: '2.14'
+            docker: ubuntu2004
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.14'
+            docker: ubuntu2004
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.14'
+            docker: default
+            python: '3.9'
+            target: azp/generic/1/
+          - ansible: '2.14'
+            docker: default
+            python: '3.9'
             target: azp/generic/2/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, and ansible-core-2.16 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core-2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,2 @@
+tests/ee/roles/smoke/library/smoke_ipaddress.py shebang
+tests/ee/roles/smoke/library/smoke_pyyaml.py shebang

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
