### PR TITLE
cryptography CRL code: support InvalidityDate.invalidity_date_utc

### DIFF
--- a/changelogs/fragments/730-cryptography-invalidity_date.yml
+++ b/changelogs/fragments/730-cryptography-invalidity_date.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - When using cryptography >= 43.0.0, use offset-aware ``datetime.datetime`` objects (with timezone UTC) instead of offset-naive UTC timestamps for the ``InvalidityDate`` X.509 CRL extension (https://github.com/ansible-collections/community.crypto/issues/726, https://github.com/ansible-collections/community.crypto/pull/730).

--- a/plugins/module_utils/crypto/cryptography_crl.py
+++ b/plugins/module_utils/crypto/cryptography_crl.py
@@ -8,7 +8,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+from ansible_collections.community.crypto.plugins.module_utils.version import LooseVersion as _LooseVersion
+
 try:
+    import cryptography
     from cryptography import x509
 except ImportError:
     # Error handled in the calling module.
@@ -32,6 +35,8 @@ from ._obj2txt import (
 #       to True and adjust get_invalidity_date() accordingly.
 #       (https://github.com/pyca/cryptography/issues/10818)
 CRYPTOGRAPHY_TIMEZONE_INVALIDITY_DATE = False
+if HAS_CRYPTOGRAPHY:
+    CRYPTOGRAPHY_TIMEZONE_INVALIDITY_DATE = _LooseVersion(cryptography.__version__) >= _LooseVersion('43.0.0')
 
 TIMESTAMP_FORMAT = "%Y%m%d%H%M%SZ"
 
@@ -139,7 +144,8 @@ def get_revocation_date(obj):
 
 
 def get_invalidity_date(obj):
-    # TODO: special handling if CRYPTOGRAPHY_TIMEZONE_INVALIDITY_DATE is True
+    if CRYPTOGRAPHY_TIMEZONE_INVALIDITY_DATE:
+        return obj.invalidity_date_utc
     return obj.invalidity_date
 
 


### PR DESCRIPTION
##### SUMMARY
Ref: #726
Ref: https://github.com/pyca/cryptography/pull/10848

This needs to wait for the cryptography 43.0.0 release to make sure this will really be in there for that version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/crypto/cryptography_crl.py
