### PR TITLE
acme_certificate: avoid exception if certificate has no AKI

### DIFF
--- a/plugins/module_utils/acme/utils.py
+++ b/plugins/module_utils/acme/utils.py
@@ -102,13 +102,21 @@ def parse_retry_after(value, relative_with_timezone=True, now=None):
     raise ValueError('Cannot parse Retry-After header value %s' % repr(value))
 
 
-def compute_cert_id(backend, cert_info=None, cert_filename=None, cert_content=None):
+def compute_cert_id(
+    backend,
+    cert_info=None,
+    cert_filename=None,
+    cert_content=None,
+    none_if_required_information_is_missing=False,
+):
     # Obtain certificate info if not provided
     if cert_info is None:
         cert_info = backend.get_cert_information(cert_filename=cert_filename, cert_content=cert_content)
 
     # Convert Authority Key Identifier to string
     if cert_info.authority_key_identifier is None:
+        if none_if_required_information_is_missing:
+            return None
         raise ModuleFailException('Certificate has no Authority Key Identifier extension')
     aki = to_native(base64.urlsafe_b64encode(cert_info.authority_key_identifier)).replace('=', '')
 

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -755,7 +755,11 @@ class ACMECertificateClient(object):
             ):
                 cert_info = self._get_cert_info_or_none()
                 if cert_info is not None:
-                    replaces_cert_id = compute_cert_id(self.client.backend, cert_info=cert_info)
+                    replaces_cert_id = compute_cert_id(
+                        self.client.backend,
+                        cert_info=cert_info,
+                        none_if_required_information_is_missing=True,
+                    )
             self.order = Order.create(self.client, self.identifiers, replaces_cert_id)
             self.order_uri = self.order.url
             self.order.load_authorizations(self.client)

--- a/plugins/modules/acme_certificate_renewal_info.py
+++ b/plugins/modules/acme_certificate_renewal_info.py
@@ -186,9 +186,7 @@ def main():
             cert_filename=module.params['certificate_path'],
             cert_content=module.params['certificate_content'],
         )
-        cert_id = None
-        if cert_info.authority_key_identifier is not None:
-            cert_id = compute_cert_id(backend, cert_info=cert_info)
+        cert_id = compute_cert_id(backend, cert_info=cert_info, none_if_required_information_is_missing=True)
         if cert_id is not None:
             result['cert_id'] = cert_id
 


### PR DESCRIPTION
##### SUMMARY
Shouldn't happen since CA-issued certs should always have AKI, but better be safe than sorry.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
