### PR TITLE
Remove usage of old ACME test container

### DIFF
--- a/tests/utils/shippable/generic.sh
+++ b/tests/utils/shippable/generic.sh
@@ -16,7 +16,6 @@ target="azp/generic/${group}/"
 stage="${S:-prod}"
 
 # shellcheck disable=SC2086
-export ANSIBLE_ACME_CONTAINER=quay.io/ansible/acme-test-container:2.0.0  # use new container until
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote-terminate always --remote-stage "${stage}" \
     --docker --python "${python}"


### PR DESCRIPTION
##### SUMMARY
Removes an outdated temporary fix from 2020 (#98) that is causing an old ACME container being used in some tests.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
