### PR TITLE
Stop building EE with CentOS Stream 8, which no longer has builds

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -78,16 +78,6 @@ jobs:
             pre_base: '"#"'
             # We don't have PyOpenSSL for Python 3.9
             extra_vars: -e has_no_pyopenssl=true
-          - name: ansible-core 2.12 @ CentOS Stream 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.12.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: quay.io/centos/centos:stream8
-            pre_base: '"#"'
-            # We don't have PyOpenSSL for Python 3.9
-            extra_vars: -e has_no_pyopenssl=true
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
##### SUMMARY
According to https://www.centos.org/download/ "CentOS Stream 8 end of builds is May 31, 2024", so the build seems dead as we can no longer install things. So let's remove it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
EE tests
