### PR TITLE
Fix CI for CentOS 7

### DIFF
--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -19,3 +19,9 @@
     ansible_pkg_mgr: community.general.zypper
     cacheable: true
   when: ansible_os_family == 'Suse' and ansible_version.string is version('2.10', '>=')
+
+- shell:
+    cmd: |
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+      sed -i 's%#baseurl=http://mirror.centos.org/%baseurl=https://vault.centos.org/%g' /etc/yum.repos.d/*.repo
+  when: ansible_distribution in 'CentOS' and ansible_distribution_major_version == '7'


### PR DESCRIPTION
##### SUMMARY
CentOS 7 is EOL and the package mirrors have been turned off.

Ref: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
