### PR TITLE
certificate_complete_chain: add ability to identify ed25519 complete chains

### DIFF
--- a/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
+++ b/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - complete_chain - add ability to identify ed25519 and ed448 complete chains.
+  - certificate_complete_chain - add ability to identify ed25519 and ed448 complete chains (https://github.com/ansible-collections/community.crypto/pull/777).

--- a/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
+++ b/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - complete_chain - add ability to identify ed25519 and ed448 complete chains.

--- a/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
+++ b/changelogs/fragments/777-add_ability_to_identify_ed25519_complete_chains.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - certificate_complete_chain - add ability to identify ed25519 and ed448 complete chains (https://github.com/ansible-collections/community.crypto/pull/777).
+  - certificate_complete_chain - add ability to identify Ed25519 and Ed448 complete chains (https://github.com/ansible-collections/community.crypto/pull/777).

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -150,6 +150,7 @@ try:
     import cryptography.hazmat.primitives.serialization
     import cryptography.hazmat.primitives.asymmetric.rsa
     import cryptography.hazmat.primitives.asymmetric.ec
+    import cryptography.hazmat.primitives.asymmetric.ed25519
     import cryptography.hazmat.primitives.asymmetric.padding
     import cryptography.hazmat.primitives.hashes
     import cryptography.hazmat.primitives.asymmetric.utils
@@ -195,6 +196,11 @@ def is_parent(module, cert, potential_parent):
                 cert.cert.signature,
                 cert.cert.tbs_certificate_bytes,
                 cryptography.hazmat.primitives.asymmetric.ec.ECDSA(cert.cert.signature_hash_algorithm),
+            )
+        elif isinstance(public_key, cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey):
+            public_key.verify(
+                cert.cert.signature,
+                cert.cert.tbs_certificate_bytes
             )
         else:
             # Unknown public key type

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -141,8 +141,11 @@ from ansible_collections.community.crypto.plugins.module_utils.version import Lo
 from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import (
     split_pem_list,
 )
+
 from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
-    CRYPTOGRAPHY_HAS_ED448_SIGN, CRYPTOGRAPHY_HAS_ED25519_SIGN)
+    CRYPTOGRAPHY_HAS_ED448_SIGN,
+    CRYPTOGRAPHY_HAS_ED25519_SIGN,
+)
 
 
 CRYPTOGRAPHY_IMP_ERR = None

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -141,6 +141,9 @@ from ansible_collections.community.crypto.plugins.module_utils.version import Lo
 from ansible_collections.community.crypto.plugins.module_utils.crypto.pem import (
     split_pem_list,
 )
+from ansible_collections.community.crypto.plugins.module_utils.crypto.basic import (
+    CRYPTOGRAPHY_HAS_ED448_SIGN, CRYPTOGRAPHY_HAS_ED25519_SIGN)
+
 
 CRYPTOGRAPHY_IMP_ERR = None
 try:
@@ -150,6 +153,7 @@ try:
     import cryptography.hazmat.primitives.serialization
     import cryptography.hazmat.primitives.asymmetric.rsa
     import cryptography.hazmat.primitives.asymmetric.ec
+    import cryptography.hazmat.primitives.asymmetric.ed448
     import cryptography.hazmat.primitives.asymmetric.ed25519
     import cryptography.hazmat.primitives.asymmetric.padding
     import cryptography.hazmat.primitives.hashes
@@ -197,11 +201,12 @@ def is_parent(module, cert, potential_parent):
                 cert.cert.tbs_certificate_bytes,
                 cryptography.hazmat.primitives.asymmetric.ec.ECDSA(cert.cert.signature_hash_algorithm),
             )
-        elif isinstance(public_key, cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey):
-            public_key.verify(
-                cert.cert.signature,
-                cert.cert.tbs_certificate_bytes
-            )
+        elif CRYPTOGRAPHY_HAS_ED25519_SIGN and isinstance(
+                public_key, cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey):
+            public_key.verify(cert.cert.signature, cert.cert.tbs_certificate_bytes)
+        elif CRYPTOGRAPHY_HAS_ED448_SIGN and isinstance(
+                public_key, cryptography.hazmat.primitives.asymmetric.ed448.Ed448PublicKey):
+            public_key.verify(cert.cert.signature, cert.cert.tbs_certificate_bytes)
         else:
             # Unknown public key type
             module.warn('Unknown public key type "{0}"'.format(public_key))

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -147,7 +147,6 @@ from ansible_collections.community.crypto.plugins.module_utils.crypto.basic impo
     CRYPTOGRAPHY_HAS_ED25519_SIGN,
 )
 
-
 CRYPTOGRAPHY_IMP_ERR = None
 try:
     import cryptography

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -156,8 +156,6 @@ try:
     import cryptography.hazmat.primitives.serialization
     import cryptography.hazmat.primitives.asymmetric.rsa
     import cryptography.hazmat.primitives.asymmetric.ec
-    import cryptography.hazmat.primitives.asymmetric.ed448
-    import cryptography.hazmat.primitives.asymmetric.ed25519
     import cryptography.hazmat.primitives.asymmetric.padding
     import cryptography.hazmat.primitives.hashes
     import cryptography.hazmat.primitives.asymmetric.utils


### PR DESCRIPTION
##### SUMMARY
This adds the ability to use the certificate_complete_chain module on ed25519 certificates.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
certificate_complete_chain

##### ADDITIONAL INFORMATION
Without this change, using this module with an ed25519 cert provides an error:
[WARNING]: Unknown public key type "<cryptography.hazmat.backends.openssl.ed25519._Ed25519PublicKey object at 0x7f5263b8bd90>"


Upon making the change, it works.  However I do not like it.  The reason I don't like it is because the "verify" method for class Ed25519PublicKey in the cryptography library is an abstractmethod with undefined functionality.  I could never find where the actual functionality is defined.  I don't really understand the cryptography library well, nor how this ansible module uses it.  Which means more work may be needed but I am having trouble identifying what that might be.

References:
- https://github.com/pyca/cryptography/blob/main/src/cryptography/hazmat/primitives/asymmetric/ed25519.py

I am quite open to critics and pointers.
