### PR TITLE
Remove EOL'ed FreeBSD 13.2 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -252,8 +252,8 @@ stages:
               test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
+            # - name: FreeBSD 13.2
+            #   test: freebsd/13.2
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Apparently the packages are no longer available.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
