### PR TITLE
Fix PKCS#12 tests

### DIFF
--- a/tests/integration/targets/openssl_pkcs12/tests/validate.yml
+++ b/tests/integration/targets/openssl_pkcs12/tests/validate.yml
@@ -20,7 +20,8 @@
     that:
       - p12_standard_check is changed
       - p12_standard is changed
-      - p12.stdout_lines[2].split(':')[-1].strip() == 'abracadabra'
+      - p12.stdout_lines[2].split(':')[-1].strip() == 'abracadabra' or
+        p12.stdout_lines[1].split(':')[-1].strip() == 'abracadabra'
       - p12_standard.mode == '0400'
       - p12_no_pkey is changed
       - p12_validate_no_pkey.stdout_lines[-1] == '-----END CERTIFICATE-----'


### PR DESCRIPTION
##### SUMMARY
This is probably related to the way certificates are serialized in cryptograpy 43.0.0 (https://cryptography.io/en/latest/changelog/#v43-0-0).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
openssl_pkcs12 integration tests
