### PR TITLE
lookup lowercase domain names when verifying authorizations to preven…

### DIFF
--- a/changelogs/fragments/803-fix-authorization-failure-with-mixed-case-sans.yml
+++ b/changelogs/fragments/803-fix-authorization-failure-with-mixed-case-sans.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - acme_certificate - fix authorization failure when CSR contains SANs with mixed case
+  - acme_certificate - fix authorization failure when CSR contains SANs with mixed case (https://github.com/ansible-collections/community.crypto/pull/803).

--- a/changelogs/fragments/803-fix-authorization-failure-with-mixed-case-sans.yml
+++ b/changelogs/fragments/803-fix-authorization-failure-with-mixed-case-sans.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - acme_certificate - fix authorization failure when CSR contains SANs with mixed case

--- a/plugins/module_utils/acme/challenges.py
+++ b/plugins/module_utils/acme/challenges.py
@@ -46,9 +46,11 @@ def create_key_authorization(client, token):
 def combine_identifier(identifier_type, identifier):
     return '{type}:{identifier}'.format(type=identifier_type, identifier=identifier)
 
+
 def normalize_combined_identifier(identifier):
     parts = split_identifier(identifier)
     return '{type}:{identifier}'.format(type=parts[0], identifier=parts[1].lower())
+
 
 def split_identifier(identifier):
     parts = identifier.split(':', 1)

--- a/plugins/module_utils/acme/challenges.py
+++ b/plugins/module_utils/acme/challenges.py
@@ -48,8 +48,10 @@ def combine_identifier(identifier_type, identifier):
 
 
 def normalize_combined_identifier(identifier):
-    parts = split_identifier(identifier)
-    return '{type}:{identifier}'.format(type=parts[0], identifier=parts[1].lower())
+    identifier_type, identifier = split_identifier(identifier)
+    # Normalize DNS names and IPs
+    identifier = identifier.lower()
+    return combine_identifier(identifier_type, identifier)
 
 
 def split_identifier(identifier):

--- a/plugins/module_utils/acme/challenges.py
+++ b/plugins/module_utils/acme/challenges.py
@@ -46,6 +46,9 @@ def create_key_authorization(client, token):
 def combine_identifier(identifier_type, identifier):
     return '{type}:{identifier}'.format(type=identifier_type, identifier=identifier)
 
+def normalize_combined_identifier(identifier):
+    parts = split_identifier(identifier)
+    return '{type}:{identifier}'.format(type=parts[0], identifier=parts[1].lower())
 
 def split_identifier(identifier):
     parts = identifier.split(':', 1)

--- a/plugins/module_utils/acme/orders.py
+++ b/plugins/module_utils/acme/orders.py
@@ -93,7 +93,7 @@ class Order(object):
     def load_authorizations(self, client):
         for auth_uri in self.authorization_uris:
             authz = Authorization.from_url(client, auth_uri)
-            self.authorizations[authz.combined_identifier] = authz
+            self.authorizations[authz.combined_identifier.lower()] = authz
 
     def wait_for_finalization(self, client):
         while True:

--- a/plugins/module_utils/acme/orders.py
+++ b/plugins/module_utils/acme/orders.py
@@ -21,6 +21,7 @@ from ansible_collections.community.crypto.plugins.module_utils.acme.errors impor
 
 from ansible_collections.community.crypto.plugins.module_utils.acme.challenges import (
     Authorization,
+    normalize_combined_identifier,
 )
 
 
@@ -93,7 +94,7 @@ class Order(object):
     def load_authorizations(self, client):
         for auth_uri in self.authorization_uris:
             authz = Authorization.from_url(client, auth_uri)
-            self.authorizations[authz.combined_identifier.lower()] = authz
+            self.authorizations[normalize_combined_identifier(authz.combined_identifier)] = authz
 
     def wait_for_finalization(self, client):
         while True:

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -837,7 +837,7 @@ class ACMECertificateClient(object):
         for identifier_type, identifier in self.identifiers:
             authz = self.authorizations.get(combine_identifier(identifier_type, identifier.lower()))
             if authz is None:
-                raise ModuleFailException('Found no authorization information for "{identifier.lower()}"!'.format(
+                raise ModuleFailException('Found no authorization information for "{identifier}"!'.format(
                     identifier=combine_identifier(identifier_type, identifier.lower())))
             if authz.status != 'valid':
                 authz.raise_error('Status is "{status}" and not "valid"'.format(status=authz.status), module=self.module)

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -835,10 +835,10 @@ class ACMECertificateClient(object):
         with an error.
         '''
         for identifier_type, identifier in self.identifiers:
-            authz = self.authorizations.get(combine_identifier(identifier_type, identifier))
+            authz = self.authorizations.get(combine_identifier(identifier_type, identifier.lower()))
             if authz is None:
-                raise ModuleFailException('Found no authorization information for "{identifier}"!'.format(
-                    identifier=combine_identifier(identifier_type, identifier)))
+                raise ModuleFailException('Found no authorization information for "{identifier.lower()}"!'.format(
+                    identifier=combine_identifier(identifier_type, identifier.lower())))
             if authz.status != 'valid':
                 authz.raise_error('Status is "{status}" and not "valid"'.format(status=authz.status), module=self.module)
 

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -721,7 +721,7 @@ class ACMECertificateClient(object):
                     raise ModuleFailException('ACME v1 only supports DNS identifiers!')
             for identifier_type, identifier in self.identifiers:
                 authz = Authorization.create(self.client, identifier_type, identifier)
-                self.authorizations[authz.combined_identifier] = authz
+                self.authorizations[authz.combined_identifier.lower()] = authz
         else:
             replaces_cert_id = None
             if (


### PR DESCRIPTION
…t failure when CSR has mixed-case names

##### SUMMARY
I received a CSR from a vendor that had uppercase characters in someof the requested domain names, which resulted in the following error when validating challenges with the acme_certificate module: "Found no authorization information for \"dns:My.FQDN.com\"!". The problem was caused by the authorizations in the returned challenge data having all domains (keys for the validation object) converted to lowercase, but when the keys were being looked up to make sure each is valid, the original case in the CSR was used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate 

##### ADDITIONAL INFORMATION
Before change
```
TASK [ansible_acme : Complete challenge] ***************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Found no authorization information for \"dns:My.FQDN.com\"!", "other": {}}
```

After change, task completes successfully.
