### PR TITLE
openssl_pkcs12: deprecate PyOpenSSL backend

### DIFF
--- a/changelogs/fragments/831-openssl_pkcs12-deprecate-pyopenssl.yml
+++ b/changelogs/fragments/831-openssl_pkcs12-deprecate-pyopenssl.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - "openssl_pkcs12 - the PyOpenSSL based backend is deprecated and will be removed from community.crypto 3.0.0.
+    From that point on you need cryptography 3.0 or newer to use this module
+    (https://github.com/ansible-collections/community.crypto/issues/667, https://github.com/ansible-collections/community.crypto/pull/831)."

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -153,6 +153,7 @@ options:
         V(auto) will always result in C(pyopenssl) to be chosen for backwards compatibility.
       - If set to V(pyopenssl), will try to use the L(pyOpenSSL,https://pypi.org/project/pyOpenSSL/) library.
       - If set to V(cryptography), will try to use the L(cryptography,https://cryptography.io/) library.
+      - B(Note) that the V(pyopenssl) backend is deprecated and will be removed from community.crypto 3.0.0.
     type: str
     default: auto
     choices: [auto, cryptography, pyopenssl]
@@ -737,8 +738,8 @@ def select_backend(module, backend):
                 'pyOpenSSL >= {0}, < {1}'.format(MINIMAL_PYOPENSSL_VERSION, MAXIMAL_PYOPENSSL_VERSION)
             )
             module.fail_json(msg=msg, exception=PYOPENSSL_IMP_ERR)
-        # module.deprecate('The module is using the PyOpenSSL backend. This backend has been deprecated',
-        #                  version='x.0.0', collection_name='community.crypto')
+        module.deprecate('The module is using the PyOpenSSL backend. This backend has been deprecated',
+                         version='3.0.0', collection_name='community.crypto')
         return backend, PkcsPyOpenSSL(module)
     elif backend == 'cryptography':
         if not CRYPTOGRAPHY_FOUND:


### PR DESCRIPTION
##### SUMMARY
Ref: #667.

I think it's time to deprecate the PyOpenSSL backend for openssl_pkcs12. It's the last PyOpenSSL usage in this collection, and since we want to drop a lot of old stuff for community.crypto 3.0.0 (#559), let's also get rid of that. Note that PyOpenSSL 23.3.0 and newer cannot be used with the module anyway.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_pkcs12
