### PR TITLE
Deprecate ansible-core < 2.17 and cryptography < 3.4

### DIFF
--- a/changelogs/fragments/3.0.0-deprecations.yml
+++ b/changelogs/fragments/3.0.0-deprecations.yml
@@ -1,0 +1,15 @@
+deprecated_features:
+  - "Support for ansible-core 2.11, 2.12, 2.13, 2.14, 2.15, and 2.16 is deprecated,
+     and will be removed in the next major release (community.crypto 3.0.0).
+     Some modules might still work with some of these versions afterwards,
+     but we will no longer keep compatibility code that was needed to support them.
+     Note that this means that support for all Python versions before 3.7 will be dropped,
+     also on the target side
+     (https://github.com/ansible-collections/community.crypto/issues/559,
+      https://github.com/ansible-collections/community.crypto/pull/839)."
+  - "Support for cryptography < 3.4 is deprecated,
+     and will be removed in the next major release (community.crypto 3.0.0).
+     Some modules might still work with older versions of cryptography,
+     but we will no longer keep compatibility code that was needed to support them
+     (https://github.com/ansible-collections/community.crypto/issues/559,
+      https://github.com/ansible-collections/community.crypto/pull/839)."


### PR DESCRIPTION
##### SUMMARY
See #559.

I decided to deprecate ansible-core 2.16 as well, since it will be EOL soon after the community.crypto 3.0.0 release planned for May 2025.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
collection changelog
