### PR TITLE
Move EOL'ed ansible-core 2.15 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -98,17 +98,6 @@ stages:
               test: '2.16/sanity/1'
             - name: Units
               test: '2.16/units/1'
-  - stage: Ansible_2_15
-    displayName: Sanity & Units 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.15/sanity/1'
-            - name: Units
-              test: '2.15/units/1'
 ### Docker
   - stage: Docker_devel
     displayName: Docker devel
@@ -175,21 +164,6 @@ stages:
               test: opensuse15
             - name: Alpine 3
               test: alpine3
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_15
-    displayName: Docker 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/linux/{0}
-          targets:
-            - name: Fedora 37
-              test: fedora37
-            - name: CentOS 7
-              test: centos7
           groups:
             - 1
             - 2
@@ -297,29 +271,10 @@ stages:
               test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
-            # - name: FreeBSD 13.2
-            #   test: freebsd/13.2
-          groups:
-            - 1
-            - 2
-  - stage: Remote_2_15
-    displayName: Remote 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/{0}
-          targets:
-            - name: RHEL 9.1
-              test: rhel/9.1
-            - name: RHEL 8.7
-              test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
-            # - name: FreeBSD 13.1
-            #   test: freebsd/13.1
-            # - name: FreeBSD 12.4
-            #   test: freebsd/12.4
+            # - name: FreeBSD 13.2
+            #   test: freebsd/13.2
           groups:
             - 1
             - 2
@@ -384,20 +339,6 @@ stages:
           groups:
             - 1
             - 2
-  - stage: Generic_2_15
-    displayName: Generic 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.15/generic/{0}
-          targets:
-            - test: 3.5
-            - test: "3.10"
-          groups:
-            - 1
-            - 2
 
   ## Finally
 
@@ -408,23 +349,19 @@ stages:
       - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
-      - Ansible_2_15
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_18
       - Remote_2_17
       - Remote_2_16
-      - Remote_2_15
       - Docker_devel
       - Docker_2_18
       - Docker_2_17
       - Docker_2_16
-      - Docker_2_15
       - Docker_community_devel
       - Generic_devel
       - Generic_2_18
       - Generic_2_17
       - Generic_2_16
-      - Generic_2_15
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -35,6 +35,7 @@ jobs:
           - '2.12'
           - '2.13'
           - '2.14'
+          - '2.15'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -77,6 +78,7 @@ jobs:
           - '2.12'
           - '2.13'
           - '2.14'
+          - '2.15'
 
     steps:
       - name: >-
@@ -257,6 +259,39 @@ jobs:
           - ansible: '2.14'
             docker: default
             python: '3.9'
+            target: azp/generic/2/
+          # 2.15
+          - ansible: '2.15'
+            docker: fedora37
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.15'
+            docker: fedora37
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.15'
+            docker: centos7
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.15'
+            docker: centos7
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.15'
+            docker: default
+            python: '3.5'
+            target: azp/generic/1/
+          - ansible: '2.15'
+            docker: default
+            python: '3.5'
+            target: azp/generic/2/
+          - ansible: '2.15'
+            docker: default
+            python: '3.10'
+            target: azp/generic/1/
+          - ansible: '2.15'
+            docker: default
+            python: '3.10'
             target: azp/generic/2/
 
     steps:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -270,14 +270,6 @@ jobs:
             python: ''
             target: azp/posix/2/
           - ansible: '2.15'
-            docker: centos7
-            python: ''
-            target: azp/posix/1/
-          - ansible: '2.15'
-            docker: centos7
-            python: ''
-            target: azp/posix/2/
-          - ansible: '2.15'
             docker: default
             python: '3.5'
             target: azp/generic/1/


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.15 is EOL since November 2024.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
