### PR TITLE
CI: Add macOS 15.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -212,8 +212,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: macOS 14.3
-              test: macos/14.3
+            - name: macOS 15.3
+              test: macos/15.3
             - name: RHEL 9.5
               test: rhel/9.5
             - name: FreeBSD 14.2
@@ -231,6 +231,8 @@ stages:
         parameters:
           testFormat: 2.18/{0}
           targets:
+            - name: macOS 14.3
+              test: macos/14.3
             - name: RHEL 9.4
               test: rhel/9.4
             - name: FreeBSD 14.1


### PR DESCRIPTION
##### SUMMARY
ansible-core devel's ansible-test replaced macOS 14.3 with 15.3.

Ref: https://github.com/ansible/ansible/pull/84665
Ref: https://forum.ansible.com/t/40650

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
