### PR TITLE
Skip openssh_cert test on Rocky Linux 9+ due to SHA-1 restrictions

### DIFF
--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -74,11 +74,12 @@
         assert:
           that:
             - second_signature_algorithm is changed
-      # RHEL9 and Fedora 41 disable the SHA-1 algorithms by default, making this test fail with a 'libcrypt' error.
+      # RHEL9, Fedora 41 and Rocky 9.3 disable the SHA-1 algorithms by default, making this test fail with a 'libcrypt' error.
       # Other systems which impose a similar restriction may also need to skip this block in the future.
       when:
         - not (ansible_facts['distribution'] == "RedHat" and (ansible_facts['distribution_major_version'] | int) >= 9)
         - not (ansible_facts['distribution'] == "Fedora" and (ansible_facts['distribution_major_version'] | int) >= 41)
+        - not (ansible_facts['distribution'] == "Rocky" and (ansible_facts['distribution_major_version'] | int) >= 9)
 
     - name: Omit signature algorithm
       openssh_cert:

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -74,7 +74,7 @@
         assert:
           that:
             - second_signature_algorithm is changed
-      # RHEL9, Fedora 41 and Rocky 9.3 disable the SHA-1 algorithms by default, making this test fail with a 'libcrypt' error.
+      # RHEL9, Fedora 41 and Rocky 9 disable the SHA-1 algorithms by default, making this test fail with a 'libcrypt' error.
       # Other systems which impose a similar restriction may also need to skip this block in the future.
       when:
         - not (ansible_facts['distribution'] == "RedHat" and (ansible_facts['distribution_major_version'] | int) >= 9)

--- a/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
+++ b/tests/integration/targets/openssh_cert/tests/key_idempotency.yml
@@ -77,9 +77,8 @@
       # RHEL9, Fedora 41 and Rocky 9 disable the SHA-1 algorithms by default, making this test fail with a 'libcrypt' error.
       # Other systems which impose a similar restriction may also need to skip this block in the future.
       when:
-        - not (ansible_facts['distribution'] == "RedHat" and (ansible_facts['distribution_major_version'] | int) >= 9)
+        - not (ansible_facts['distribution'] in ["RedHat", "Rocky"] and (ansible_facts['distribution_major_version'] | int) >= 9)
         - not (ansible_facts['distribution'] == "Fedora" and (ansible_facts['distribution_major_version'] | int) >= 41)
-        - not (ansible_facts['distribution'] == "Rocky" and (ansible_facts['distribution_major_version'] | int) >= 9)
 
     - name: Omit signature algorithm
       openssh_cert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Skip `openssh_cert` test on Rocky Linux 9+ where SHA-1 is disabled by default, causing `ssh-rsa` certificate generation to fail with a libcrypto error. Matches existing skip conditions for RHEL 9+ and Fedora 41+.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #855 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert integration tests


