### PR TITLE
Remove FreeBSD 14.0 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -250,8 +250,6 @@ stages:
               test: rhel/9.3
             - name: FreeBSD 13.3
               test: freebsd/13.3
-            - name: FreeBSD 14.0
-              test: freebsd/14.0
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
In ansible-core it has been replaced with 14.1, but we're already testing against that. Ref: https://github.com/ansible/ansible/commit/3546111f2d83dd254c928b6b9e273ef1daf1f296

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
