### PR TITLE
luks_device: add no_log=False to passphrase_encoding

### DIFF
--- a/changelogs/fragments/867-passphrase-encoding-nolog.yml
+++ b/changelogs/fragments/867-passphrase-encoding-nolog.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "luks_device - mark parameter ``passphrase_encoding`` as ``no_log=False`` to avoid confusing warning (https://github.com/ansible-collections/community.crypto/pull/867)."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -990,7 +990,7 @@ def run_module():
         passphrase=dict(type='str', no_log=True),
         new_passphrase=dict(type='str', no_log=True),
         remove_passphrase=dict(type='str', no_log=True),
-        passphrase_encoding=dict(type='str', default='text', choices=['text', 'base64']),
+        passphrase_encoding=dict(type='str', default='text', choices=['text', 'base64'], no_log=False),
         keyslot=dict(type='int', no_log=False),
         new_keyslot=dict(type='int', no_log=False),
         remove_keyslot=dict(type='int', no_log=False),


### PR DESCRIPTION
##### SUMMARY
Looks like the "forgotten no_log detection" has been changed, since I get `[WARNING]: Module did not set no_log for passphrase_encoding`. This explicitly sets `no_log=False` to disable this warning, as `passphrase_encoding` is definitely not sensitive.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
luks_device
