### PR TITLE
luks_device: fix killing of keyslot

### DIFF
--- a/changelogs/fragments/868-luks-remove-keyslot.yml
+++ b/changelogs/fragments/868-luks-remove-keyslot.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "luks_device - removing a specific keyslot with ``remove_keyslot`` caused the module to hang while cryptsetup was waiting for a passphrase from stdin,
+     while the module did not supply one. Since a keyslot is not necessary, do not provide one
+     (https://github.com/ansible-collections/community.crypto/issues/864, https://github.com/ansible-collections/community.crypto/pull/868)."

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -757,12 +757,14 @@ class CryptHandler(Handler):
 
         if keyslot is None:
             args = [self._cryptsetup_bin, 'luksRemoveKey', device, '-q']
+            if keyfile:
+                args.extend(['--key-file', keyfile])
+            elif passphrase is not None:
+                args.extend(['--key-file', '-'])
         else:
+            # Since we supply -q no passphrase is needed
             args = [self._cryptsetup_bin, 'luksKillSlot', device, '-q', str(keyslot)]
-        if keyfile:
-            args.extend(['--key-file', keyfile])
-        else:
-            args.extend(['--key-file', '-'])
+            passphrase = None
         result = self._run_command(args, data=passphrase)
         if result[RETURN_CODE] != 0:
             raise ValueError('Error while removing LUKS key from %s: %s'


### PR DESCRIPTION
##### SUMMARY
Before 2433fdab989ee34918a5d07fabd3839b63e5c971 a passphrase wasn't provided to cryptsetup when killing a keyslot. The commit changed the behavior that `--key-file -` was passed, but nothing provided on stdin, which causes some versions of `cryptsetup` to hang. (For some reason this happens locally with cryptsetup 2.7.5, but not in CI.)

Fixes #864.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
luks_device
