### PR TITLE
Make all doc_fragments private

### DIFF
--- a/changelogs/fragments/898-doc_fragments.yml
+++ b/changelogs/fragments/898-doc_fragments.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - "All doc_fragments are now private to the collection and must not be used from other collections or unrelated plugins/modules.
+     Breaking changes in these can happen at any time, even in bugfix releases
+     (https://github.com/ansible-collections/community.crypto/pull/898)."

--- a/plugins/doc_fragments/_acme.py
+++ b/plugins/doc_fragments/_acme.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_attributes.py
+++ b/plugins/doc_fragments/_attributes.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_cryptography_dep.py
+++ b/plugins/doc_fragments/_cryptography_dep.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_ecs_credential.py
+++ b/plugins/doc_fragments/_ecs_credential.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_module_certificate.py
+++ b/plugins/doc_fragments/_module_certificate.py
@@ -3,6 +3,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_module_csr.py
+++ b/plugins/doc_fragments/_module_csr.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_module_privatekey.py
+++ b/plugins/doc_fragments/_module_privatekey.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_module_privatekey_convert.py
+++ b/plugins/doc_fragments/_module_privatekey_convert.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/doc_fragments/_name_encoding.py
+++ b/plugins/doc_fragments/_name_encoding.py
@@ -2,6 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Note that this doc fragment is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
 from __future__ import annotations
 
 

--- a/plugins/filter/openssl_csr_info.py
+++ b/plugins/filter/openssl_csr_info.py
@@ -21,7 +21,7 @@ options:
     type: string
     required: true
 extends_documentation_fragment:
-  - community.crypto.name_encoding
+  - community.crypto._name_encoding
 seealso:
   - module: community.crypto.openssl_csr_info
   - plugin: community.crypto.to_serial

--- a/plugins/filter/openssl_privatekey_info.py
+++ b/plugins/filter/openssl_privatekey_info.py
@@ -32,7 +32,7 @@ options:
     type: bool
     default: false
 extends_documentation_fragment:
-  - community.crypto.name_encoding
+  - community.crypto._name_encoding
 seealso:
   - module: community.crypto.openssl_privatekey_info
 """

--- a/plugins/filter/x509_certificate_info.py
+++ b/plugins/filter/x509_certificate_info.py
@@ -21,7 +21,7 @@ options:
     type: string
     required: true
 extends_documentation_fragment:
-  - community.crypto.name_encoding
+  - community.crypto._name_encoding
 seealso:
   - module: community.crypto.x509_certificate_info
   - plugin: community.crypto.to_serial

--- a/plugins/filter/x509_crl_info.py
+++ b/plugins/filter/x509_crl_info.py
@@ -29,7 +29,7 @@ options:
     default: true
     version_added: 1.7.0
 extends_documentation_fragment:
-  - community.crypto.name_encoding
+  - community.crypto._name_encoding
 seealso:
   - module: community.crypto.x509_crl_info
   - plugin: community.crypto.to_serial

--- a/plugins/modules/acme_account.py
+++ b/plugins/modules/acme_account.py
@@ -31,10 +31,10 @@ seealso:
   - module: community.crypto.acme_inspect
     description: Allows to debug problems.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/acme_account_info.py
+++ b/plugins/modules/acme_account_info.py
@@ -18,12 +18,12 @@ notes:
   - The M(community.crypto.acme_account) module allows to modify, create and delete ACME accounts.
   - This module was called C(acme_account_facts) before Ansible 2.8. The usage did not change.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
 options:
   retrieve_orders:
     description:

--- a/plugins/modules/acme_ari_info.py
+++ b/plugins/modules/acme_ari_info.py
@@ -17,11 +17,11 @@ description:
     (U(https://datatracker.ietf.org/doc/draft-ietf-acme-ari/)).
     This module implements version 3 of the ARI draft.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.no_account
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
+  - community.crypto._acme.basic
+  - community.crypto._acme.no_account
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
 options:
   certificate_path:
     description:

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -65,12 +65,12 @@ seealso:
   - module: community.crypto.acme_certificate_deactivate_authz
     description: Allows to deactivate (invalidate) ACME v2 orders.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.acme.certificate
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._acme.certificate
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/acme_certificate_deactivate_authz.py
+++ b/plugins/modules/acme_certificate_deactivate_authz.py
@@ -21,10 +21,10 @@ description:
 seealso:
   - module: community.crypto.acme_certificate
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/acme_certificate_order_create.py
+++ b/plugins/modules/acme_certificate_order_create.py
@@ -80,11 +80,11 @@ seealso:
   - module: community.crypto.acme_inspect
     description: Allows to debug problems.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.acme.certificate
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._acme.certificate
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/acme_certificate_order_finalize.py
+++ b/plugins/modules/acme_certificate_order_finalize.py
@@ -48,12 +48,12 @@ seealso:
   - module: community.crypto.acme_certificate_deactivate_authz
     description: Allows to deactivate (invalidate) ACME v2 orders.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.acme.certificate
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
-  - community.crypto.attributes.files
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._acme.certificate
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/acme_certificate_order_info.py
+++ b/plugins/modules/acme_certificate_order_info.py
@@ -40,12 +40,12 @@ seealso:
   - module: community.crypto.acme_certificate_deactivate_authz
     description: Allows to deactivate (invalidate) ACME v2 orders.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.attributes.info_module
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._attributes.info_module
 options:
   order_uri:
     description:

--- a/plugins/modules/acme_certificate_order_validate.py
+++ b/plugins/modules/acme_certificate_order_validate.py
@@ -49,11 +49,11 @@ seealso:
   - module: community.crypto.acme_certificate_deactivate_authz
     description: Allows to deactivate (invalidate) ACME v2 orders.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
-  - community.crypto.attributes.files
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/acme_certificate_renewal_info.py
+++ b/plugins/modules/acme_certificate_renewal_info.py
@@ -16,11 +16,11 @@ description:
   - If available, the ARI extension (ACME Renewal Information, U(https://datatracker.ietf.org/doc/draft-ietf-acme-ari/)) is
     used. This module implements version 3 of the ARI draft.".
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.no_account
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
+  - community.crypto._acme.basic
+  - community.crypto._acme.no_account
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
 attributes:
   idempotent:
     support: partial

--- a/plugins/modules/acme_certificate_revoke.py
+++ b/plugins/modules/acme_certificate_revoke.py
@@ -29,10 +29,10 @@ seealso:
   - module: community.crypto.acme_inspect
     description: Allows to debug problems.
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/acme_challenge_cert_helper.py
+++ b/plugins/modules/acme_challenge_cert_helper.py
@@ -22,8 +22,8 @@ seealso:
     description: The specification of the C(tls-alpn-01) challenge (RFC 8737).
     link: https://www.rfc-editor.org/rfc/rfc8737.html
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/acme_inspect.py
+++ b/plugins/modules/acme_inspect.py
@@ -32,10 +32,10 @@ seealso:
     description: The specification of the C(tls-alpn-01) challenge (RFC 8737).
     link: https://www.rfc-editor.org/rfc/rfc8737.html
 extends_documentation_fragment:
-  - community.crypto.acme.basic
-  - community.crypto.acme.account
-  - community.crypto.attributes
-  - community.crypto.attributes.actiongroup_acme
+  - community.crypto._acme.basic
+  - community.crypto._acme.account
+  - community.crypto._attributes
+  - community.crypto._attributes.actiongroup_acme
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/certificate_complete_chain.py
+++ b/plugins/modules/certificate_complete_chain.py
@@ -18,9 +18,9 @@ description:
     that the signature is correct. It ignores validity dates and key usage completely. If you need to verify that a generated
     chain is valid, please use C(openssl verify ...).
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/crypto_info.py
+++ b/plugins/modules/crypto_info.py
@@ -16,9 +16,9 @@ description:
   - The current version retrieves information on the L(Python cryptography library, https://cryptography.io/) available to
     Ansible modules, and on the OpenSSL binary C(openssl) found in the path.
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
 options: {}
 """
 

--- a/plugins/modules/ecs_certificate.py
+++ b/plugins/modules/ecs_certificate.py
@@ -20,10 +20,10 @@ description:
 notes:
   - O(path) must be specified as the output location of the certificate.
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.cryptography_dep.minimum
-  - community.crypto.ecs_credential
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._cryptography_dep.minimum
+  - community.crypto._ecs_credential
 attributes:
   check_mode:
     support: partial

--- a/plugins/modules/ecs_domain.py
+++ b/plugins/modules/ecs_domain.py
@@ -34,8 +34,8 @@ notes:
     when requesting a validation while O(verification_method=dns) or O(verification_method=web_server). Be aware of that if
     doing many domain validation requests.
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.ecs_credential
+  - community.crypto._attributes
+  - community.crypto._ecs_credential
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/get_certificate.py
+++ b/plugins/modules/get_certificate.py
@@ -14,9 +14,9 @@ description:
   - Makes a secure connection and returns information about the presented certificate.
   - The module uses the cryptography Python library.
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: none

--- a/plugins/modules/luks_device.py
+++ b/plugins/modules/luks_device.py
@@ -15,7 +15,7 @@ description:
   - Module manages L(LUKS,https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) on given device. Supports creating, destroying,
     opening and closing of LUKS container and adding or removing new keys and passphrases.
 extends_documentation_fragment:
-  - community.crypto.attributes
+  - community.crypto._attributes
 
 attributes:
   check_mode:

--- a/plugins/modules/openssh_cert.py
+++ b/plugins/modules/openssh_cert.py
@@ -16,8 +16,8 @@ requirements:
   - "ssh-keygen"
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
+  - community.crypto._attributes
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -18,8 +18,8 @@ requirements:
   - cryptography >= 3.3 (if O(backend=cryptography))
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
+  - community.crypto._attributes
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_csr.py
+++ b/plugins/modules/openssl_csr.py
@@ -18,9 +18,9 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.module_csr
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._module_csr
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_csr_info.py
+++ b/plugins/modules/openssl_csr_info.py
@@ -18,11 +18,11 @@ author:
   - Felix Fontein (@felixfontein)
   - Yanis Guenane (@Spredzy)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
-  - community.crypto.name_encoding
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
+  - community.crypto._name_encoding
 options:
   path:
     description:

--- a/plugins/modules/openssl_csr_pipe.py
+++ b/plugins/modules/openssl_csr_pipe.py
@@ -18,8 +18,8 @@ author:
   - Yanis Guenane (@Spredzy)
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.module_csr
+  - community.crypto._attributes
+  - community.crypto._module_csr
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_dhparam.py
+++ b/plugins/modules/openssl_dhparam.py
@@ -23,8 +23,8 @@ author:
   - Thom Wiggers (@thomwiggers)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
+  - community.crypto._attributes
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -16,9 +16,9 @@ description:
   - The module uses the cryptography Python library.
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_privatekey.py
+++ b/plugins/modules/openssl_privatekey.py
@@ -20,9 +20,9 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.module_privatekey
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._module_privatekey
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_privatekey_convert.py
+++ b/plugins/modules/openssl_privatekey_convert.py
@@ -17,9 +17,9 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.module_privatekey_convert
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._module_privatekey_convert
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_privatekey_info.py
+++ b/plugins/modules/openssl_privatekey_info.py
@@ -20,10 +20,10 @@ author:
   - Felix Fontein (@felixfontein)
   - Yanis Guenane (@Spredzy)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
 options:
   path:
     description:

--- a/plugins/modules/openssl_privatekey_pipe.py
+++ b/plugins/modules/openssl_privatekey_pipe.py
@@ -21,9 +21,9 @@ author:
   - Yanis Guenane (@Spredzy)
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.flow
-  - community.crypto.module_privatekey
+  - community.crypto._attributes
+  - community.crypto._attributes.flow
+  - community.crypto._module_privatekey
 attributes:
   action:
     support: full

--- a/plugins/modules/openssl_publickey.py
+++ b/plugins/modules/openssl_publickey.py
@@ -19,9 +19,9 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_publickey_info.py
+++ b/plugins/modules/openssl_publickey_info.py
@@ -16,10 +16,10 @@ version_added: 1.7.0
 author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
 options:
   path:
     description:

--- a/plugins/modules/openssl_signature.py
+++ b/plugins/modules/openssl_signature.py
@@ -17,8 +17,8 @@ author:
   - Patrick Pichler (@aveexy)
   - Markus Teufelberger (@MarkusTeufelberger)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._cryptography_dep.minimum
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/openssl_signature_info.py
+++ b/plugins/modules/openssl_signature_info.py
@@ -17,10 +17,10 @@ author:
   - Patrick Pichler (@aveexy)
   - Markus Teufelberger (@MarkusTeufelberger)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
 options:
   path:
     description:

--- a/plugins/modules/x509_certificate.py
+++ b/plugins/modules/x509_certificate.py
@@ -25,13 +25,13 @@ author:
   - Markus Teufelberger (@MarkusTeufelberger)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.module_certificate
-  - community.crypto.module_certificate.backend_acme_documentation
-  - community.crypto.module_certificate.backend_entrust_documentation
-  - community.crypto.module_certificate.backend_ownca_documentation
-  - community.crypto.module_certificate.backend_selfsigned_documentation
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._module_certificate
+  - community.crypto._module_certificate.backend_acme_documentation
+  - community.crypto._module_certificate.backend_entrust_documentation
+  - community.crypto._module_certificate.backend_ownca_documentation
+  - community.crypto._module_certificate.backend_selfsigned_documentation
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/x509_certificate_convert.py
+++ b/plugins/modules/x509_certificate_convert.py
@@ -16,8 +16,8 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
+  - community.crypto._attributes
+  - community.crypto._attributes.files
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/x509_certificate_info.py
+++ b/plugins/modules/x509_certificate_info.py
@@ -24,11 +24,11 @@ author:
   - Yanis Guenane (@Spredzy)
   - Markus Teufelberger (@MarkusTeufelberger)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
-  - community.crypto.name_encoding
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
+  - community.crypto._name_encoding
 options:
   path:
     description:

--- a/plugins/modules/x509_certificate_pipe.py
+++ b/plugins/modules/x509_certificate_pipe.py
@@ -19,11 +19,11 @@ author:
   - Markus Teufelberger (@MarkusTeufelberger)
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.module_certificate
-  - community.crypto.module_certificate.backend_entrust_documentation
-  - community.crypto.module_certificate.backend_ownca_documentation
-  - community.crypto.module_certificate.backend_selfsigned_documentation
+  - community.crypto._attributes
+  - community.crypto._module_certificate
+  - community.crypto._module_certificate.backend_entrust_documentation
+  - community.crypto._module_certificate.backend_ownca_documentation
+  - community.crypto._module_certificate.backend_selfsigned_documentation
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/x509_crl.py
+++ b/plugins/modules/x509_crl.py
@@ -18,10 +18,10 @@ author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
   - ansible.builtin.files
-  - community.crypto.attributes
-  - community.crypto.attributes.files
-  - community.crypto.cryptography_dep.minimum
-  - community.crypto.name_encoding
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._cryptography_dep.minimum
+  - community.crypto._name_encoding
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/x509_crl_info.py
+++ b/plugins/modules/x509_crl_info.py
@@ -15,11 +15,11 @@ description:
 author:
   - Felix Fontein (@felixfontein)
 extends_documentation_fragment:
-  - community.crypto.attributes
-  - community.crypto.attributes.info_module
-  - community.crypto.attributes.idempotent_not_modify_state
-  - community.crypto.cryptography_dep.minimum
-  - community.crypto.name_encoding
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
+  - community.crypto._name_encoding
 options:
   path:
     description:


### PR DESCRIPTION
##### SUMMARY
This makes it easier to refactor things. Also none of them are designed to be proper reusable, and all module utils are already private.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
doc fragments
