### PR TITLE
Document supported curves for Elliptic Curve keys on ACME Accounts

### DIFF
--- a/plugins/doc_fragments/_acme.py
+++ b/plugins/doc_fragments/_acme.py
@@ -82,6 +82,7 @@ options:
   account_key_src:
     description:
       - Path to a file containing the ACME account RSA or Elliptic Curve key.
+      - "For Elliptic Curve keys only the following curves are supported: V(secp256r1), V(secp384r1), and V(secp521r1)."
       - 'Private keys can be created with the M(community.crypto.openssl_privatekey) or M(community.crypto.openssl_privatekey_pipe)
         modules. If the requisite (cryptography) is not available, keys can also be created directly with the C(openssl) command
         line tool: RSA keys can be created with C(openssl genrsa ...). Elliptic curve keys can be created with C(openssl ecparam
@@ -94,6 +95,7 @@ options:
   account_key_content:
     description:
       - Content of the ACME account RSA or Elliptic Curve key.
+      - "For Elliptic Curve keys only the following curves are supported: V(secp256r1), V(secp384r1), and V(secp521r1)."
       - Mutually exclusive with O(account_key_src).
       - Required if O(account_key_src) is not used.
       - B(Warning:) the content will be written into a temporary file, which will be deleted by Ansible when the module completes.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

It took me way too long to figure out why I was greeted with `Error while parsing account key: unknown elliptic curve: brainpoolP256r1`, so I'm now documenting this properly for everybody else.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

acme_account

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

none