### PR TITLE
CSR: avoid access of private attributes

### DIFF
--- a/changelogs/fragments/910-csr.yml
+++ b/changelogs/fragments/910-csr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "openssl_csr, openssl_csr_pipe - avoid accessing internal members of cryptography's ``KeyUsage`` extension object (https://github.com/ansible-collections/community.crypto/pull/910)."

--- a/plugins/module_utils/_crypto/module_backends/csr.py
+++ b/plugins/module_utils/_crypto/module_backends/csr.py
@@ -600,8 +600,7 @@ class CertificateSigningRequestCryptographyBackend(CertificateSigningRequestBack
                 return False
             params = cryptography_parse_key_usage_params(self.keyUsage)
             for param, value in params.items():
-                # TODO: check whether getattr() with '_' prepended is really needed
-                if getattr(current_keyusage_ext.value, "_" + param) != value:
+                if getattr(current_keyusage_ext.value, param) != value:
                     return False
             return current_keyusage_ext.critical == self.keyUsage_critical
 


### PR DESCRIPTION
##### SUMMARY
This might have been necessary for older cryptography versions, but is no longer needed nowadays. Let's see what CI says.

##### ISSUE TYPE
- Refactor Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
CSR modules
