### PR TITLE
Remove no longer needed backend abstractions

### DIFF
--- a/changelogs/fragments/refactoring.yml
+++ b/changelogs/fragments/refactoring.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - "Various code refactorings (https://github.com/ansible-collections/community.crypto/pull/905, https://github.com/ansible-collections/community.crypto/pull/909, https://github.com/ansible-collections/community.crypto/pull/911)."
+  - "Remove various no longer needed abstraction layers for multiple backends (https://github.com/ansible-collections/community.crypto/pull/912)."


### PR DESCRIPTION
##### SUMMARY
For modules that only have a cryptography backend and nothing else. Now that we have type hints, the abstractions don't really work anymore anyway, resp. would need a major overhaul to get working well with typing.

(This also allows to simplify the code further, and improve existing typing hints, and remove the need for some assertions.)

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
various
