### PR TITLE
Docs: mention RFC 9773 instead of the ARI draft

### DIFF
--- a/plugins/modules/acme_ari_info.py
+++ b/plugins/modules/acme_ari_info.py
@@ -14,7 +14,7 @@ short_description: Retrieves ACME Renewal Information (ARI) for a certificate
 description:
   - Allows to retrieve renewal information on a certificate obtained with the L(ACME protocol,https://tools.ietf.org/html/rfc8555).
   - This module only works with the ACME v2 protocol, and requires the ACME server to support the ARI extension
-    (U(https://datatracker.ietf.org/doc/draft-ietf-acme-ari/)).
+    (L(RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html)).
     This module implements version 3 of the ARI draft.
 extends_documentation_fragment:
   - community.crypto._acme.basic
@@ -54,7 +54,7 @@ EXAMPLES = r"""
 
 RETURN = r"""
 renewal_info:
-  description: The ARI renewal info object (U(https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-4.2)).
+  description: The ARI renewal info object (U(https://www.rfc-editor.org/rfc/rfc9773.html#section-4.2)).
   returned: success
   type: dict
   contains:

--- a/plugins/modules/acme_ari_info.py
+++ b/plugins/modules/acme_ari_info.py
@@ -15,7 +15,6 @@ description:
   - Allows to retrieve renewal information on a certificate obtained with the L(ACME protocol,https://tools.ietf.org/html/rfc8555).
   - This module only works with the ACME v2 protocol, and requires the ACME server to support the ARI extension
     (L(RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html)).
-    This module implements version 3 of the ARI draft.
 extends_documentation_fragment:
   - community.crypto._acme.basic
   - community.crypto._acme.no_account

--- a/plugins/modules/acme_certificate.py
+++ b/plugins/modules/acme_certificate.py
@@ -236,8 +236,8 @@ options:
         type: str
   include_renewal_cert_id:
     description:
-      - Determines whether to request renewal of an existing certificate according to L(the ACME ARI draft 3,
-        https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-5).
+      - Determines whether to request renewal of an existing certificate according to L(Section 5 of RFC 9773,
+        https://www.rfc-editor.org/rfc/rfc9773.html#section-5).
       - This is only used when the certificate specified in O(dest) or O(fullchain_dest) already exists.
       - Generally you should use V(when_ari_supported) if you know that the ACME service supports a compatible draft (or final
         version, once it is out) of the ARI extension. V(always) should never be necessary. If you are not sure, or if you

--- a/plugins/modules/acme_certificate_order_create.py
+++ b/plugins/modules/acme_certificate_order_create.py
@@ -106,9 +106,9 @@ options:
   replaces_cert_id:
     description:
       - If provided, will request the order to replace the certificate identified by this certificate ID
-        according to L(the ACME ARI draft 3, https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-5).
+        according to L(Section 5 of RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html#section-5).
       - This certificate ID must be computed as specified in
-        L(the ACME ARI draft 3, https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-4.1).
+        L(Section 4.1 of RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html#section-4.1).
         It is returned as return value RV(community.crypto.acme_certificate_renewal_info#module:cert_id) of the
         M(community.crypto.acme_certificate_renewal_info) module.
       - ACME servers might refuse to create new orders that indicate to replace a certificate for which

--- a/plugins/modules/acme_certificate_order_info.py
+++ b/plugins/modules/acme_certificate_order_info.py
@@ -175,10 +175,10 @@ order:
     replaces:
       description:
         - If the order was created to replace an existing certificate using the C(replaces) mechanism from
-          L(draft-ietf-acme-ari, https://datatracker.ietf.org/doc/draft-ietf-acme-ari/), this provides the
+          L(RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html), this provides the
           certificate ID of the certificate that will be replaced by this order.
       type: str
-      returned: when the certificate order is replacing a certificate through draft-ietf-acme-ari
+      returned: when the certificate order is replacing a certificate through RFC 9773
     profile:
       description:
         - If the ACME CA supports profiles through the L(draft-aaron-acme-profiles,

--- a/plugins/modules/acme_certificate_renewal_info.py
+++ b/plugins/modules/acme_certificate_renewal_info.py
@@ -13,7 +13,7 @@ version_added: 2.20.0
 short_description: Determine whether a certificate should be renewed or not
 description:
   - Uses various information to determine whether a certificate should be renewed or not.
-  - If available, the ARI extension (ACME Renewal Information, U(https://datatracker.ietf.org/doc/draft-ietf-acme-ari/)) is
+  - If available, the ARI extension (ACME Renewal Information, L(RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html)) is
     used. This module implements version 3 of the ARI draft.".
 extends_documentation_fragment:
   - community.crypto._acme.basic
@@ -49,7 +49,7 @@ options:
     description:
       - If ARI information is used, selects which algorithm is used to determine whether to renew now.
       - V(standard) selects the L(algorithm provided in the the ARI specification,
-        https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#name-renewalinfo-objects).
+        https://www.rfc-editor.org/rfc/rfc9773.html#section-4.2).
       - V(start) returns RV(should_renew=true) once the start of the renewal interval has been reached.
     type: str
     choices:
@@ -152,7 +152,7 @@ supports_ari:
 
 cert_id:
   description:
-    - The certificate ID according to the L(ARI specification, https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#section-4.1).
+    - The certificate ID according to L(Section 4.1 in RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html#section-4.1).
   returned: success, the certificate exists, and has an Authority Key Identifier X.509 extension
   type: str
   sample: aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE

--- a/plugins/modules/acme_certificate_renewal_info.py
+++ b/plugins/modules/acme_certificate_renewal_info.py
@@ -14,7 +14,7 @@ short_description: Determine whether a certificate should be renewed or not
 description:
   - Uses various information to determine whether a certificate should be renewed or not.
   - If available, the ARI extension (ACME Renewal Information, L(RFC 9773, https://www.rfc-editor.org/rfc/rfc9773.html)) is
-    used. This module implements version 3 of the ARI draft.".
+    used.
 extends_documentation_fragment:
   - community.crypto._acme.basic
   - community.crypto._acme.no_account


### PR DESCRIPTION
##### SUMMARY
Now that RFC 9773 (https://www.rfc-editor.org/rfc/rfc9773.html) is out, let's reference that instead of the ARI draft.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various docs
