### PR TITLE
Ensure consistent SSH key format with idempotent Ed25519 key regeneration

### DIFF
--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -158,7 +158,6 @@ EXAMPLES = r"""
   community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     force: true
-    
 - name: Regenerate SSH keypair only if format or options mismatch
   community.crypto.openssh_keypair:
     path: /home/devops/.ssh/id_ed25519

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -158,6 +158,13 @@ EXAMPLES = r"""
   community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     force: true
+    
+- name: Regenerate SSH keypair only if format or options mismatch
+  community.crypto.openssh_keypair:
+    path: /home/devops/.ssh/id_ed25519
+    type: ed25519
+    regenerate: full_idempotence
+    private_key_format: ssh
 
 - name: Generate an OpenSSH keypair with a different algorithm (dsa)
   community.crypto.openssh_keypair:

--- a/plugins/modules/openssh_keypair.py
+++ b/plugins/modules/openssh_keypair.py
@@ -158,6 +158,7 @@ EXAMPLES = r"""
   community.crypto.openssh_keypair:
     path: /tmp/id_ssh_rsa
     force: true
+
 - name: Regenerate SSH keypair only if format or options mismatch
   community.crypto.openssh_keypair:
     path: /home/devops/.ssh/id_ed25519


### PR DESCRIPTION
### SUMMARY
- Added task to generate Ed25519 SSH keypair at /home/devops/.ssh/id_ed25519
- Enforces OpenSSH private key format using private_key_format: ssh
- Uses regenerate: full_idempotence to only replace key when format or options mismatch

### ISSUE TYPE
Docs Pull Request

### COMPONENT NAME
community.crypto.openssh_keypair: