### PR TITLE
Remove unstable CI target

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -338,8 +338,8 @@ stages:
         parameters:
           testFormat: 2.18/{0}
           targets:
-            - name: macOS 14.3
-              test: macos/14.3
+            # - name: macOS 14.3
+            #   test: macos/14.3
             - name: FreeBSD 14.1
               test: freebsd/14.1
           groups:


### PR DESCRIPTION
##### SUMMARY
macOS with ansible-core 2.18 is extremely unstable and often timeouts at 50 minutes.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
