### PR TITLE
Use nox in AZP CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -49,378 +49,324 @@ resources:
 pool: Standard
 
 stages:
-### Sanity & units
-  - stage: Ansible_devel
-    displayName: Sanity & Units devel
+  - stage: sanity
+    displayName: Sanity
     dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
     jobs:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: Sanity
-              test: 'devel/sanity/1'
-            - name: Units
-              test: 'devel/units/1'
-  - stage: Ansible_2_21
-    displayName: Sanity & Units 2.21
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.21/sanity/1'
-            - name: Units
-              test: '2.21/units/1'
-  - stage: Ansible_2_20
-    displayName: Sanity & Units 2.20
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.20/sanity/1'
-            - name: Units
-              test: '2.20/units/1'
-  - stage: Ansible_2_19
-    displayName: Sanity & Units 2.19
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.19/sanity/1'
-            - name: Units
-              test: '2.19/units/1'
-  - stage: Ansible_2_18
-    displayName: Sanity & Units 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.18/sanity/1'
-            - name: Units
-              test: '2.18/units/1'
-### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/linux/{0}
-          targets:
-            - name: Fedora 44
-              test: fedora44
-            - name: Ubuntu 26.04
-              test: ubuntu2604
-            - name: Alpine 3.23
-              test: alpine323
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_21
-    displayName: Docker 2.21
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.21/linux/{0}
-          targets:
-            - name: Fedora 43
-              test: fedora43
-            - name: Ubuntu 24.04
-              test: ubuntu2404
-            # - name: Alpine 3.23
-            #   test: alpine323
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_20
-    displayName: Docker 2.20
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.20/linux/{0}
-          targets:
-            - name: Fedora 42
-              test: fedora42
-            - name: Ubuntu 22.04
-              test: ubuntu2204
-            - name: Alpine 3.22
-              test: alpine322
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_19
-    displayName: Docker 2.19
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.19/linux/{0}
-          targets:
-            - name: Fedora 41
-              test: fedora41
-            - name: Alpine 3.21
-              test: alpine321
-          groups:
-            - 1
-            - 2
-  - stage: Docker_2_18
-    displayName: Docker 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.18/linux/{0}
-          targets:
-            - name: Fedora 40
-              test: fedora40
-            - name: Ubuntu 24.04
-              test: ubuntu2404
-            - name: Alpine 3.20
-              test: alpine320
-          groups:
-            - 1
-            - 2
+            - name: "2.18"
+              test: ansible-test-sanity-2.18
+            - name: "2.19"
+              test: ansible-test-sanity-2.19
+            - name: "2.20"
+              test: ansible-test-sanity-2.20
+            - name: "2.21"
+              test: ansible-test-sanity-2.21
+            - name: devel
+              test: ansible-test-sanity-devel
 
-### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: units
+    displayName: Unit tests
     dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
           targets:
-            - name: Debian 13 Trixie
-              test: debian-13-trixie/3.13
-            - name: Debian 12 Bookworm
-              test: debian-bookworm/3.11
-            - name: Debian 11 Bullseye
-              test: debian-bullseye/3.9
-            - name: ArchLinux
-              test: archlinux/3.14
-          groups:
-            - 1
-            - 2
+            - name: "2.18"
+              test: ansible-test-units-2.18
+            - name: "2.19"
+              test: ansible-test-units-2.19
+            - name: "2.20"
+              test: ansible-test-units-2.20
+            - name: "2.21"
+              test: ansible-test-units-2.21
+            - name: devel
+              test: ansible-test-units-devel
 
-### Remote
-  - stage: Remote_devel_extra_vms
-    displayName: Remote devel extra VMs
+  - stage: docker_2_18
+    displayName: Docker ansible-core 2.18
     dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
           targets:
-            - name: Alpine 3.23
-              test: alpine/3.23
-            - name: Fedora 44
-              test: fedora/44
-            - name: Ubuntu 26.04
-              test: ubuntu/26.04
-            - name: Ubuntu 24.04
-              test: ubuntu/24.04
-          groups:
-            - vm
-  - stage: Remote_devel
-    displayName: Remote devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/{0}
-          targets:
-            - name: macOS 26.3
-              test: macos/26.3
-            - name: RHEL 10.1
-              test: rhel/10.1
-            - name: RHEL 9.7
-              test: rhel/9.7
-            - name: FreeBSD 15.0
-              test: freebsd/15.0
-            - name: FreeBSD 14.4
-              test: freebsd/14.4
-          groups:
-            - 1
-            - 2
-  - stage: Remote_2_21
-    displayName: Remote 2.21
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.21/{0}
-          targets:
-            # - name: macOS 26.3
-            #   test: macos/26.3
-            - name: RHEL 10.1
-              test: rhel/10.1
-            # - name: RHEL 9.7
-            #   test: rhel/9.7
-            # - name: FreeBSD 15.0
-            #   test: freebsd/15.0
-            # - name: FreeBSD 14.4
-            #   test: freebsd/14.4
-          groups:
-            - 1
-            - 2
-  - stage: Remote_2_20
-    displayName: Remote 2.20
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.20/{0}
-          targets:
-            - name: macOS 15.3
-              test: macos/15.3
-            - name: RHEL 9.7
-              test: rhel/9.7
-            - name: FreeBSD 14.3
-              test: freebsd/14.3
-          groups:
-            - 1
-            - 2
-  - stage: Remote_2_19
-    displayName: Remote 2.19
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.19/{0}
-          targets:
-            - name: RHEL 10.1
-              test: rhel/10.1
-            - name: FreeBSD 14.2
-              test: freebsd/14.2
-          groups:
-            - 1
-            - 2
-  - stage: Remote_2_18
-    displayName: Remote 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.18/{0}
-          targets:
-            # - name: macOS 14.3
-            #   test: macos/14.3
-            - name: FreeBSD 14.1
-              test: freebsd/14.1
-          groups:
-            - 1
-            - 2
-### Generic
-  - stage: Generic_devel
-    displayName: Generic devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: devel/generic/{0}
-          targets:
-            - test: "3.9"
-            - test: "3.10"
-            - test: "3.11"
-            - test: "3.13"
-            - test: "3.14"
-            - test: "3.15"
-          groups:
-            - 1
-            - 2
-  - stage: Generic_2_21
-    displayName: Generic 2.21
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.21/generic/{0}
-          targets:
-            - test: "3.11"
-            - test: "3.14"
-          groups:
-            - 1
-            - 2
-  - stage: Generic_2_20
-    displayName: Generic 2.20
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.20/generic/{0}
-          targets:
-            - test: "3.10"
-            - test: "3.14"
-          groups:
-            - 1
-            - 2
-  - stage: Generic_2_19
-    displayName: Generic 2.19
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.19/generic/{0}
-          targets:
-            - test: "3.9"
-            - test: "3.13"
-          groups:
-            - 1
-            - 2
-  - stage: Generic_2_18
-    displayName: Generic 2.18
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.18/generic/{0}
-          targets:
-            - test: "3.8"
-            - test: "3.13"
-          groups:
-            - 1
-            - 2
+            - name: alpine320 + azp/posix/1/
+              test: ansible-test-integration-2.18-alpine320-azp-posix-1
+            - name: alpine320 + azp/posix/2/
+              test: ansible-test-integration-2.18-alpine320-azp-posix-2
+            - name: default + py3.13 + azp/generic/1/
+              test: ansible-test-integration-2.18-default-3.13-azp-generic-1
+            - name: default + py3.13 + azp/generic/2/
+              test: ansible-test-integration-2.18-default-3.13-azp-generic-2
+            - name: default + py3.8 + azp/generic/1/
+              test: ansible-test-integration-2.18-default-3.8-azp-generic-1
+            - name: default + py3.8 + azp/generic/2/
+              test: ansible-test-integration-2.18-default-3.8-azp-generic-2
+            - name: fedora40 + azp/posix/1/
+              test: ansible-test-integration-2.18-fedora40-azp-posix-1
+            - name: fedora40 + azp/posix/2/
+              test: ansible-test-integration-2.18-fedora40-azp-posix-2
+            - name: ubuntu2204 + azp/posix/1/
+              test: ansible-test-integration-2.18-ubuntu2204-azp-posix-1
+            - name: ubuntu2204 + azp/posix/2/
+              test: ansible-test-integration-2.18-ubuntu2204-azp-posix-2
 
-  ## Finally
+  - stage: docker_2_19
+    displayName: Docker ansible-core 2.19
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: alpine321 + azp/posix/1/
+              test: ansible-test-integration-2.19-alpine321-azp-posix-1
+            - name: alpine321 + azp/posix/2/
+              test: ansible-test-integration-2.19-alpine321-azp-posix-2
+            - name: default + py3.13 + azp/generic/1/
+              test: ansible-test-integration-2.19-default-3.13-azp-generic-1
+            - name: default + py3.13 + azp/generic/2/
+              test: ansible-test-integration-2.19-default-3.13-azp-generic-2
+            - name: default + py3.9 + azp/generic/1/
+              test: ansible-test-integration-2.19-default-3.9-azp-generic-1
+            - name: default + py3.9 + azp/generic/2/
+              test: ansible-test-integration-2.19-default-3.9-azp-generic-2
+            - name: fedora41 + azp/posix/1/
+              test: ansible-test-integration-2.19-fedora41-azp-posix-1
+            - name: fedora41 + azp/posix/2/
+              test: ansible-test-integration-2.19-fedora41-azp-posix-2
+
+  - stage: docker_2_20
+    displayName: Docker ansible-core 2.20
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: alpine322 + azp/posix/1/
+              test: ansible-test-integration-2.20-alpine322-azp-posix-1
+            - name: alpine322 + azp/posix/2/
+              test: ansible-test-integration-2.20-alpine322-azp-posix-2
+            - name: default + py3.10 + azp/generic/1/
+              test: ansible-test-integration-2.20-default-3.10-azp-generic-1
+            - name: default + py3.10 + azp/generic/2/
+              test: ansible-test-integration-2.20-default-3.10-azp-generic-2
+            - name: default + py3.14 + azp/generic/1/
+              test: ansible-test-integration-2.20-default-3.14-azp-generic-1
+            - name: default + py3.14 + azp/generic/2/
+              test: ansible-test-integration-2.20-default-3.14-azp-generic-2
+            - name: fedora42 + azp/posix/1/
+              test: ansible-test-integration-2.20-fedora42-azp-posix-1
+            - name: fedora42 + azp/posix/2/
+              test: ansible-test-integration-2.20-fedora42-azp-posix-2
+            - name: ubuntu2204 + azp/posix/1/
+              test: ansible-test-integration-2.20-ubuntu2204-azp-posix-1
+            - name: ubuntu2204 + azp/posix/2/
+              test: ansible-test-integration-2.20-ubuntu2204-azp-posix-2
+
+  - stage: docker_2_21
+    displayName: Docker ansible-core 2.21
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: default + py3.11 + azp/generic/1/
+              test: ansible-test-integration-2.21-default-3.11-azp-generic-1
+            - name: default + py3.11 + azp/generic/2/
+              test: ansible-test-integration-2.21-default-3.11-azp-generic-2
+            - name: default + py3.14 + azp/generic/1/
+              test: ansible-test-integration-2.21-default-3.14-azp-generic-1
+            - name: default + py3.14 + azp/generic/2/
+              test: ansible-test-integration-2.21-default-3.14-azp-generic-2
+            - name: fedora43 + azp/posix/1/
+              test: ansible-test-integration-2.21-fedora43-azp-posix-1
+            - name: fedora43 + azp/posix/2/
+              test: ansible-test-integration-2.21-fedora43-azp-posix-2
+            - name: ubuntu2404 + azp/posix/1/
+              test: ansible-test-integration-2.21-ubuntu2404-azp-posix-1
+            - name: ubuntu2404 + azp/posix/2/
+              test: ansible-test-integration-2.21-ubuntu2404-azp-posix-2
+
+  - stage: docker_devel
+    displayName: Docker ansible-core devel
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: alpine323 + azp/posix/1/
+              test: ansible-test-integration-devel-alpine323-azp-posix-1
+            - name: alpine323 + azp/posix/2/
+              test: ansible-test-integration-devel-alpine323-azp-posix-2
+            - name: archlinux + py3.14 + azp/posix/1/
+              test: ansible-test-integration-devel-archlinux-3.14-azp-posix-1
+            - name: archlinux + py3.14 + azp/posix/2/
+              test: ansible-test-integration-devel-archlinux-3.14-azp-posix-2
+            - name: debian-13-trixie + py3.13 + azp/posix/1/
+              test: ansible-test-integration-devel-debian-13-trixie-3.13-azp-posix-1
+            - name: debian-13-trixie + py3.13 + azp/posix/2/
+              test: ansible-test-integration-devel-debian-13-trixie-3.13-azp-posix-2
+            - name: debian-bookworm + py3.11 + azp/posix/1/
+              test: ansible-test-integration-devel-debian-bookworm-3.11-azp-posix-1
+            - name: debian-bookworm + py3.11 + azp/posix/2/
+              test: ansible-test-integration-devel-debian-bookworm-3.11-azp-posix-2
+            - name: debian-bullseye + py3.9 + azp/posix/1/
+              test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-1
+            - name: debian-bullseye + py3.9 + azp/posix/2/
+              test: ansible-test-integration-devel-debian-bullseye-3.9-azp-posix-2
+            - name: default + py3.12 + azp/generic/1/
+              test: ansible-test-integration-devel-default-3.12-azp-generic-1
+            - name: default + py3.12 + azp/generic/2/
+              test: ansible-test-integration-devel-default-3.12-azp-generic-2
+            - name: default + py3.15 + azp/generic/1/
+              test: ansible-test-integration-devel-default-3.15-azp-generic-1
+            - name: default + py3.15 + azp/generic/2/
+              test: ansible-test-integration-devel-default-3.15-azp-generic-2
+            - name: fedora44 + azp/posix/1/
+              test: ansible-test-integration-devel-fedora44-azp-posix-1
+            - name: fedora44 + azp/posix/2/
+              test: ansible-test-integration-devel-fedora44-azp-posix-2
+            - name: ubuntu2604 + azp/posix/1/
+              test: ansible-test-integration-devel-ubuntu2604-azp-posix-1
+            - name: ubuntu2604 + azp/posix/2/
+              test: ansible-test-integration-devel-ubuntu2604-azp-posix-2
+
+  - stage: remote_2_18
+    displayName: Remote ansible-core 2.18
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: freebsd/14.1 + azp/posix/1/
+              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-1
+            - name: freebsd/14.1 + azp/posix/2/
+              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-2
+
+  - stage: remote_2_19
+    displayName: Remote ansible-core 2.19
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: freebsd/14.2 + azp/posix/1/
+              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-1
+            - name: freebsd/14.2 + azp/posix/2/
+              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-2
+            - name: rhel/10.1 + azp/posix/1/
+              test: ansible-test-integration-2.19-rhel-10.1-azp-posix-1
+            - name: rhel/10.1 + azp/posix/2/
+              test: ansible-test-integration-2.19-rhel-10.1-azp-posix-2
+
+  - stage: remote_2_20
+    displayName: Remote ansible-core 2.20
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: freebsd/14.3 + azp/posix/1/
+              test: ansible-test-integration-2.20-freebsd-14.3-azp-posix-1
+            - name: freebsd/14.3 + azp/posix/2/
+              test: ansible-test-integration-2.20-freebsd-14.3-azp-posix-2
+            - name: macos/15.3 + azp/posix/1/
+              test: ansible-test-integration-2.20-macos-15.3-azp-posix-1
+            - name: macos/15.3 + azp/posix/2/
+              test: ansible-test-integration-2.20-macos-15.3-azp-posix-2
+            - name: rhel/9.7 + azp/posix/1/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-posix-1
+            - name: rhel/9.7 + azp/posix/2/
+              test: ansible-test-integration-2.20-rhel-9.7-azp-posix-2
+
+  - stage: remote_2_21
+    displayName: Remote ansible-core 2.21
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: rhel/10.1 + azp/posix/1/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-posix-1
+            - name: rhel/10.1 + azp/posix/2/
+              test: ansible-test-integration-2.21-rhel-10.1-azp-posix-2
+
+  - stage: remote_devel
+    displayName: Remote ansible-core devel
+    dependsOn: []
+    variables:
+      entryPoint: tests/utils/shippable/nox.sh
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: alpine/3.23 + azp/posix/vm/
+              test: ansible-test-integration-devel-alpine-3.23-azp-posix-vm
+            - name: fedora/44 + azp/posix/vm/
+              test: ansible-test-integration-devel-fedora-44-azp-posix-vm
+            - name: freebsd/14.4 + azp/posix/1/
+              test: ansible-test-integration-devel-freebsd-14.4-azp-posix-1
+            - name: freebsd/14.4 + azp/posix/2/
+              test: ansible-test-integration-devel-freebsd-14.4-azp-posix-2
+            - name: freebsd/15.0 + azp/posix/1/
+              test: ansible-test-integration-devel-freebsd-15.0-azp-posix-1
+            - name: freebsd/15.0 + azp/posix/2/
+              test: ansible-test-integration-devel-freebsd-15.0-azp-posix-2
+            - name: macos/26.3 + azp/posix/1/
+              test: ansible-test-integration-devel-macos-26.3-azp-posix-1
+            - name: macos/26.3 + azp/posix/2/
+              test: ansible-test-integration-devel-macos-26.3-azp-posix-2
+            - name: rhel/10.1 + azp/posix/1/
+              test: ansible-test-integration-devel-rhel-10.1-azp-posix-1
+            - name: rhel/10.1 + azp/posix/2/
+              test: ansible-test-integration-devel-rhel-10.1-azp-posix-2
+            - name: rhel/9.7 + azp/posix/1/
+              test: ansible-test-integration-devel-rhel-9.7-azp-posix-1
+            - name: rhel/9.7 + azp/posix/2/
+              test: ansible-test-integration-devel-rhel-9.7-azp-posix-2
+            - name: ubuntu/24.04 + azp/posix/vm/
+              test: ansible-test-integration-devel-ubuntu-24.04-azp-posix-vm
+            - name: ubuntu/26.04 + azp/posix/vm/
+              test: ansible-test-integration-devel-ubuntu-26.04-azp-posix-vm
 
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Ansible_devel
-      - Ansible_2_21
-      - Ansible_2_20
-      - Ansible_2_19
-      - Ansible_2_18
-      - Remote_devel_extra_vms
-      - Remote_devel
-      - Remote_2_21
-      - Remote_2_20
-      - Remote_2_19
-      - Remote_2_18
-      - Docker_devel
-      - Docker_2_21
-      - Docker_2_20
-      - Docker_2_19
-      - Docker_2_18
-      - Docker_community_devel
-      - Generic_devel
-      - Generic_2_21
-      - Generic_2_20
-      - Generic_2_19
-      - Generic_2_18
+      - sanity
+      - units
+      - docker_2_18
+      - docker_2_19
+      - docker_2_20
+      - docker_2_21
+      - docker_devel
+      - remote_2_18
+      - remote_2_19
+      - remote_2_20
+      - remote_2_21
+      - remote_devel
     jobs:
       - template: templates/coverage.yml

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -105,6 +105,7 @@ include_devel = true
 session_name_template = "ansible-test-integration-{ansible_core}{dash_docker_short}{dash_remote}{dash_python_version}{dash_target_dashized}"
 display_name_template = "Ⓐ{ansible_core}{plus_docker_short}{plus_remote}{plus_py_python_version}{plus_target}"
 description_template = "Run integration tests with ansible-core {ansible_core}{comma_docker_short}{comma_remote}{comma_py_python_version}{comma_target}"
+retry_on_error = "in-ci"
 
 ##################################################################################################
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,6 +12,7 @@ import nox
 
 try:
     import antsibull_nox
+    from antsibull_nox.cli import run as run_antsibull_nox
 except ImportError:
     print("You need to install antsibull-nox in the same Python environment as nox.")
     sys.exit(1)
@@ -31,6 +32,22 @@ def create_certificates(session: nox.Session) -> None:
         "Note that you need to modify some values in tests/integration/targets/x509_certificate_info/tasks/impl.yml"
         " and tests/integration/targets/filter_x509_certificate_info/tasks/impl.yml!"
     )
+
+
+@nox.session(name="update-azp-config", python=False)
+def update_azp_config(session: nox.Session) -> None:
+    command = [
+        "antsibull-nox",
+        "update-azp-config",
+        "--min-ansible-core",
+        "2.18",
+    ]
+    if antsibull_nox.IN_CI:
+        command.append("--fail-on-change")
+    session.debug(" ".join(command))
+    result = run_antsibull_nox(command)
+    if result != 0:
+        session.fail(f"Execution failed with status code {result}")
 
 
 # Allow to run the noxfile with `python noxfile.py`, `pipx run noxfile.py`, or similar.

--- a/tests/utils/shippable/nox.sh
+++ b/tests/utils/shippable/nox.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -o pipefail -eux
+
+nox_session="$1"
+
+docker images ansible/ansible
+docker images quay.io/ansible/*
+docker ps
+
+for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v -e '^drydock/' -e '^quay.io/ansible/azure-pipelines-test-container:' | sed 's/^.* //'); do
+    docker rm -f "${container}" || true  # ignore errors
+done
+
+docker ps
+command -v python
+python -V
+
+function retry
+{
+    # shellcheck disable=SC2034
+    for repetition in 1 2 3; do
+        set +e
+        "$@"
+        result=$?
+        set -e
+        if [ ${result} == 0 ]; then
+            return ${result}
+        fi
+        echo "@* -> ${result}"
+    done
+    echo "Command '@*' failed 3 times!"
+    exit 255
+}
+
+command -v pip
+pip --version
+pip list --disable-pip-version-check
+retry pip install https://github.com/ansible-community/antsibull-nox/archive/main.tar.gz --disable-pip-version-check
+
+export PYTHONIOENCODING='utf-8'
+
+if [ -n "${COVERAGE:-}" ]; then
+    # on-demand coverage reporting triggered by setting the COVERAGE environment variable to a non-empty value
+    export COVERAGE="--coverage"
+elif [[ "${COMMIT_MESSAGE}" =~ ci_coverage ]]; then
+    # on-demand coverage reporting triggered by having 'ci_coverage' in the latest commit message
+    export COVERAGE="--coverage"
+else
+    # on-demand coverage reporting disabled (default behavior, always-on coverage reporting remains enabled)
+    export COVERAGE="--coverage-check"
+fi
+
+if [ -n "${COMPLETE:-}" ]; then
+    # disable change detection triggered by setting the COMPLETE environment variable to a non-empty value
+    export ANTSIBULL_CHANGE_DETECTION=""
+elif [[ "${COMMIT_MESSAGE}" =~ ci_complete ]]; then
+    # disable change detection triggered by having 'ci_complete' in the latest commit message
+    export ANTSIBULL_CHANGE_DETECTION=""
+else
+    # enable change detection (default behavior)
+    export ANTSIBULL_CHANGE_DETECTION="true"
+    export ANTSIBULL_BASE_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    # Create a branch for the current HEAD, which happens to be a merge commit
+    git checkout -b "pull-request-branch"
+    # Name the target branch
+    git branch "${SYSTEM_PULLREQUEST_TARGETBRANCH}" --track "origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    # Show branches
+    git branch -vv
+fi
+
+if [[ "${COVERAGE:-}" == "--coverage" ]]; then
+    export ANTSIBULL_NOX_TIMEOUT=60
+else
+    export ANTSIBULL_NOX_TIMEOUT=50
+fi
+
+export FORCE_COLOR=1
+export ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS="true"
+export ANTSIBULL_NOX_ALWAYS_COPY_REPO_STRUCTURE="true"  # https://github.com/ansible/ansible/issues/87052
+
+nox -e "${nox_session}" -- ${COVERAGE}


### PR DESCRIPTION
##### SUMMARY
Also generate the AZP matrix with nox, so antsibull-nox.toml is the full source of truth for CI.

Uses https://github.com/ansible-community/antsibull-nox/pull/200 for updating the CI config, https://github.com/ansible-community/antsibull-nox/pull/201 for `--retry-on-error` support, and https://github.com/ansible-community/antsibull-nox/pull/203 to make antsibull-nox recognize AZP.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
