### PR TITLE
CI: Move ansible-core 2.18 to GHA; remove FreeBSD 14.[12] from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -222,10 +222,6 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: FreeBSD 14.2 + group 1
-              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-1
-            - name: FreeBSD 14.2 + group 2
-              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-2
             - name: RHEL 10.1 + group 1
               test: ansible-test-integration-2.19-rhel-10.1-azp-posix-1
             - name: RHEL 10.1 + group 2

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -86,7 +86,7 @@ stages:
               test: ansible-test-units-devel
 
   - stage: docker_2_19
-    displayName: Docker ansible-core 2.19
+    displayName: Docker 2.19
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -112,7 +112,7 @@ stages:
               test: ansible-test-integration-2.19-fedora41-azp-posix-2
 
   - stage: docker_2_20
-    displayName: Docker ansible-core 2.20
+    displayName: Docker 2.20
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -142,7 +142,7 @@ stages:
               test: ansible-test-integration-2.20-ubuntu2204-azp-posix-2
 
   - stage: docker_2_21
-    displayName: Docker ansible-core 2.21
+    displayName: Docker 2.21
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -168,7 +168,7 @@ stages:
               test: ansible-test-integration-2.21-ubuntu2404-azp-posix-2
 
   - stage: docker_devel
-    displayName: Docker ansible-core devel
+    displayName: Docker devel
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -214,7 +214,7 @@ stages:
               test: ansible-test-integration-devel-ubuntu2604-azp-posix-2
 
   - stage: remote_2_19
-    displayName: Remote ansible-core 2.19
+    displayName: Remote 2.19
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -232,7 +232,7 @@ stages:
               test: ansible-test-integration-2.19-rhel-10.1-azp-posix-2
 
   - stage: remote_2_20
-    displayName: Remote ansible-core 2.20
+    displayName: Remote 2.20
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -254,7 +254,7 @@ stages:
               test: ansible-test-integration-2.20-rhel-9.7-azp-posix-2
 
   - stage: remote_2_21
-    displayName: Remote ansible-core 2.21
+    displayName: Remote 2.21
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -268,7 +268,7 @@ stages:
               test: ansible-test-integration-2.21-rhel-10.1-azp-posix-2
 
   - stage: remote_devel
-    displayName: Remote ansible-core devel
+    displayName: Remote devel
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -58,8 +58,6 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: ansible-core 2.18
-              test: ansible-test-sanity-2.18
             - name: ansible-core 2.19
               test: ansible-test-sanity-2.19
             - name: ansible-core 2.20
@@ -78,8 +76,6 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: ansible-core 2.18
-              test: ansible-test-units-2.18
             - name: ansible-core 2.19
               test: ansible-test-units-2.19
             - name: ansible-core 2.20
@@ -88,36 +84,6 @@ stages:
               test: ansible-test-units-2.21
             - name: ansible-core devel
               test: ansible-test-units-devel
-
-  - stage: docker_2_18
-    displayName: Docker ansible-core 2.18
-    dependsOn: []
-    variables:
-      entryPoint: tests/utils/shippable/nox.sh
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Alpine 3.20 + group 1
-              test: ansible-test-integration-2.18-alpine320-azp-posix-1
-            - name: Alpine 3.20 + group 2
-              test: ansible-test-integration-2.18-alpine320-azp-posix-2
-            - name: Generic + py3.13 + group 1
-              test: ansible-test-integration-2.18-default-3.13-azp-generic-1
-            - name: Generic + py3.13 + group 2
-              test: ansible-test-integration-2.18-default-3.13-azp-generic-2
-            - name: Generic + py3.8 + group 1
-              test: ansible-test-integration-2.18-default-3.8-azp-generic-1
-            - name: Generic + py3.8 + group 2
-              test: ansible-test-integration-2.18-default-3.8-azp-generic-2
-            - name: Fedora 40 + group 1
-              test: ansible-test-integration-2.18-fedora40-azp-posix-1
-            - name: Fedora 40 + group 2
-              test: ansible-test-integration-2.18-fedora40-azp-posix-2
-            - name: Ubuntu 22.04 + group 1
-              test: ansible-test-integration-2.18-ubuntu2204-azp-posix-1
-            - name: Ubuntu 22.04 + group 2
-              test: ansible-test-integration-2.18-ubuntu2204-azp-posix-2
 
   - stage: docker_2_19
     displayName: Docker ansible-core 2.19
@@ -247,20 +213,6 @@ stages:
             - name: Ubuntu 26.04 + group 2
               test: ansible-test-integration-devel-ubuntu2604-azp-posix-2
 
-  - stage: remote_2_18
-    displayName: Remote ansible-core 2.18
-    dependsOn: []
-    variables:
-      entryPoint: tests/utils/shippable/nox.sh
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: FreeBSD 14.1 + group 1
-              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-1
-            - name: FreeBSD 14.1 + group 2
-              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-2
-
   - stage: remote_2_19
     displayName: Remote ansible-core 2.19
     dependsOn: []
@@ -358,12 +310,10 @@ stages:
     dependsOn:
       - sanity
       - units
-      - docker_2_18
       - docker_2_19
       - docker_2_20
       - docker_2_21
       - docker_devel
-      - remote_2_18
       - remote_2_19
       - remote_2_20
       - remote_2_21

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -36,6 +36,6 @@ jobs:
       upload-codecov-push: false
       upload-codecov-schedule: true
       allow-coverage-cd-override: true
-      max-ansible-core: "2.17"
+      max-ansible-core: "2.18"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -161,7 +161,7 @@ ansible_core = "2.18"
 target = [ "azp/posix/1/", "azp/posix/2/" ]
 remote = [
     # "macos/14.3",
-    "freebsd/14.1"
+    # "freebsd/14.1"
 ]
 
 # Ansible-core 2.19:
@@ -184,7 +184,10 @@ python_version = [ "3.9", "3.13" ]
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.19"
 target = [ "azp/posix/1/", "azp/posix/2/" ]
-remote = [ "rhel/10.1", "freebsd/14.2" ]
+remote = [
+    "rhel/10.1",
+    # "freebsd/14.2",
+]
 
 # Ansible-core 2.20:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ def update_azp_config(session: nox.Session) -> None:
         "antsibull-nox",
         "update-azp-config",
         "--min-ansible-core",
-        "2.18",
+        "2.19",
     ]
     if antsibull_nox.IN_CI:
         command.append("--fail-on-change")


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.18 is now EOL.
FreeBSD 14.1 and 14.2 seem to be EOL as well, package information is no longer available.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
