### PR TITLE
[stable-2] CI: Move ansible-core 2.18 to GHA; remove FreeBSD 14.[12] from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -58,8 +58,6 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: ansible-core 2.18
-              test: ansible-test-sanity-2.18
             - name: ansible-core 2.19
               test: ansible-test-sanity-2.19
 
@@ -72,40 +70,8 @@ stages:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: ansible-core 2.18
-              test: ansible-test-units-2.18
             - name: ansible-core 2.19
               test: ansible-test-units-2.19
-
-  - stage: docker_2_18
-    displayName: Docker ansible-core 2.18
-    dependsOn: []
-    variables:
-      entryPoint: tests/utils/shippable/nox.sh
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Alpine 3.20 + group 1
-              test: ansible-test-integration-2.18-alpine320-azp-posix-1
-            - name: Alpine 3.20 + group 2
-              test: ansible-test-integration-2.18-alpine320-azp-posix-2
-            - name: Generic + py3.13 + group 1
-              test: ansible-test-integration-2.18-default-3.13-azp-generic-1
-            - name: Generic + py3.13 + group 2
-              test: ansible-test-integration-2.18-default-3.13-azp-generic-2
-            - name: Generic + py3.8 + group 1
-              test: ansible-test-integration-2.18-default-3.8-azp-generic-1
-            - name: Generic + py3.8 + group 2
-              test: ansible-test-integration-2.18-default-3.8-azp-generic-2
-            - name: Fedora 40 + group 1
-              test: ansible-test-integration-2.18-fedora40-azp-posix-1
-            - name: Fedora 40 + group 2
-              test: ansible-test-integration-2.18-fedora40-azp-posix-2
-            - name: Ubuntu 24.04 + group 1
-              test: ansible-test-integration-2.18-ubuntu2404-azp-posix-1
-            - name: Ubuntu 24.04 + group 2
-              test: ansible-test-integration-2.18-ubuntu2404-azp-posix-2
 
   - stage: docker_2_19
     displayName: Docker ansible-core 2.19
@@ -149,24 +115,6 @@ stages:
             - name: Ubuntu 24.04 + group 2
               test: ansible-test-integration-2.19-ubuntu2404-azp-posix-2
 
-  - stage: remote_2_18
-    displayName: Remote ansible-core 2.18
-    dependsOn: []
-    variables:
-      entryPoint: tests/utils/shippable/nox.sh
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: FreeBSD 14.1 + group 1
-              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-1
-            - name: FreeBSD 14.1 + group 2
-              test: ansible-test-integration-2.18-freebsd-14.1-azp-posix-2
-            - name: macOS 14.3 + group 1
-              test: ansible-test-integration-2.18-macos-14.3-azp-posix-1
-            - name: macOS 14.3 + group 2
-              test: ansible-test-integration-2.18-macos-14.3-azp-posix-2
-
   - stage: remote_2_19
     displayName: Remote ansible-core 2.19
     dependsOn: []
@@ -206,9 +154,7 @@ stages:
     dependsOn:
       - sanity
       - units
-      - docker_2_18
       - docker_2_19
-      - remote_2_18
       - remote_2_19
     jobs:
       - template: templates/coverage.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
               test: ansible-test-units-2.19
 
   - stage: docker_2_19
-    displayName: Docker ansible-core 2.19
+    displayName: Docker 2.19
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh
@@ -116,7 +116,7 @@ stages:
               test: ansible-test-integration-2.19-ubuntu2404-azp-posix-2
 
   - stage: remote_2_19
-    displayName: Remote ansible-core 2.19
+    displayName: Remote 2.19
     dependsOn: []
     variables:
       entryPoint: tests/utils/shippable/nox.sh

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -132,10 +132,6 @@ stages:
               test: ansible-test-integration-2.19-freebsd-13.5-azp-posix-1
             - name: FreeBSD 13.5 + group 2
               test: ansible-test-integration-2.19-freebsd-13.5-azp-posix-2
-            - name: FreeBSD 14.2 + group 1
-              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-1
-            - name: FreeBSD 14.2 + group 2
-              test: ansible-test-integration-2.19-freebsd-14.2-azp-posix-2
             - name: RHEL 10.1 + group 1
               test: ansible-test-integration-2.19-rhel-10.1-azp-posix-1
             - name: RHEL 10.1 + group 2

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -36,4 +36,6 @@ jobs:
       upload-codecov-push: false
       upload-codecov-schedule: true
       allow-coverage-cd-override: true
-      max-ansible-core: "2.17"
+      max-ansible-core: "2.18"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -284,7 +284,7 @@ ansible_core = "2.18"
 target = [ "azp/posix/1/", "azp/posix/2/" ]
 remote = [
     "macos/14.3",
-    "freebsd/14.1"
+    # "freebsd/14.1"
 ]
 
 # Ansible-core 2.19:
@@ -336,7 +336,7 @@ target = [ "azp/posix/1/", "azp/posix/2/" ]
 remote = [
     "rhel/10.1",
     "rhel/9.7",
-    "freebsd/14.2",
+    # "freebsd/14.2",
     "freebsd/13.5",
 ]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def update_azp_config(session: nox.Session) -> None:
         "antsibull-nox",
         "update-azp-config",
         "--min-ansible-core",
-        "2.18",
+        "2.19",
     ]
     if antsibull_nox.IN_CI:
         command.append("--fail-on-change")


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.18 is now EOL.
FreeBSD 14.1 and 14.2 seem to be EOL as well, package information is no longer available.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
