### PR TITLE
Avoid unsupported private key types

### DIFF
--- a/changelogs/fragments/1044-pqc.yml
+++ b/changelogs/fragments/1044-pqc.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "openssh_* modules - prevent use of currently unsupported MLDSA private keys in the cryptography backend (https://github.com/ansible-collections/community.crypto/pull/1044)."
+  - "openssl_pkcs12 - prevent use of MLDSA private keys, which are not supported by PKCS#12, or at least cryptography's implementation (https://github.com/ansible-collections/community.crypto/pull/1044)."

--- a/plugins/module_utils/_openssh/cryptography.py
+++ b/plugins/module_utils/_openssh/cryptography.py
@@ -68,11 +68,32 @@ except ImportError:
     CRYPTOGRAPHY_VERSION = "0.0"
     _ALGORITHM_PARAMETERS = {}
 
+try:
+    from cryptography.hazmat.primitives.asymmetric.mldsa import (
+        MLDSA44PrivateKey,
+        MLDSA65PrivateKey,
+        MLDSA87PrivateKey,
+    )
+
+    HAS_MLDSA_SUPPORT = True
+except ImportError:  # pragma: no cover
+
+    class MLDSA44PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    class MLDSA65PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    class MLDSA87PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    HAS_MLDSA_SUPPORT = False
+
 from ansible_collections.community.crypto.plugins.module_utils._crypto.cryptography_support import (
     is_potential_certificate_issuer_private_key,
 )
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     KeyFormat = t.Literal["SSH", "PKCS8", "PKCS1"]  # pragma: no cover
     KeySerializationFormat = t.Literal["PEM", "DER", "SSH"]  # pragma: no cover
     KeyType = t.Literal["rsa", "dsa", "ed25519", "ecdsa"]  # pragma: no cover
@@ -703,6 +724,17 @@ def load_privatekey(
 
     if not is_potential_certificate_issuer_private_key(privatekey) or isinstance(
         privatekey, Ed448PrivateKey
+    ):
+        raise InvalidPrivateKeyFileError(
+            f"{privatekey} is not a supported private key type"
+        )
+    if isinstance(
+        privatekey,
+        (
+            MLDSA44PrivateKey,
+            MLDSA65PrivateKey,
+            MLDSA87PrivateKey,
+        ),
     ):
         raise InvalidPrivateKeyFileError(
             f"{privatekey} is not a supported private key type"

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -316,6 +316,27 @@ try:
 except ImportError:
     pass
 
+try:
+    from cryptography.hazmat.primitives.asymmetric.mldsa import (
+        MLDSA44PrivateKey,
+        MLDSA65PrivateKey,
+        MLDSA87PrivateKey,
+    )
+
+    HAS_MLDSA_SUPPORT = True
+except ImportError:  # pragma: no cover
+
+    class MLDSA44PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    class MLDSA65PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    class MLDSA87PrivateKey:  # type: ignore[no-redef]
+        pass
+
+    HAS_MLDSA_SUPPORT = False
+
 CRYPTOGRAPHY_COMPATIBILITY2022_ERR: str | None
 try:
     import cryptography.x509
@@ -334,13 +355,13 @@ else:
     CRYPTOGRAPHY_COMPATIBILITY2022_ERR = None  # pylint: disable=invalid-name
     CRYPTOGRAPHY_HAS_COMPATIBILITY2022 = True
 
-if t.TYPE_CHECKING:
-    from ansible_collections.community.crypto.plugins.module_utils._crypto.cryptography_support import (  # pragma: no cover
-        CertificateIssuerPrivateKeyTypes,
+if t.TYPE_CHECKING:  # pragma: no cover
+    from cryptography.hazmat.primitives.serialization.pkcs12 import (
+        PKCS12PrivateKeyTypes,
     )
 
     PKCS12 = tuple[
-        t.Union[CertificateIssuerPrivateKeyTypes, None],  # noqa: UP007
+        t.Union[PKCS12PrivateKeyTypes, None],  # noqa: UP007
         t.Union[cryptography.x509.Certificate, None],  # noqa: UP007
         list[cryptography.x509.Certificate],
         t.Union[bytes, None],  # noqa: UP007
@@ -463,15 +484,27 @@ class Pkcs(OpenSSLObject):
 
     def generate_bytes(self, module: AnsibleModule) -> bytes:
         """Generate PKCS#12 file archive."""
-        pkey = None
+        pkey: PKCS12PrivateKeyTypes | None = None
         if self.privatekey_content:
             try:
-                pkey = load_certificate_issuer_privatekey(
+                private_key = load_certificate_issuer_privatekey(
                     content=self.privatekey_content,
                     passphrase=self.privatekey_passphrase,
                 )
             except OpenSSLBadPassphraseError as exc:
                 raise PkcsError(exc) from exc
+
+            if isinstance(
+                private_key,
+                (
+                    MLDSA44PrivateKey,
+                    MLDSA65PrivateKey,
+                    MLDSA87PrivateKey,
+                ),
+            ):
+                raise PkcsError(f"{private_key} is not a supported private key type")
+
+            pkey = private_key
 
         cert = None
         if self.certificate_content:


### PR DESCRIPTION
##### SUMMARY
Right now the typing tests fail because of this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
loading private keys for OpenSSH certs and PKCS12 files
