### PR TITLE
[stable-2] CI: Restrict pyOpenSSL on FreeBSD

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -13,6 +13,6 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyopenssl < 22.0.0 ; python_version < '3.6' # pyOpenSSL 22.0.0 and later require python 3.6 or later
-pyopenssl < 26.3.0 ; sys_platform == 'freebsd13'  # 26.3.0 requires cryptography 46.0.0+, which tries to install the latest cryptography, which needs a Rust compiler to be installed
+pyopenssl < 26.3.0 ; 'freebsd' in sys_platform  # 26.3.0 requires cryptography 46.0.0+, which tries to install the latest cryptography, which needs a Rust compiler to be installed
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -13,6 +13,6 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyopenssl < 22.0.0 ; python_version < '3.6' # pyOpenSSL 22.0.0 and later require python 3.6 or later
-pyopenssl < 26.3.0 ; sys_platform == 'freebsd'  # 26.3.0 requires cryptography 46.0.0+, which tries to install the latest cryptography, which needs a Rust compiler to be installed
+pyopenssl < 26.3.0 ; sys_platform == 'freebsd13'  # 26.3.0 requires cryptography 46.0.0+, which tries to install the latest cryptography, which needs a Rust compiler to be installed
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -13,5 +13,6 @@ requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for p
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyopenssl < 22.0.0 ; python_version < '3.6' # pyOpenSSL 22.0.0 and later require python 3.6 or later
+pyopenssl < 26.3.0 ; sys_platform == 'freebsd'  # 26.3.0 requires cryptography 46.0.0+, which tries to install the latest cryptography, which needs a Rust compiler to be installed
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:


### PR DESCRIPTION
##### SUMMARY
Right now CI fails on FreeBSD 13.5, since installing latest pyOpenSSL tries to install cryptography 46.0.0+, which causes installing the latest cryptography, which fails due to missing Rust compiler.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
