### PR TITLE
CI: Replace devel RHEL 9.7 and 10.1 remotes with 9.8 and 10.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -296,14 +296,14 @@ stages:
               test: ansible-test-integration-devel-macos-26.3-azp-posix-1
             - name: macOS 26.3 + group 2
               test: ansible-test-integration-devel-macos-26.3-azp-posix-2
-            - name: RHEL 10.1 + group 1
-              test: ansible-test-integration-devel-rhel-10.1-azp-posix-1
-            - name: RHEL 10.1 + group 2
-              test: ansible-test-integration-devel-rhel-10.1-azp-posix-2
-            - name: RHEL 9.7 + group 1
-              test: ansible-test-integration-devel-rhel-9.7-azp-posix-1
-            - name: RHEL 9.7 + group 2
-              test: ansible-test-integration-devel-rhel-9.7-azp-posix-2
+            - name: RHEL 10.2 + group 1
+              test: ansible-test-integration-devel-rhel-10.2-azp-posix-1
+            - name: RHEL 10.2 + group 2
+              test: ansible-test-integration-devel-rhel-10.2-azp-posix-2
+            - name: RHEL 9.8 + group 1
+              test: ansible-test-integration-devel-rhel-9.8-azp-posix-1
+            - name: RHEL 9.8 + group 2
+              test: ansible-test-integration-devel-rhel-9.8-azp-posix-2
             - name: Ubuntu 24.04 + extra VMs
               test: ansible-test-integration-devel-ubuntu-24.04-azp-posix-vm
             - name: Ubuntu 26.04 + extra VMs

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -310,8 +310,8 @@ ansible_core = "devel"
 target = [ "azp/posix/1/", "azp/posix/2/" ]
 remote = [
     "macos/26.3",
-    "rhel/10.1",
-    "rhel/9.7",
+    "rhel/10.2",
+    "rhel/9.8",
     "freebsd/15.0",
     "freebsd/14.4",
 ]


### PR DESCRIPTION
##### SUMMARY
See https://forum.ansible.com/t/ansible-test-devel-rhel-9-7-and-10-1-remotes-replaced-by-9-8-and-10-2/45976.

Ref: https://github.com/ansible/ansible/commit/9cc7281c69fe74282fc8831fb6796d0700f8f9a6

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
