### PR TITLE
Add openssl_pkcs12_info and openssl_pkcs12_extract modules

### DIFF
--- a/plugins/module_utils/_io.py
+++ b/plugins/module_utils/_io.py
@@ -73,14 +73,7 @@ def write_file(
     Uses file arguments from module.
     """
     # Find out parameters for file
-    try:
-        file_args = module.load_file_common_arguments(module.params, path=path)
-    except TypeError:
-        # The path argument is only supported in Ansible 2.10+. Fall back to
-        # pre-2.10 behavior of module_utils/crypto.py for older Ansible versions.
-        file_args = module.load_file_common_arguments(module.params)
-        if path is not None:
-            file_args["path"] = path
+    file_args = module.load_file_common_arguments(module.params, path=path)
     if file_args["mode"] is None:
         file_args["mode"] = default_mode
     # Create tempfile name

--- a/plugins/modules/openssl_pkcs12.py
+++ b/plugins/modules/openssl_pkcs12.py
@@ -33,12 +33,14 @@ options:
   action:
     description:
       - V(export) or V(parse) a PKCS#12.
+      - Note that V(parse) will be deprecated in the future.
+        Use M(community.crypto.openssl_pkcs12_extract) instead.
     type: str
     default: export
     choices: [export, parse]
   other_certificates:
     description:
-      - List of other certificates to include. Pre Ansible 2.8 this parameter was called O(ca_certificates).
+      - List of other certificates to include.
       - Assumes there is one PEM-encoded certificate per file. If a file contains multiple PEM certificates, set O(other_certificates_parse_all)
         to V(true).
       - Mutually exclusive with O(other_certificates_content).
@@ -175,6 +177,8 @@ seealso:
   - module: community.crypto.x509_certificate
   - module: community.crypto.openssl_csr
   - module: community.crypto.openssl_dhparam
+  - module: community.crypto.openssl_pkcs12_info
+  - module: community.crypto.openssl_pkcs12_extract
   - module: community.crypto.openssl_privatekey
   - module: community.crypto.openssl_publickey
 """

--- a/plugins/modules/openssl_pkcs12_extract.py
+++ b/plugins/modules/openssl_pkcs12_extract.py
@@ -1,0 +1,409 @@
+#!/usr/bin/python
+# Copyright (c) 2017, Guillaume Delpierre <gde@llew.me>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: openssl_pkcs12_extract
+author:
+  - Felix Fontein (@felixfontein)
+  - Guillaume Delpierre (@gdelpierre)
+short_description: Extract certificate and private key from PKCS#12 archive
+version_added: 3.4.0
+description:
+  - This module allows to extract certificates and private key from a PKCS#12 archive.
+extends_documentation_fragment:
+  - ansible.builtin.files
+  - community.crypto._attributes
+  - community.crypto._attributes.files
+  - community.crypto._cryptography_dep.minimum
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+  safe_file_operations:
+    support: full
+  idempotent:
+    support: full
+options:
+  passphrase:
+    description:
+      - The PKCS#12 password.
+    type: str
+  path:
+    description:
+      - Filename to read the PKCS#12 file from.
+      - Either O(path) or O(content) must be specified, but not both.
+    type: path
+  content:
+    description:
+      - Base64 encoded contents of a PKCS#12 file.
+      - Either O(path) or O(content) must be specified, but not both.
+    type: str
+  backup:
+    description:
+      - Create a backup file including a timestamp so you can get the original output file back if you overwrote it with a
+        new one by accident.
+    type: bool
+    default: false
+  combined_path:
+    description:
+      - If specified, the concatenation of private key (if exists), certificate (if exists), and other certificates will be written to this path.
+        All objects are written in PEM format.
+      - If O(backup=true) and the file exists and is about to be overwritten,
+        a backup will be created and its filename is returned as RV(combined_backup_file).
+      - At least one of O(combined_path), O(cert_path), O(privatekey_path), O(other_certs_path), and O(all_certs_path) must be specified.
+    type: path
+  cert_path:
+    description:
+      - If specified, the certificate (if exists) associated to the private key will be written to this path in PEM format.
+      - If O(backup=true) and the file exists and is about to be overwritten,
+        a backup will be created and its filename is returned as RV(cert_backup_file).
+      - At least one of O(combined_path), O(cert_path), O(privatekey_path), O(other_certs_path), and O(all_certs_path) must be specified.
+    type: path
+  privatekey_path:
+    description:
+      - If specified, the private key will be written to this path in PEM format.
+      - If O(backup=true) and the file exists and is about to be overwritten,
+        a backup will be created and its filename is returned as RV(privatekey_backup_file).
+      - At least one of O(combined_path), O(cert_path), O(privatekey_path), O(other_certs_path), and O(all_certs_path) must be specified.
+    type: path
+  other_certs_path:
+    description:
+      - If specified, the concatenation of all other certificates (not associated to the private key) will be written to this path in PEM format.
+      - If O(backup=true) and the file exists and is about to be overwritten,
+        a backup will be created and its filename is returned as RV(other_certs_backup_file).
+      - At least one of O(combined_path), O(cert_path), O(privatekey_path), O(other_certs_path), and O(all_certs_path) must be specified.
+    type: path
+  all_certs_path:
+    description:
+      - If specified, the concatenation of all certificates will be written to this path in PEM format.
+      - If O(backup=true) and the file exists and is about to be overwritten,
+        a backup will be created and its filename is returned as RV(all_certs_backup_file).
+      - At least one of O(combined_path), O(cert_path), O(privatekey_path), O(other_certs_path), and O(all_certs_path) must be specified.
+    type: path
+
+seealso:
+  - module: community.crypto.x509_certificate_info
+  - module: community.crypto.openssl_pkcs12
+  - module: community.crypto.openssl_pkcs12_info
+  - module: community.crypto.openssl_privatekey_info
+"""
+
+EXAMPLES = r"""
+---
+- name: Parse PKCS#12 file and concatenate private key and certs into PEM file
+  community.crypto.openssl_pkcs12_extract:
+    path: /opt/certs/ansible.p12
+    combined_path: /opt/certs/ansible-combined.pem
+"""
+
+RETURN = r"""
+combined_backup_file:
+  description:
+    - Name of backup file created.
+  returned: O(backup=true), O(combined_path) is specified, and the file contents have been changed
+  type: str
+  sample: /path/to/ansible.com-combined.pem.2019-03-09@11:22~
+cert_backup_file:
+  description:
+    - Name of backup file created.
+  returned: O(backup=true), O(cert_path) is specified, and the file contents have been changed
+  type: str
+  sample: /path/to/ansible.com.pem.2019-03-09@11:22~
+privatekey_backup_file:
+  description:
+    - Name of backup file created.
+  returned: O(backup=true), O(privatekey_path) is specified, and the file contents have been changed
+  type: str
+  sample: /path/to/ansible.com.key.2019-03-09@11:22~
+other_certs_backup_file:
+  description:
+    - Name of backup file created.
+  returned: O(backup=true), O(other_certs_path) is specified, and the file contents have been changed
+  type: str
+  sample: /path/to/ansible.com-chain.pem.2019-03-09@11:22~
+all_certs_backup_file:
+  description:
+    - Name of backup file created.
+  returned: O(backup=true), O(all_certs_path) is specified, and the file contents have been changed
+  type: str
+  sample: /path/to/ansible.com-all-certs.pem.2019-03-09@11:22~
+"""
+
+import base64
+import os
+import typing as t
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.crypto.plugins.module_utils._crypto.basic import (
+    OpenSSLObjectError,
+)
+from ansible_collections.community.crypto.plugins.module_utils._crypto.cryptography_support import (
+    parse_pkcs12,
+)
+from ansible_collections.community.crypto.plugins.module_utils._cryptography_dep import (
+    COLLECTION_MINIMUM_CRYPTOGRAPHY_VERSION,
+    assert_required_cryptography_version,
+)
+from ansible_collections.community.crypto.plugins.module_utils._io import (
+    load_file_if_exists,
+    write_file,
+)
+
+MINIMAL_CRYPTOGRAPHY_VERSION = COLLECTION_MINIMUM_CRYPTOGRAPHY_VERSION
+
+try:
+    from cryptography.hazmat.primitives import serialization
+except ImportError:
+    pass
+
+
+class PkcsError(OpenSSLObjectError):
+    pass
+
+
+class PkcsExtract:
+    def __init__(self, module: AnsibleModule) -> None:
+        self.module = module
+        self.passphrase: str | None = module.params["passphrase"]
+        self.path: str | None = module.params["path"]
+        self.return_private_key: bool = module.params["return_private_key"]
+        self.backup: bool = module.params["backup"]
+
+        self.combined_path: str | None = module.params["combined_path"]
+        self.cert_path: str | None = module.params["cert_path"]
+        self.privatekey_path: str | None = module.params["privatekey_path"]
+        self.other_certs_path: str | None = module.params["other_certs_path"]
+        self.all_certs_path: str | None = module.params["all_certs_path"]
+
+    def parse_bytes(self) -> tuple[
+        bytes | None,
+        bytes | None,
+        list[bytes],
+        bytes | None,
+    ]:
+        if self.path is not None:
+            try:
+                with open(self.path, "rb") as fh:
+                    content = fh.read()
+            except (IOError, OSError) as exc:
+                raise PkcsError(f"Error while reading {self.path}: {exc}") from exc
+        else:
+            try:
+                content = base64.b64decode(self.module.params["content"])
+            except Exception as exc:
+                raise PkcsError(
+                    f"Error while decoding Base64 encoded content: {exc}"
+                ) from exc
+
+        try:
+            private_key, certificate, additional_certificates, friendly_name = (
+                parse_pkcs12(content, passphrase=self.passphrase)
+            )
+
+            pkey = None
+            if private_key is not None:
+                pkey = private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+
+            crt = None
+            if certificate is not None:
+                crt = certificate.public_bytes(serialization.Encoding.PEM)
+
+            other_certs = []
+            if additional_certificates is not None:
+                other_certs = [
+                    other_cert.public_bytes(serialization.Encoding.PEM)
+                    for other_cert in additional_certificates
+                ]
+
+            return pkey, crt, other_certs, friendly_name
+        except ValueError as exc:
+            raise PkcsError(exc) from exc
+
+    def get_file_contents(
+        self, pkey: bytes | None, cert: bytes | None, other_certs: list[bytes]
+    ) -> dict[str, tuple[bytes, str, bool]]:
+        result: dict[str, tuple[bytes, str, bool]] = {}
+
+        if self.combined_path is not None:
+            expected_content = b"".join(
+                [pem for pem in [pkey, cert] + other_certs if pem is not None]
+            )
+            result[self.combined_path] = (
+                expected_content,
+                "combined_backup_file",
+                True,
+            )
+
+        if self.cert_path is not None and cert is not None:
+            result[self.cert_path] = (cert, "cert_backup_file", False)
+
+        if self.privatekey_path is not None and pkey is not None:
+            result[self.privatekey_path] = (pkey, "privatekey_backup_file", True)
+
+        if self.other_certs_path is not None:
+            result[self.other_certs_path] = (
+                b"".join(other_certs),
+                "other_certs_backup_file",
+                False,
+            )
+
+        if self.all_certs_path is not None:
+            expected_content = b"".join(
+                [pem for pem in [cert] + other_certs if pem is not None]
+            )
+            result[self.all_certs_path] = (
+                expected_content,
+                "all_certs_backup_file",
+                False,
+            )
+
+        return result
+
+    def write_file_content(
+        self,
+        filename: str,
+        content: bytes,
+        *,
+        result: dict[str, t.Any],
+        contains_pkey: bool,
+        backup_key: str,
+    ) -> bool:
+        base_dir = os.path.dirname(filename) or "."
+        if not os.path.isdir(base_dir):
+            raise PkcsError(
+                f"The directory '{base_dir}' does not exist or the path is not a directory"
+            )
+
+        current_content = load_file_if_exists(path=filename, ignore_errors=True)
+        if current_content == content:
+            return False
+
+        if not self.module.check_mode:
+            if self.backup:
+                result[backup_key] = self.module.backup_local(filename)
+            write_file(
+                module=self.module,
+                path=filename,
+                content=content,
+                default_mode=0o600 if contains_pkey else None,
+            )
+
+        return True
+
+    def write_file(
+        self,
+        filename: str,
+        content: bytes,
+        *,
+        result: dict[str, t.Any],
+        contains_pkey: bool,
+        backup_key: str,
+    ) -> bool:
+        changed = self.write_file_content(
+            filename,
+            content,
+            result=result,
+            contains_pkey=contains_pkey,
+            backup_key=backup_key,
+        )
+
+        if not self.module.check_file_absent_if_check_mode(filename):
+            file_args = self.module.load_file_common_arguments(
+                self.module.params, path=filename
+            )
+            changed = self.module.set_fs_attributes_if_different(file_args, changed)
+
+        return changed
+
+    def run(self) -> dict[str, t.Any]:
+        """Run the module."""
+        pkey, cert, other_certs, friendly_name = self.parse_bytes()
+        files = self.get_file_contents(pkey, cert, other_certs)
+        result: dict[str, t.Any] = {
+            "friendly_name": friendly_name,
+        }
+        changed = False
+        for file, (content, backup_key, contains_pkey) in files.items():
+            if self.write_file(
+                file,
+                content,
+                result=result,
+                contains_pkey=contains_pkey,
+                backup_key=backup_key,
+            ):
+                changed = True
+        result["changed"] = changed
+        return result
+
+
+def select_backend(module: AnsibleModule) -> PkcsExtract:
+    assert_required_cryptography_version(
+        module, minimum_cryptography_version=MINIMAL_CRYPTOGRAPHY_VERSION
+    )
+    return PkcsExtract(module)
+
+
+def main() -> t.NoReturn:
+    argument_spec = {
+        "path": {"type": "path"},
+        "content": {"type": "str", "no_log": True},
+        "passphrase": {"type": "str", "no_log": True},
+        "backup": {"type": "bool", "default": False},
+        "combined_path": {"type": "path"},
+        "cert_path": {"type": "path"},
+        "privatekey_path": {"type": "path"},
+        "other_certs_path": {"type": "path"},
+        "all_certs_path": {"type": "path"},
+    }
+
+    required_one_of = [
+        ("path", "content"),
+        (
+            "combined_path",
+            "cert_path",
+            "privatekey_path",
+            "other_certs_path",
+            "all_certs_path",
+        ),
+    ]
+
+    mutually_exclusive = [
+        ("path", "content"),
+    ]
+
+    module = AnsibleModule(
+        add_file_common_args=True,
+        argument_spec=argument_spec,
+        required_one_of=required_one_of,
+        mutually_exclusive=mutually_exclusive,
+        supports_check_mode=True,
+    )
+
+    pkcs12 = select_backend(module)
+
+    base_dir = os.path.dirname(module.params["path"]) or "."
+    if not os.path.isdir(base_dir):
+        module.fail_json(
+            name=base_dir,
+            msg=f"The directory '{base_dir}' does not exist or the path is not a directory",
+        )
+
+    try:
+        result = pkcs12.run()
+        module.exit_json(**result)
+    except OpenSSLObjectError as exc:
+        module.fail_json(msg=str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/openssl_pkcs12_extract.py
+++ b/plugins/modules/openssl_pkcs12_extract.py
@@ -172,7 +172,6 @@ class PkcsExtract:
         self.module = module
         self.passphrase: str | None = module.params["passphrase"]
         self.path: str | None = module.params["path"]
-        self.return_private_key: bool = module.params["return_private_key"]
         self.backup: bool = module.params["backup"]
 
         self.combined_path: str | None = module.params["combined_path"]

--- a/plugins/modules/openssl_pkcs12_extract.py
+++ b/plugins/modules/openssl_pkcs12_extract.py
@@ -102,6 +102,14 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+friendly_name:
+  description:
+    - >-
+      "Friendly name" of the certificate and private key pair.
+    - If no private key is contained in the archive, this has value V(null).
+  returned: success
+  type: str
+  sample: keypair
 combined_backup_file:
   description:
     - Name of backup file created.

--- a/plugins/modules/openssl_pkcs12_info.py
+++ b/plugins/modules/openssl_pkcs12_info.py
@@ -1,0 +1,223 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: openssl_pkcs12_info
+author:
+  - Felix Fontein (@felixfontein)
+short_description: Return certificates and (optionally) private key of a PKCS#12 file
+version_added: 3.4.0
+description:
+  - This module loads an PKCS#12 file and returns the contained certificates.
+  - If O(return_private_key=true), the private key (if contained) is also returned.
+extends_documentation_fragment:
+  - community.crypto._attributes
+  - community.crypto._attributes.info_module
+  - community.crypto._attributes.idempotent_not_modify_state
+  - community.crypto._cryptography_dep.minimum
+options:
+  passphrase:
+    description:
+      - The PKCS#12 password.
+    type: str
+  path:
+    description:
+      - Filename to read the PKCS#12 file from.
+      - Either O(path) or O(content) must be specified, but not both.
+    type: path
+  content:
+    description:
+      - Base64 encoded contents of a PKCS#12 file.
+      - Either O(path) or O(content) must be specified, but not both.
+    type: str
+  return_private_key:
+    description:
+      - Whether to return the private key as RV(privatekey).
+      - Avoid returning this unless needed.
+    type: bool
+    default: false
+seealso:
+  - module: community.crypto.x509_certificate_info
+  - module: community.crypto.openssl_pkcs12
+  - module: community.crypto.openssl_pkcs12_extract
+"""
+
+EXAMPLES = r"""
+---
+- name: Obtain certificates from PKCS#12 file
+  community.crypto.openssl_pkcs12_info:
+    path: /opt/certs/ansible.p12
+  register: result
+"""
+
+RETURN = r"""
+certificate:
+  description:
+    - Certificate associated to the private key in the PKCS#12 archive in PEM format.
+    - If no private key is contained in the archive, this has value V(null).
+  returned: success
+  type: str
+  sample: |-
+    -----BEGIN CERTIFICATE-----
+    MIIBljCCATugAw...
+other_certificates:
+  description:
+    - Other certificates (not associated to the private key) in the PKCS#12 archive in PEM format.
+  returned: success
+  type: list
+  elements: str
+  sample:
+    - |-
+      -----BEGIN CERTIFICATE-----
+      MIIBljCCATugAw...
+privatekey:
+  description:
+    - The PKCS#12 archive's private key in PEM format, if present.
+    - Only returned if O(return_private_key=true).
+  returned: success if O(return_private_key=true)
+  type: str
+"""
+
+import base64
+import typing as t
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
+
+from ansible_collections.community.crypto.plugins.module_utils._crypto.basic import (
+    OpenSSLObjectError,
+)
+from ansible_collections.community.crypto.plugins.module_utils._crypto.cryptography_support import (
+    parse_pkcs12,
+)
+from ansible_collections.community.crypto.plugins.module_utils._cryptography_dep import (
+    COLLECTION_MINIMUM_CRYPTOGRAPHY_VERSION,
+    assert_required_cryptography_version,
+)
+
+MINIMAL_CRYPTOGRAPHY_VERSION = COLLECTION_MINIMUM_CRYPTOGRAPHY_VERSION
+
+try:
+    from cryptography.hazmat.primitives import serialization
+except ImportError:
+    pass
+
+
+class PkcsError(OpenSSLObjectError):
+    pass
+
+
+class PkcsInfo:
+    def __init__(self, module: AnsibleModule) -> None:
+        self.module = module
+        self.passphrase: str | None = module.params["passphrase"]
+        self.path: str | None = module.params["path"]
+        self.return_private_key: bool = module.params["return_private_key"]
+
+    def parse_bytes(self) -> tuple[
+        bytes | None,
+        bytes | None,
+        list[bytes],
+        bytes | None,
+    ]:
+        if self.path is not None:
+            try:
+                with open(self.path, "rb") as fh:
+                    content = fh.read()
+            except (IOError, OSError) as exc:
+                raise PkcsError(f"Error while reading {self.path}: {exc}") from exc
+        else:
+            try:
+                content = base64.b64decode(self.module.params["content"])
+            except Exception as exc:
+                raise PkcsError(
+                    f"Error while decoding Base64 encoded content: {exc}"
+                ) from exc
+
+        try:
+            private_key, certificate, additional_certificates, friendly_name = (
+                parse_pkcs12(content, passphrase=self.passphrase)
+            )
+
+            pkey = None
+            if private_key is not None:
+                pkey = private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+
+            crt = None
+            if certificate is not None:
+                crt = certificate.public_bytes(serialization.Encoding.PEM)
+
+            other_certs = []
+            if additional_certificates is not None:
+                other_certs = [
+                    other_cert.public_bytes(serialization.Encoding.PEM)
+                    for other_cert in additional_certificates
+                ]
+
+            return pkey, crt, other_certs, friendly_name
+        except ValueError as exc:
+            raise PkcsError(exc) from exc
+
+    def run(self) -> dict[str, t.Any]:
+        """Run the module."""
+        pkey, cert, other_certs, friendly_name = self.parse_bytes()
+        result: dict[str, t.Any] = {
+            "certificate": to_text(cert) if cert else None,
+            "other_certificates": [to_text(crt) for crt in other_certs],
+            "friendly_name": friendly_name,
+        }
+        if self.return_private_key:
+            result["privatekey"] = to_text(pkey)
+
+        return result
+
+
+def select_backend(module: AnsibleModule) -> PkcsInfo:
+    assert_required_cryptography_version(
+        module, minimum_cryptography_version=MINIMAL_CRYPTOGRAPHY_VERSION
+    )
+    return PkcsInfo(module)
+
+
+def main() -> t.NoReturn:
+    argument_spec = {
+        "path": {"type": "path"},
+        "content": {"type": "str", "no_log": True},
+        "passphrase": {"type": "str", "no_log": True},
+        "return_private_key": {"type": "bool", "default": False},
+    }
+
+    required_one_of = [
+        ("path", "content"),
+    ]
+
+    mutually_exclusive = [
+        ("path", "content"),
+    ]
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=required_one_of,
+        mutually_exclusive=mutually_exclusive,
+        supports_check_mode=True,
+    )
+
+    pkcs12 = select_backend(module)
+
+    try:
+        result = pkcs12.run()
+        module.exit_json(**result)
+    except OpenSSLObjectError as exc:
+        module.fail_json(msg=str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/openssl_pkcs12_info.py
+++ b/plugins/modules/openssl_pkcs12_info.py
@@ -180,7 +180,9 @@ class PkcsInfo:
         result: dict[str, t.Any] = {
             "certificate": to_text(cert) if cert else None,
             "other_certificates": [to_text(crt) for crt in other_certs],
-            "friendly_name": to_text(friendly_name) if friendly_name is not None else None,
+            "friendly_name": (
+                to_text(friendly_name) if friendly_name is not None else None
+            ),
         }
         if self.return_private_key:
             result["privatekey"] = to_text(pkey) if pkey else None

--- a/plugins/modules/openssl_pkcs12_info.py
+++ b/plugins/modules/openssl_pkcs12_info.py
@@ -172,10 +172,10 @@ class PkcsInfo:
         result: dict[str, t.Any] = {
             "certificate": to_text(cert) if cert else None,
             "other_certificates": [to_text(crt) for crt in other_certs],
-            "friendly_name": friendly_name,
+            "friendly_name": to_text(friendly_name) if friendly_name is not None else None,
         }
         if self.return_private_key:
-            result["privatekey"] = to_text(pkey)
+            result["privatekey"] = to_text(pkey) if pkey else None
 
         return result
 

--- a/plugins/modules/openssl_pkcs12_info.py
+++ b/plugins/modules/openssl_pkcs12_info.py
@@ -55,6 +55,14 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+friendly_name:
+  description:
+    - >-
+      "Friendly name" of the certificate and private key pair.
+    - If no private key is contained in the archive, this has value V(null).
+  returned: success
+  type: str
+  sample: keypair
 certificate:
   description:
     - Certificate associated to the private key in the PKCS#12 archive in PEM format.

--- a/tests/integration/targets/openssl_pkcs12_extract/aliases
+++ b/tests/integration/targets/openssl_pkcs12_extract/aliases
@@ -1,0 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/generic/2
+azp/posix/2
+destructive

--- a/tests/integration/targets/openssl_pkcs12_extract/meta/main.yml
+++ b/tests/integration/targets/openssl_pkcs12_extract/meta/main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_openssl
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/openssl_pkcs12_extract/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12_extract/tasks/main.yml
@@ -86,8 +86,11 @@
   ansible.builtin.assert:
     that:
       - p12_dumped is changed
+      - p12_dumped.friendly_name == "abracadabra"
       - p12_dumped_idempotency is not changed
+      - p12_dumped_idempotency.friendly_name == "abracadabra"
       - p12_dumped_check_mode is not changed
+      - p12_dumped_check_mode.friendly_name == "abracadabra"
 
 - name: "Read file"
   ansible.builtin.slurp:

--- a/tests/integration/targets/openssl_pkcs12_extract/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12_extract/tasks/main.yml
@@ -1,0 +1,248 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Generate private keys
+  community.crypto.openssl_privatekey:
+    path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    size: '{{ default_rsa_key_size_certificates }}'
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Read all keys
+  ansible.builtin.slurp:
+    src: '{{ item }}'
+  loop:
+    - "{{ remote_tmp_dir }}/ansible_pkey1.pem"
+    - "{{ remote_tmp_dir }}/ansible_pkey2.pem"
+    - "{{ remote_tmp_dir }}/ansible_pkey3.pem"
+  register: all_keys
+
+- name: Generate CSRs
+  community.crypto.openssl_csr:
+    path: '{{ remote_tmp_dir }}/ansible{{ item }}.csr'
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    commonName: www{{ item }}.ansible.com
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Generate certificate
+  community.crypto.x509_certificate:
+    path: '{{ remote_tmp_dir }}/ansible{{ item }}.crt'
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    csr_path: '{{ remote_tmp_dir }}/ansible{{ item }}.csr'
+    provider: selfsigned
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Read all certificates
+  ansible.builtin.slurp:
+    src: '{{ item }}'
+  loop:
+    - "{{ remote_tmp_dir }}/ansible1.crt"
+    - "{{ remote_tmp_dir }}/ansible2.crt"
+    - "{{ remote_tmp_dir }}/ansible3.crt"
+  register: all_certs
+
+- name: Generate concatenated PEM file
+  ansible.builtin.copy:
+    dest: '{{ remote_tmp_dir }}/ansible23.crt'
+    content: '{{ all_certs.results[1].content | b64decode }}{{ all_certs.results[2].content | b64decode }}'
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    friendly_name: abracadabra
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    state: present
+    mode: '0644'
+
+- name: "Dump PKCS#12"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    combined_path: '{{ remote_tmp_dir }}/ansible_extract.pem'
+  register: p12_dumped
+
+- name: "Dump PKCS#12 file again, idempotency"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    combined_path: '{{ remote_tmp_dir }}/ansible_extract.pem'
+  register: p12_dumped_idempotency
+
+- name: "Dump PKCS#12, check mode"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    combined_path: '{{ remote_tmp_dir }}/ansible_extract.pem'
+  check_mode: true
+  register: p12_dumped_check_mode
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is changed
+      - p12_dumped_idempotency is not changed
+      - p12_dumped_check_mode is not changed
+
+- name: "Read file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract.pem"
+  register: slurp
+
+- name: 'Check file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{{ all_keys.results[0].content | b64decode }}{% for index in [0] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file without private key"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_no_pkey.p12'
+    friendly_name: abracadabra
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    state: present
+    mode: '0644'
+
+- name: "Dump PKCS#12 with no private key"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible_no_pkey.p12'
+    combined_path: '{{ remote_tmp_dir }}/ansible_extract_no_pkey.pem'
+
+- name: "Read file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_no_pkey.pem"
+  register: slurp
+
+- name: 'Check file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{% for index in [0] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file with multiple certs and passphrase"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_multi_certs.p12'
+    friendly_name: abracadabra
+    passphrase: hunter3
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    other_certificates: '{{ remote_tmp_dir }}/ansible23.crt'
+    other_certificates_parse_all: true
+    state: present
+
+- name: "Dump PKCS#12 with multiple certs and passphrase"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible_multi_certs.p12'
+    passphrase: hunter3
+    combined_path: '{{ remote_tmp_dir }}/ansible_extract_multi_certs.pem'
+    cert_path: '{{ remote_tmp_dir }}/ansible_extract_multi_certs_cert.pem'
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_extract_multi_certs_pkey.pem'
+    other_certs_path: '{{ remote_tmp_dir }}/ansible_extract_multi_certs_other_certs.pem'
+    all_certs_path: '{{ remote_tmp_dir }}/ansible_extract_multi_certs_all_certs.pem'
+
+- name: "Read combined file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_multi_certs.pem"
+  register: slurp
+
+- name: 'Check combined file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{{ all_keys.results[0].content | b64decode }}{% for index in [0, 1, 2] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+- name: "Read cert file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_multi_certs_cert.pem"
+  register: slurp
+
+- name: 'Check cert file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{% for index in [0] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+- name: "Read private key file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_multi_certs_pkey.pem"
+  register: slurp
+
+- name: 'Check private key file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{{ all_keys.results[0].content | b64decode }}"
+
+- name: "Read other certs file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_multi_certs_other_certs.pem"
+  register: slurp
+
+- name: 'Check other certs file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{% for index in [1, 2] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+- name: "Read all certs file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_extract_multi_certs_all_certs.pem"
+  register: slurp
+
+- name: 'Check all certs file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{% for index in [0, 1, 2] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"
+
+#####################################################################################################################
+
+- name: "Generate 'empty' PKCS#12 file"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_empty.p12'
+    friendly_name: abracadabra
+    other_certificates:
+      - '{{ remote_tmp_dir }}/ansible2.crt'
+      - '{{ remote_tmp_dir }}/ansible3.crt'
+    state: present
+
+- name: "Generate 'empty' PKCS#12 file (parse)"
+  community.crypto.openssl_pkcs12_extract:
+    path: '{{ remote_tmp_dir }}/ansible_empty.p12'
+    combined_path: '{{ remote_tmp_dir }}/ansible_empty.pem'
+
+- name: "Read 'empty' file"
+  ansible.builtin.slurp:
+    src: "{{ remote_tmp_dir }}/ansible_empty.pem"
+  register: slurp
+
+- name: 'Check "empty" file'
+  ansible.builtin.assert:
+    that:
+      - empty_contents == empty_expected
+  vars:
+    empty_contents: "{{ slurp.content | b64decode }}"
+    empty_expected: "{% for index in [1, 2] %}{{ all_certs.results[index].content | b64decode }}{% endfor %}"

--- a/tests/integration/targets/openssl_pkcs12_info/aliases
+++ b/tests/integration/targets/openssl_pkcs12_info/aliases
@@ -1,0 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/generic/2
+azp/posix/2
+destructive

--- a/tests/integration/targets/openssl_pkcs12_info/meta/main.yml
+++ b/tests/integration/targets/openssl_pkcs12_info/meta/main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_openssl
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/openssl_pkcs12_info/tasks/main.yml
+++ b/tests/integration/targets/openssl_pkcs12_info/tasks/main.yml
@@ -1,0 +1,200 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Generate private keys
+  community.crypto.openssl_privatekey:
+    path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    size: '{{ default_rsa_key_size_certificates }}'
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Read all keys
+  ansible.builtin.slurp:
+    src: '{{ item }}'
+  loop:
+    - "{{ remote_tmp_dir }}/ansible_pkey1.pem"
+    - "{{ remote_tmp_dir }}/ansible_pkey2.pem"
+    - "{{ remote_tmp_dir }}/ansible_pkey3.pem"
+  register: all_keys
+
+- name: Generate CSRs
+  community.crypto.openssl_csr:
+    path: '{{ remote_tmp_dir }}/ansible{{ item }}.csr'
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    commonName: www{{ item }}.ansible.com
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Generate certificate
+  community.crypto.x509_certificate:
+    path: '{{ remote_tmp_dir }}/ansible{{ item }}.crt'
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey{{ item }}.pem'
+    csr_path: '{{ remote_tmp_dir }}/ansible{{ item }}.csr'
+    provider: selfsigned
+  loop: "{{ range(1, 4) | list }}"
+
+- name: Read all certificates
+  ansible.builtin.slurp:
+    src: '{{ item }}'
+  loop:
+    - "{{ remote_tmp_dir }}/ansible1.crt"
+    - "{{ remote_tmp_dir }}/ansible2.crt"
+    - "{{ remote_tmp_dir }}/ansible3.crt"
+  register: all_certs
+
+- name: Generate concatenated PEM file
+  ansible.builtin.copy:
+    dest: '{{ remote_tmp_dir }}/ansible23.crt'
+    content: '{{ all_certs.results[1].content | b64decode }}{{ all_certs.results[2].content | b64decode }}'
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    friendly_name: abracadabra
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    state: present
+    mode: '0644'
+
+- name: "Dump PKCS#12 w/o private key"
+  community.crypto.openssl_pkcs12_info:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is string
+      - p12_dumped.certificate == (all_certs.results[0].content | b64decode)
+      - p12_dumped.other_certificates | length == 0
+      - p12_dumped.friendly_name == "abracadabra"
+      - p12_dumped.privatekey is not defined
+
+- name: "Query PKCS#12 w/ private key"
+  community.crypto.openssl_pkcs12_info:
+    path: '{{ remote_tmp_dir }}/ansible.p12'
+    return_private_key: true
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is string
+      - p12_dumped.certificate == (all_certs.results[0].content | b64decode)
+      - p12_dumped.other_certificates | length == 0
+      - p12_dumped.friendly_name == "abracadabra"
+      - p12_dumped.privatekey is string
+      - p12_dumped.privatekey == (all_keys.results[0].content | b64decode)
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file without private key"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_no_pkey.p12'
+    friendly_name: abracadabra
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    state: present
+    mode: '0644'
+
+- name: "Query PKCS#12 with no private key"
+  community.crypto.openssl_pkcs12_info:
+    path: '{{ remote_tmp_dir }}/ansible_no_pkey.p12'
+    return_private_key: true
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is none
+      - p12_dumped.other_certificates | length == 1
+      - p12_dumped.other_certificates[0] == (all_certs.results[0].content | b64decode)
+      - p12_dumped.friendly_name is none
+      - p12_dumped.privatekey is none
+
+#####################################################################################################################
+
+- name: "Generate PKCS#12 file with multiple certs and passphrase"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_multi_certs.p12'
+    passphrase: hunter3
+    friendly_name: foobar
+    privatekey_path: '{{ remote_tmp_dir }}/ansible_pkey1.pem'
+    certificate_path: '{{ remote_tmp_dir }}/ansible1.crt'
+    other_certificates: '{{ remote_tmp_dir }}/ansible23.crt'
+    other_certificates_parse_all: true
+    state: present
+
+- name: "Query PKCS#12 w/o private key"
+  community.crypto.openssl_pkcs12_info:
+    path: '{{ remote_tmp_dir }}/ansible_multi_certs.p12'
+    passphrase: hunter3
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is string
+      - p12_dumped.certificate == (all_certs.results[0].content | b64decode)
+      - p12_dumped.other_certificates | length == 2
+      - p12_dumped.other_certificates[0] == (all_certs.results[1].content | b64decode)
+      - p12_dumped.other_certificates[1] == (all_certs.results[2].content | b64decode)
+      - p12_dumped.friendly_name == "foobar"
+      - p12_dumped.privatekey is not defined
+
+- name: "Query PKCS#12 w/ private key"
+  community.crypto.openssl_pkcs12_info:
+    path: '{{ remote_tmp_dir }}/ansible_multi_certs.p12'
+    passphrase: hunter3
+    return_private_key: true
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is string
+      - p12_dumped.certificate == (all_certs.results[0].content | b64decode)
+      - p12_dumped.other_certificates | length == 2
+      - p12_dumped.other_certificates[0] == (all_certs.results[1].content | b64decode)
+      - p12_dumped.other_certificates[1] == (all_certs.results[2].content | b64decode)
+      - p12_dumped.friendly_name == "foobar"
+      - p12_dumped.privatekey is string
+      - p12_dumped.privatekey == (all_keys.results[0].content | b64decode)
+
+#####################################################################################################################
+
+- name: "Generate 'empty' PKCS#12 file"
+  community.crypto.openssl_pkcs12:
+    path: '{{ remote_tmp_dir }}/ansible_empty.p12'
+    friendly_name: abracadabra
+    other_certificates:
+      - '{{ remote_tmp_dir }}/ansible2.crt'
+      - '{{ remote_tmp_dir }}/ansible3.crt'
+    state: present
+
+- name: "Query PKCS#12 w/o private key"
+  community.crypto.openssl_pkcs12_info:
+    path: "{{ remote_tmp_dir }}/ansible_empty.p12"
+  register: p12_dumped
+
+- name: 'Validate changes'
+  ansible.builtin.assert:
+    that:
+      - p12_dumped is not changed
+      - p12_dumped.certificate is none
+      - p12_dumped.other_certificates | length == 2
+      - p12_dumped.other_certificates[0] == (all_certs.results[1].content | b64decode)
+      - p12_dumped.other_certificates[1] == (all_certs.results[2].content | b64decode)
+      - p12_dumped.friendly_name is none
+      - p12_dumped.privatekey is not defined


### PR DESCRIPTION
##### SUMMARY
openssl_pkcs12_info provides the parts of a PKCS#12 archive as return values.

openssl_pkcs12_extract is basically `action=parse` of openssl_pkcs12, but with more flexibility.

Fixes #1042.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
openssl_pkcs12_info
openssl_pkcs12_extract
